### PR TITLE
Finalize progress indicators

### DIFF
--- a/rust/gitxetcore/src/stream/git_stream.rs
+++ b/rust/gitxetcore/src/stream/git_stream.rs
@@ -329,12 +329,13 @@ impl<R: Read + Send + 'static, W: Write> GitStreamInterface<R, W> {
         self.repo.write().await.finalize_cleaning().await?;
 
         // Print final messages of progress indicators.
-        for pi in [&self.clean_progress, &self.smudge_progress] {
-            if let Some(pi) = pi {
-                let mut pi = pi.lock().await;
-                if pi.0 {
-                    pi.1.finalize();
-                }
+        for pi in [&self.clean_progress, &self.smudge_progress]
+            .into_iter()
+            .flatten()
+        {
+            let mut pi = pi.lock().await;
+            if pi.0 {
+                pi.1.finalize();
             }
         }
 


### PR DESCRIPTION
The clean and smudge progress indicators for filter process never printed their final messages. This prints the final speed.