### PR TITLE
Decrease channel size from 1 TB to 256 MB

### DIFF
--- a/rust/gitxetcore/src/stream/git_stream.rs
+++ b/rust/gitxetcore/src/stream/git_stream.rs
@@ -36,9 +36,9 @@ const EXPECTED_GIT_VERSION: u32 = 2;
 
 /// The channel limit for the read side of the handler
 /// The git packet size is limited to 64K-ish.
-/// so this limits the channel volume to 1TB. This is also
+/// so this limits the channel volume to 256MB. This is also
 /// the maximum file size we can "pass-through".
-const GIT_READ_MPSC_CHANNEL_SIZE: usize = 4096 * 4096;
+const GIT_READ_MPSC_CHANNEL_SIZE: usize = 4096;
 /// The channel limit for the write side of the handler
 /// The write handler may write messages up to 16MB.
 /// so this limits the per-channel volume to about 256 MB


### PR DESCRIPTION
Reducing channel size to 256 MB greatly reduce peak memory usage when files are large. Refer to https://github.com/xetdata/xethub/issues/1384