### PR TITLE
Bugfix: CAS uploads fail silently if the prefix contains '.'

### DIFF
--- a/rust/cas_client/src/local_client.rs
+++ b/rust/cas_client/src/local_client.rs
@@ -11,7 +11,7 @@ use tokio::{
     fs::{metadata, File},
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info};
 
 #[derive(Debug)]
 pub struct LocalClient {
@@ -140,7 +140,7 @@ impl LocalClient {
                     }
                 }
                 if !is_okay {
-                    warn!("File '{x:?}' in staging area not in valid format, ignoring.");
+                    debug!("File '{x:?}' in staging area not in valid format, ignoring.");
                 }
             });
         Ok(ret)

--- a/rust/cas_client/src/staging_client.rs
+++ b/rust/cas_client/src/staging_client.rs
@@ -6,7 +6,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use progress_reporting::DataProgressReporter;
 use tokio::sync::Mutex;
-use tracing::{info, info_span, Instrument};
+use tracing::{debug, info, info_span, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use merklehash::MerkleHash;
@@ -151,7 +151,7 @@ impl<T: Client + Debug + Sync + Send + 'static> StagingUpload for StagingClient<
                 // most rustic way to make a particular Err enum not an error?)
                 if res.is_err() {
                     if let Err(CasClientError::XORBRejected) = res {
-                        info!(
+                        debug!(
                             "XORB {}/{} rejected; possibly already present.",
                             &entry.prefix, &entry.hash,
                         );


### PR DESCRIPTION
Also added more logging sections.