### PR TITLE
Added error class for mdb shard.

### DIFF
--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -22,6 +22,9 @@ pub enum GitXetRepoError {
     #[error("MerkleDBError : {0}")]
     MerkleDBError(#[from] merkledb::error::MerkleDBError),
 
+    #[error("MerkleDB Shard Error : {0}")]
+    MDBShardError(#[from] mdb_shard::error::MDBShardError),
+
     #[error("CAS Error : {0}")]
     CasClientError(String),
 

--- a/rust/mdb_shard/Cargo.toml
+++ b/rust/mdb_shard/Cargo.toml
@@ -22,7 +22,9 @@ binary-heap-plus = "0.5.0"
 tempfile = "3.2.0"
 clap = { version = "3.1.6", features = ["derive"] }
 anyhow = "1"
-rand = "0.8.5"
+rand = {version = "0.8.5", features = ["small_rng"]}
+thiserror = "1.0.30"
+async-trait = "0.1.9"
 
 [[bin]]
 name = "shard_benchmark"

--- a/rust/mdb_shard/src/error.rs
+++ b/rust/mdb_shard/src/error.rs
@@ -1,0 +1,56 @@
+use merkledb::error::MerkleDBError;
+use merklehash::MerkleHash;
+use std::io;
+use thiserror::Error;
+
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum MDBShardError {
+    #[error("File I/O error")]
+    IOError(#[from] io::Error),
+
+    #[error("Too many collisions when searching for truncated hash : {0}")]
+    TruncatedHashCollisionError(u64),
+
+    #[error("Shard version parse error: {0}")]
+    ShardVersionError(String),
+
+    #[error("Bad file name format: {0}")]
+    BadFilename(String),
+
+    #[error("Other Internal Error: {0}")]
+    InternalError(anyhow::Error),
+
+    #[error("Shard not found")]
+    ShardNotFound(MerkleHash),
+
+    #[error("File not found")]
+    FileNotFound(MerkleHash),
+
+    #[error("Query failed: {0}")]
+    QueryFailed(String),
+
+    #[error("Client connection error: {0}")]
+    GrpcClientError(#[from] anyhow::Error),
+
+    #[error("MerkleDB Error: {0}")]
+    MerkleDBError(#[from] MerkleDBError),
+
+    #[error("Error: {0}")]
+    Other(String),
+}
+
+// Define our own result type here (this seems to be the standard).
+pub type Result<T> = std::result::Result<T, MDBShardError>;
+
+// For error checking
+impl PartialEq for MDBShardError {
+    fn eq(&self, other: &MDBShardError) -> bool {
+        match (self, other) {
+            (MDBShardError::IOError(ref e1), MDBShardError::IOError(ref e2)) => {
+                e1.kind() == e2.kind()
+            }
+            _ => false,
+        }
+    }
+}

--- a/rust/mdb_shard/src/lib.rs
+++ b/rust/mdb_shard/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod cas_structs;
+pub mod error;
 pub mod file_structs;
 pub mod merging;
 pub mod serialization_utils;
 pub mod set_operations;
 pub mod shard_file;
 pub mod shard_file_manager;
+pub mod shard_file_reconstructor;
 pub mod shard_handle;
 pub mod shard_in_memory;
 pub mod shard_version;

--- a/rust/mdb_shard/src/merging.rs
+++ b/rust/mdb_shard/src/merging.rs
@@ -1,8 +1,8 @@
+use crate::error::Result;
 use crate::set_operations::shard_set_union;
 use crate::shard_handle::MDBShardFile;
 use crate::utils::shard_file_name;
 use crate::utils::temp_shard_file_name;
-use merkledb::error::Result;
 use merklehash::compute_data_hash;
 use merklehash::MerkleHash;
 use std::io::Cursor;

--- a/rust/mdb_shard/src/set_operations.rs
+++ b/rust/mdb_shard/src/set_operations.rs
@@ -1,11 +1,11 @@
+use crate::error::Result;
 use crate::{
     cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader},
     file_structs::{FileDataSequenceEntry, FileDataSequenceHeader},
     serialization_utils::{write_u32, write_u64},
-    shard_file::{MDBShardInfo, MDBShardFileFooter, MDBShardFileHeader},
+    shard_file::{MDBShardFileFooter, MDBShardFileHeader, MDBShardInfo},
     utils::truncate_hash,
 };
-use merkledb::error::Result;
 use merklehash::{HashedWrite, MerkleHash};
 use std::{
     env::current_dir,
@@ -347,8 +347,8 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+    use crate::error::Result;
     use crate::{shard_file::test_routines::*, shard_in_memory::MDBInMemoryShard};
-    use merkledb::error::Result;
     use merklehash::compute_data_hash;
     use tempdir::TempDir;
 

--- a/rust/mdb_shard/src/shard_file.rs
+++ b/rust/mdb_shard/src/shard_file.rs
@@ -1,5 +1,5 @@
+use crate::error::{MDBShardError, Result};
 use crate::serialization_utils::*;
-use merkledb::error::{MerkleDBError, Result};
 use merkledb::MerkleMemDB;
 use merklehash::MerkleHash;
 
@@ -64,7 +64,7 @@ impl MDBShardFileHeader {
         reader.read_exact(&mut tag)?;
 
         if tag != MDB_SHARD_HEADER_TAG {
-            return Err(MerkleDBError::ShardVersionError(
+            return Err(MDBShardError::ShardVersionError(
                 "File does not appear to be a valid Merkle DB Shard file (Wrong Magic Number)."
                     .to_owned(),
             ));
@@ -411,7 +411,7 @@ impl MDBShardInfo {
         if num_indices < dest_indices.len() {
             Ok(num_indices)
         } else {
-            Err(MerkleDBError::TruncatedHashCollisionError(truncate_hash(
+            Err(MDBShardError::TruncatedHashCollisionError(truncate_hash(
                 file_hash,
             )))
         }
@@ -436,7 +436,7 @@ impl MDBShardInfo {
         if num_indices < dest_indices.len() {
             Ok(num_indices)
         } else {
-            Err(MerkleDBError::TruncatedHashCollisionError(truncate_hash(
+            Err(MDBShardError::TruncatedHashCollisionError(truncate_hash(
                 cas_hash,
             )))
         }
@@ -461,7 +461,7 @@ impl MDBShardInfo {
         if num_indices < dest_indices.len() {
             Ok(num_indices)
         } else {
-            Err(MerkleDBError::TruncatedHashCollisionError(truncate_hash(
+            Err(MDBShardError::TruncatedHashCollisionError(truncate_hash(
                 chunk_hash,
             )))
         }
@@ -725,10 +725,10 @@ pub mod test_routines {
     use std::io::{Cursor, Read, Seek};
 
     use crate::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo};
+    use crate::error::Result;
     use crate::file_structs::{FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo};
     use crate::shard_file::MDBShardInfo;
     use crate::shard_in_memory::MDBInMemoryShard;
-    use merkledb::error::Result;
     use merklehash::MerkleHash;
     use rand::rngs::{SmallRng, StdRng};
     use rand::{Rng, SeedableRng};
@@ -952,7 +952,7 @@ pub mod test_routines {
 
 #[cfg(test)]
 mod tests {
-    use merkledb::error::Result;
+    use crate::error::Result;
 
     use super::test_routines::*;
 

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -1,6 +1,6 @@
+use crate::error::Result;
 use crate::shard_handle::MDBShardFile;
 use crate::utils::{shard_file_name, temp_shard_file_name};
-use merkledb::error::Result;
 use merklehash::MerkleHash;
 use std::collections::HashSet;
 use std::io::BufReader;
@@ -311,7 +311,7 @@ mod tests {
     };
 
     use super::*;
-    use merkledb::error::Result;
+    use crate::error::Result;
     use merklehash::compute_data_hash;
     use more_asserts::assert_lt;
     use rand::prelude::*;

--- a/rust/mdb_shard/src/shard_file_reconstructor.rs
+++ b/rust/mdb_shard/src/shard_file_reconstructor.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use merklehash::MerkleHash;
+
+use crate::{error::MDBShardError, file_structs::MDBFileInfo};
+
+#[async_trait]
+pub trait FileReconstructor {
+    async fn get_file_reconstruction_info(
+        &self,
+        file_hash: &MerkleHash,
+    ) -> Result<Option<MDBFileInfo>, MDBShardError>;
+
+    fn is_local(&self) -> bool;
+}

--- a/rust/mdb_shard/src/shard_handle.rs
+++ b/rust/mdb_shard/src/shard_handle.rs
@@ -1,5 +1,5 @@
+use crate::error::{MDBShardError, Result};
 use crate::{shard_file::MDBShardInfo, utils::parse_shard_filename};
-use merkledb::error::{MerkleDBError, Result};
 use merklehash::MerkleHash;
 use std::path::{Path, PathBuf};
 use tracing::info;
@@ -25,7 +25,7 @@ impl MDBShardFile {
                 shard: MDBShardInfo::load_from_file(&mut f)?,
             })
         } else {
-            Err(MerkleDBError::BadFilename(format!(
+            Err(MDBShardError::BadFilename(format!(
                 "{path:?} not a valid MerkleDB filename."
             )))
         }
@@ -49,7 +49,7 @@ impl MDBShardFile {
                 shards.push((h, std::fs::canonicalize(path)?));
                 info!("Registerd shard file '{file_name:?}'.");
             } else {
-                return Err(MerkleDBError::BadFilename(format!(
+                return Err(MDBShardError::BadFilename(format!(
                     "Filename {file_name} not valid shard file name."
                 )));
             }

--- a/rust/mdb_shard/src/shard_in_memory.rs
+++ b/rust/mdb_shard/src/shard_in_memory.rs
@@ -8,16 +8,14 @@ use std::{
     sync::Arc,
 };
 
+use merkledb::prelude_v2::MerkleDBReconstruction;
 use merkledb::MerkleMemDB;
-use merkledb::{
-    error::{MerkleDBError, Result},
-    prelude_v2::MerkleDBReconstruction,
-};
 use merklehash::{HashedWrite, MerkleHash};
 use tracing::debug;
 
 use crate::{
     cas_structs::*,
+    error::{MDBShardError, Result},
     file_structs::*,
     shard_file::MDBShardInfo,
     utils::{shard_file_name, temp_shard_file_name},
@@ -40,7 +38,7 @@ impl MDBInMemoryShard {
             if attr.is_file() {
                 let mut block_v = mdb.reconstruct_from_cas(&[node.clone()])?;
                 if block_v.len() != 1 {
-                    return Err(MerkleDBError::GraphInvariantError(format!(
+                    return Err(MDBShardError::QueryFailed(format!(
                         "Unable to reconstruct CAS information for hash {:?}",
                         node.hash()
                     )));

--- a/rust/mdb_shard/src/shard_version.rs
+++ b/rust/mdb_shard/src/shard_version.rs
@@ -1,6 +1,6 @@
 use std::{fmt, path::Path, str::FromStr};
 
-use merkledb::error::*;
+use crate::error::{MDBShardError, Result};
 
 pub const MDB_SHARD_VERSION: u64 = 2;
 pub const MDB_SHARD_HEADER_VERSION: u64 = MDB_SHARD_VERSION;
@@ -17,24 +17,24 @@ pub enum ShardVersion {
 }
 
 impl TryFrom<u64> for ShardVersion {
-    type Error = MerkleDBError;
+    type Error = MDBShardError;
 
     fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
         match value {
             1 => Ok(Self::V1),
             2 => Ok(Self::V2),
-            _ => Err(MerkleDBError::ShardVersionError(value.to_string())),
+            _ => Err(MDBShardError::ShardVersionError(value.to_string())),
         }
     }
 }
 
 impl FromStr for ShardVersion {
-    type Err = MerkleDBError;
+    type Err = MDBShardError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let v = s
             .parse::<u64>()
-            .map_err(|_| MerkleDBError::ShardVersionError(s.to_string()))?;
+            .map_err(|_| MDBShardError::ShardVersionError(s.to_string()))?;
         ShardVersion::try_from(v)
     }
 }
@@ -75,7 +75,7 @@ impl ShardVersion {
 mod tests {
     use crate::shard_version::{ShardVersion, MDB_SHARD_VERSION};
 
-    use merkledb::error::*;
+    use crate::error::*;
 
     use std::str::FromStr;
     use tempfile::TempDir;

--- a/rust/merkledb/src/error.rs
+++ b/rust/merkledb/src/error.rs
@@ -12,9 +12,6 @@ pub enum MerkleDBError {
     #[error("Serialization/Deserialization Error : {0}")]
     BinCodeError(#[from] bincode::Error),
 
-    #[error("Too many collisions when searching for truncated hash : {0}")]
-    TruncatedHashCollisionError(u64),
-
     #[error("Shard version parse error: {0}")]
     ShardVersionError(String),
 


### PR DESCRIPTION
Previously, the mdb shard was using the merkledb error class, but there were error conditions being stuck in the Merkledb error class that didn't make sense as part of that library.  In addition, while writing the shard client, this ended up creating some circular dependency issues.

This PR separates out the shard error type into it's own class, giving us more freedom to add shard client specific error types in. 