### PR TITLE
xetblob reads with mdbv2

### DIFF
--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -1,26 +1,278 @@
 use crate::config::XetConfig;
+use crate::constants::{LOCAL_CAS_SCHEME, MAX_CONCURRENT_DOWNLOADS, POINTER_FILE_LIMIT};
 use crate::data_processing_v1::PointerFileTranslatorV1;
 pub use crate::data_processing_v1::{
     FILTER_BYTES_CLEANED, FILTER_BYTES_SMUDGED, FILTER_CAS_BYTES_PRODUCED, GIT_XET_VERION,
 };
 use crate::data_processing_v2::PointerFileTranslatorV2;
-use crate::errors::Result;
-use crate::git_integration::git_repo;
-use cas_client::Staging;
+use crate::errors::{GitXetRepoError, Result};
+use crate::git_integration::git_repo::{self, GitRepo};
+use cas_client::{
+    new_staging_client, new_staging_client_with_progressbar, CachingClient, LocalClient,
+    RemoteClient, Staging,
+};
+use futures::prelude::stream::*;
 use mdb_shard::shard_version::ShardVersion;
-use merkledb::AsyncIterator;
+use merkledb::{AsyncIterator, ObjectRange};
+use merklehash::MerkleHash;
 use pointer_file::PointerFile;
 use progress_reporting::DataProgressReporter;
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
+use tracing::{error, info, info_span};
+use tracing_futures::Instrument;
+
+pub async fn create_cas_client(config: &XetConfig) -> Result<Box<dyn Staging + Send + Sync>> {
+    info!(
+        "CAS staging directory located at: {:?}.",
+        &config.staging_path
+    );
+
+    let endpoint = &config.cas.endpoint;
+    let (user_id, _) = &config.user.get_user_id();
+    let repo_paths = GitRepo::get_remote_urls(config.repo_path().ok().map(|x| x.as_path()))
+        .unwrap_or_else(|_| vec!["".to_string()]);
+
+    if let Some(fs_path) = endpoint.strip_prefix(LOCAL_CAS_SCHEME) {
+        info!("Using local CAS with path: {:?}.", endpoint);
+        let mut path = PathBuf::from_str(fs_path)
+            .map_err(|_| GitXetRepoError::InvalidLocalCasPath(fs_path.to_string()))?;
+        if !path.is_absolute() {
+            path = current_dir()?.join(path);
+        }
+        let client = LocalClient::new(&path, false);
+        Ok(new_staging_client_with_progressbar(
+            client,
+            config.staging_path.as_deref(),
+        ))
+    } else if config.cache.enabled {
+        let cacheclient_result = CachingClient::new(
+            RemoteClient::from_config(
+                endpoint,
+                user_id,
+                repo_paths.clone(),
+                GIT_XET_VERION.clone(),
+            )
+            .await,
+            &config.cache.path,
+            config.cache.size,
+            config.cache.blocksize,
+        );
+        match cacheclient_result {
+            Ok(cacheclient) => {
+                info!(
+                    "Using Caching CAS with endpoint {:?}, prefix {:?}, caching at {:?}.",
+                    &endpoint, &config.cas.prefix, &config.cache.path
+                );
+                Ok(new_staging_client_with_progressbar(
+                    cacheclient,
+                    config.staging_path.as_deref(),
+                ))
+            }
+            Err(e) => {
+                error!(
+                    "Unable to use caching CAS due to: {:?}; Falling back to non-caching CAS with endpoint: {:?}.",
+                    &e, &endpoint
+                );
+                let remote_client = RemoteClient::from_config(
+                    endpoint,
+                    user_id,
+                    repo_paths.clone(),
+                    GIT_XET_VERION.clone(),
+                )
+                .await;
+                Ok(new_staging_client_with_progressbar(
+                    remote_client,
+                    config.staging_path.as_deref(),
+                ))
+            }
+        }
+    } else {
+        info!("Using non-caching CAS with endpoint: {:?}.", &endpoint);
+        let remote_client = RemoteClient::from_config(
+            endpoint,
+            user_id,
+            repo_paths.clone(),
+            GIT_XET_VERION.clone(),
+        )
+        .await;
+        Ok(new_staging_client(
+            remote_client,
+            config.staging_path.as_deref(),
+        ))
+    }
+}
+
+/**  Wrapper to consolidate the logic for retrieving from CAS.   
+ */
+pub async fn get_from_cas(
+    cas: Arc<Box<dyn Staging + Send + Sync>>,
+    prefix: String,
+    hash: MerkleHash,
+    ranges: (u64, u64),
+) -> Result<Vec<u8>> {
+    if ranges.0 == ranges.1 {
+        return Ok(Vec::new());
+    }
+    let mut query_result = cas
+        .get_object_range(&prefix, &hash, vec![ranges])
+        .await
+        .map_err(|e| GitXetRepoError::Other(format!("Error fetching Xorb {hash:?}: {e:?}.")))?;
+    Ok(std::mem::take(&mut query_result[0]))
+}
+
+/// Given an Vec<ObjectRange> describing a series of range of bytes,
+/// slice a subrange. This does not check limits and may return shorter
+/// results if the slice goes past the end of the range.
+pub fn slice_object_range(v: &[ObjectRange], mut start: usize, mut len: usize) -> Vec<ObjectRange> {
+    let mut ret: Vec<ObjectRange> = Vec::new();
+    for i in v.iter() {
+        let ilen = i.end - i.start;
+        // we have not gotten to the start of the range
+        if start > 0 && start >= ilen {
+            // start is still after this range
+            start -= ilen;
+        } else {
+            // either start == 0, or start < packet len.
+            // Either way, we need some or all of this packet
+            // and after this packet start must be = 0
+            let packet_start = i.start + start;
+            // the maximum length allowed is how far to end of the packet
+            // OR the actual slice length requested which ever is shorter.
+            let max_length_allowed = std::cmp::min(i.end - packet_start, len);
+            ret.push(ObjectRange {
+                hash: i.hash,
+                start: packet_start,
+                end: packet_start + max_length_allowed,
+            });
+            start = 0;
+            len -= max_length_allowed;
+        }
+        if len == 0 {
+            break;
+        }
+    }
+    ret
+}
+
+/// Writes a collection of chunks from a Vec<ObjectRange> to a writer.
+pub async fn data_from_chunks_to_writer(
+    cas: Arc<Box<dyn Staging + Send + Sync>>,
+    prefix: String,
+    chunks: Vec<ObjectRange>,
+    writer: &mut impl std::io::Write,
+) -> Result<()> {
+    let mut bytes_smudged: u64 = 0;
+    let mut strm = iter(chunks.into_iter().map(|objr| {
+        let cas = cas.clone();
+        let prefix = prefix.clone();
+        get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
+    }))
+    .buffered(MAX_CONCURRENT_DOWNLOADS);
+
+    while let Some(buf) = strm.next().await {
+        let buf = buf?;
+        bytes_smudged += buf.len() as u64;
+        let s = info_span!("write_chunk");
+        let _ = s.enter();
+        writer.write_all(&buf)?;
+    }
+
+    FILTER_BYTES_SMUDGED.inc_by(bytes_smudged);
+
+    Ok(())
+}
+
+/// Tries to parse a pointer file from the reader, but if parsing fails, returns
+/// the data we have pulled out from the reader. (The AsyncIterator does not
+/// provide a "put-back" function and for simplicity it probably shouldn't
+/// have that).
+///
+/// if a pointer file is parsed successfully Returns `Ok(Some(PointerFile), data)`
+/// if a pointer file is parsed unsuccessfully, Returns `Ok(None, data)`
+/// if the read stream failed for reasons which are not EOF, returns `Err(e)`
+pub async fn pointer_file_from_reader(
+    path: &Path,
+    reader: &mut impl AsyncIterator,
+    force_no_smudge: bool,
+) -> Result<(Option<PointerFile>, Vec<u8>)> {
+    let mut data: Vec<u8> = Vec::new();
+
+    while data.len() < POINTER_FILE_LIMIT {
+        match reader.next().await? {
+            Some(mut new_data) => {
+                data.append(&mut new_data);
+            }
+            None => {
+                break;
+            }
+        };
+    }
+
+    if force_no_smudge || data.len() > POINTER_FILE_LIMIT {
+        // too large.
+        return Ok((None, data));
+    }
+
+    let file_str: &str = match std::str::from_utf8(&data[..]) {
+        Ok(v) => v,
+        Err(_) => return Ok((None, data)), // can't utf-8. definitely a bad pointer file
+    };
+
+    let ptr_file = PointerFile::init_from_string(file_str, path.to_str().unwrap());
+    if ptr_file.is_valid() {
+        Ok((Some(ptr_file), data))
+    } else {
+        // pointer file did not parse correctly
+        Ok((None, data))
+    }
+}
+
+/// Manages the smudigng of a single set of blocks, that does not
+/// require a full copy of the MerkleDB to hang around.
+#[derive(Clone)]
+pub struct MiniPointerFileSmudger {
+    cas: Arc<Box<dyn Staging + Send + Sync>>,
+    prefix: String,
+    blocks: Vec<ObjectRange>,
+}
+
+impl MiniPointerFileSmudger {
+    pub async fn smudge_to_writer(
+        &self,
+        writer: &mut impl std::io::Write,
+        range: Option<(usize, usize)>,
+    ) -> Result<()> {
+        let ranged_blocks = match range {
+            Some((start, end)) => {
+                // we expect callers to validate the range, but just in case, check it anyway.
+                if end < start {
+                    let msg = format!(
+                        "End range value requested ({end}) is less than start range value ({start})"
+                    );
+                    error!(msg);
+                    return Err(GitXetRepoError::Other(msg));
+                }
+                slice_object_range(&self.blocks, start, end - start)
+            }
+            None => self.blocks.clone(),
+        };
+        data_from_chunks_to_writer(self.cas.clone(), self.prefix.clone(), ranged_blocks, writer)
+            .await?;
+        Ok(())
+    }
+}
 
 enum PFTRouter {
     V1(PointerFileTranslatorV1),
     V2(PointerFileTranslatorV2),
 }
+
 pub struct PointerFileTranslator {
     pft: PFTRouter,
 }
@@ -100,6 +352,14 @@ impl PointerFileTranslator {
                 p.clean_file_and_report_progress(path, reader, progress_indicator)
                     .await
             }
+        }
+    }
+
+    /// Queries merkle db for construction info for a pointer file.
+    pub async fn derive_blocks(&self, pointer: &PointerFile) -> Result<Vec<ObjectRange>> {
+        match &self.pft {
+            PFTRouter::V1(ref p) => p.derive_blocks(pointer).await,
+            PFTRouter::V2(ref p) => p.derive_blocks(pointer).await,
         }
     }
 
@@ -224,6 +484,34 @@ impl PointerFileTranslator {
     pub async fn reload_mdb(&self) {
         if let PFTRouter::V1(ref p) = &self.pft {
             p.reload_mdb().await
+        }
+    }
+
+    /// Create a mini smudger that handles only the pointer file concerned
+    /// without taking a full copy of the MerkleDB
+    pub async fn make_mini_smudger(
+        &self,
+        path: &PathBuf,
+        pointer: &PointerFile,
+    ) -> Result<MiniPointerFileSmudger> {
+        info!("Mini Smudging file {:?}", &path);
+
+        let blocks = self
+            .derive_blocks(pointer)
+            .instrument(info_span!("derive_blocks"))
+            .await?;
+
+        match &self.pft {
+            PFTRouter::V1(ref p) => Ok(MiniPointerFileSmudger {
+                cas: p.get_cas(),
+                prefix: p.get_prefix(),
+                blocks,
+            }),
+            PFTRouter::V2(ref p) => Ok(MiniPointerFileSmudger {
+                cas: p.get_cas(),
+                prefix: p.get_prefix(),
+                blocks,
+            }),
         }
     }
 }

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -40,7 +40,7 @@ use crate::summaries::libmagic::LibmagicAnalyzer;
 use crate::summaries_plumb::WholeRepoSummary;
 use cas_client::CasClientError;
 
-pub use crate::data_processing_v1::*;
+pub use crate::data_processing::*;
 
 #[derive(Default)]
 struct CASDataAggregator {
@@ -103,7 +103,7 @@ pub struct PointerFileTranslatorV2 {
 impl PointerFileTranslatorV2 {
     /// Constructor
     pub async fn from_config(config: &XetConfig) -> Result<Self> {
-        let cas_client = PointerFileTranslatorV1::create_cas_client(config).await?;
+        let cas_client = create_cas_client(config).await?;
 
         // autosync on drop is the cause for some ctrl-c resilience issues
         // as this means that on certain non-panicking IO errors
@@ -803,7 +803,7 @@ impl PointerFileTranslatorV2 {
         }
     }
 
-    async fn derive_blocks(&self, pointer: &PointerFile) -> Result<Vec<ObjectRange>> {
+    pub async fn derive_blocks(&self, pointer: &PointerFile) -> Result<Vec<ObjectRange>> {
         let hash = MerkleHash::from_hex(pointer.hash()).map_err(|e| {
             GitXetRepoError::StreamParseError(format!("Error getting hex hash value: {e:?}"))
         })?;
@@ -928,6 +928,7 @@ mod tests {
 
     use crate::async_file_iterator::*;
     use crate::constants::*;
+    use crate::data_processing_v1::PointerFileTranslatorV1;
 
     use super::*;
 

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -1,6 +1,6 @@
 use crate::config::XetConfig;
 use crate::constants::MAX_CONCURRENT_UPLOADS;
-use crate::data_processing_v1::PointerFileTranslatorV1;
+use crate::data_processing::create_cas_client;
 use crate::errors;
 use crate::errors::GitXetRepoError;
 use crate::git_integration::git_notes_wrapper::GitNotesWrapper;
@@ -287,7 +287,7 @@ async fn sync_mdb_shards_from_cas(
     cache_dir: &Path,
 ) -> errors::Result<()> {
     info!("Sync shards from CAS");
-    let cas = PointerFileTranslatorV1::create_cas_client(config).await?;
+    let cas = create_cas_client(config).await?;
 
     let metas = MDBShardMetaCollection::open(cache_meta)?;
 
@@ -445,7 +445,7 @@ async fn sync_session_shards_to_remote(
     // Consolidate all the shards.
 
     if !shards.is_empty() {
-        let cas = PointerFileTranslatorV1::create_cas_client(config).await?;
+        let cas = create_cas_client(config).await?;
         let cas_ref = &cas;
 
         let (user_id, _) = config.user.get_user_id();

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -1,4 +1,4 @@
-use gitxetcore::data_processing_v1::*;
+use gitxetcore::data_processing::*;
 use pointer_file::PointerFile;
 
 #[derive(Clone)]


### PR DESCRIPTION
1. Moved some functions used both by PFTv1 and PFTv2 from data_processing_v1.rs to data_processing.rs. They were already extracted out of `PointerFileTranslatorV1` but remained inside data_processing_v1.rs and PointerFileTranslatorV2 had to reference to them by data_processing_v1::. This helps keep xetblob code clean.

2. Makes git fetch only merkledb* notes and reposalt note if it exists.

Test:
A v2 repo:
`xetcmd download https://hub.xetsvc.com/seanses-dev/test-MDBv2/main/121590361.jpg 121590361.jpg`

A v1 repo:
`xetcmd download https://hub.xetsvc.com/seanses-dev/Intro_to_ML/main/feature_eng.ipynb feature_eng.ipynb`

Test with larger repo after https://github.com/xetdata/xethub/pull/3294 deploys.