### PR TITLE
Fixed broken compilation in xet-core.

### DIFF
--- a/rust/cache/Cargo.toml
+++ b/rust/cache/Cargo.toml
@@ -30,7 +30,7 @@ prometheus = "0.13.0"
 tempdir = "0.3.7"
 rand = "0.8.5"
 test-context = "0.1.3"
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash"} 
 
 [features]
 strict = []

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -11,7 +11,7 @@ strict = []
 [dependencies]
 utils = {path = "../utils"}
 merkledb = {path = "../merkledb"}
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash" } 
 parutils = {path = "../parutils"}
 retry_strategy = {path = "../retry_strategy"}
 tonic = {version = "0.6", features = ["tls", "tls-roots", "transport"] }

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 cas_client = { path = "../cas_client"}
 xet_config = {path = "../xet_config"}
 merkledb = {path = "../merkledb"}
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash"} 
 mdb_shard = {path = "../mdb_shard"}
 utils = {path = "../utils"}
 parutils = {path = "../parutils"}

--- a/rust/mdb_shard/Cargo.toml
+++ b/rust/mdb_shard/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 more-asserts = "0.2.2"
 tempdir = "0.3.7"
 merkledb = {path = "../merkledb"}
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash" }
 serde = {version="1.0.129", features = ["derive"]}
 tokio = { version = "1", features = ["full"] }
 lazy_static = "1.4.0"

--- a/rust/merkledb/Cargo.toml
+++ b/rust/merkledb/Cargo.toml
@@ -14,7 +14,7 @@ lto = true
 debug = 1
 
 [dependencies]
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash"} 
 rand = "0.8.4"
 rand_core = "0.6.3"
 rand_chacha = "0.3.1"

--- a/rust/utils/Cargo.toml
+++ b/rust/utils/Cargo.toml
@@ -12,7 +12,7 @@ tonic = {version = "0.6", features = ["tls", "tls-roots", "transport"] }
 prost = "0.9"
 prost-types = "0.9"
 serde = {version = "1.0", features = ["derive"] }
-merklehash = { git = "ssh://git@github.com/xetdata/xet-core" }
+merklehash = { path = "../merklehash"} 
 thiserror = "1.0"
 futures = "0.3.17"
 


### PR DESCRIPTION
Currently, merklehash causes a break in the xet-core compilation due to others packages depending on both local and remote versions of it.  This fixes that issue.