### PR TITLE
Limit number of file handles

### DIFF
--- a/rust/mdb_shard/Cargo.toml
+++ b/rust/mdb_shard/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1"
 rand = {version = "0.8.5", features = ["small_rng"]}
 thiserror = "1.0.30"
 async-trait = "0.1.9"
+rlimit = "0.9.1"
 
 [[bin]]
 name = "shard_benchmark"


### PR DESCRIPTION
Limit the number of file handles to `RLIMIT_NOFILE` / 2 or if not exists, 200. Fix https://github.com/xetdata/xethub/issues/3227