### PR TITLE
Removed XORBRejected as error

### DIFF
--- a/rust/cas_client/src/grpc.rs
+++ b/rust/cas_client/src/grpc.rs
@@ -327,10 +327,15 @@ impl GrpcClient {
         );
 
         if !response.into_inner().was_inserted {
-            Err(CasClientError::XORBRejected)
-        } else {
-            Ok(())
+            info!(
+                "GrpcClient Req {}: XORB {}/{} not inserted; already present.",
+                get_request_id(),
+                prefix,
+                hash
+            );
         }
+
+        Ok(())
     }
 
     /// on success returns a type of 2 EndpointConfig's

--- a/rust/cas_client/src/interface.rs
+++ b/rust/cas_client/src/interface.rs
@@ -91,8 +91,6 @@ pub enum CasClientError {
     InternalError(anyhow::Error),
     #[error("not found")]
     XORBNotFound(MerkleHash),
-    #[error("insert rejected")]
-    XORBRejected,
     #[error("data transfer timeout")]
     DataTransferTimeout,
     #[error("Client connection error {0}")]
@@ -112,7 +110,6 @@ impl PartialEq for CasClientError {
             (CasClientError::HashMismatch, CasClientError::HashMismatch) => true,
             (CasClientError::InternalError(_), CasClientError::InternalError(_)) => true,
             (CasClientError::XORBNotFound(a), CasClientError::XORBNotFound(b)) => a == b,
-            (CasClientError::XORBRejected, CasClientError::XORBRejected) => true,
             (CasClientError::DataTransferTimeout, CasClientError::DataTransferTimeout) => true,
             (CasClientError::GrpcClientError(_), CasClientError::GrpcClientError(_)) => true,
             (CasClientError::ConnectionPooling(_), CasClientError::ConnectionPooling(_)) => true,

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -359,7 +359,6 @@ fn cas_client_error_retriable(err: &CasClientError) -> bool {
         CasClientError::InvalidRange
             | CasClientError::InvalidArguments
             | CasClientError::HashMismatch
-            | CasClientError::XORBRejected
     )
 }
 
@@ -397,6 +396,7 @@ impl Client for RemoteClient {
                 },
             )
             .await;
+
         if let Err(ref e) = res {
             if cas_client_error_retriable(e) {
                 error!("Too many failures writing {:?}: {:?}.", hash, e);

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -42,7 +42,6 @@ use crate::summaries::analysis::FileAnalyzers;
 use crate::summaries::csv::CSVAnalyzer;
 use crate::summaries::libmagic::LibmagicAnalyzer;
 use crate::summaries_plumb::WholeRepoSummary;
-use cas_client::CasClientError;
 
 use lazy_static::lazy_static;
 use prometheus::{register_int_counter, IntCounter};
@@ -60,7 +59,6 @@ lazy_static! {
     pub static ref GIT_XET_VERION: String =
         std::env::var("XET_VERSION").unwrap_or_else(|_| CURRENT_VERSION.to_string());
 }
-
 #[allow(clippy::borrowed_box)]
 async fn upload_to_cas(
     prefix: &str,
@@ -68,7 +66,7 @@ async fn upload_to_cas(
     casroot: &MerkleNode,
     cas: &Box<dyn Staging + Send + Sync>,
     buf: Vec<u8>,
-) -> std::io::Result<()> {
+) -> Result<()> {
     let mut chunk_boundaries: Vec<u64> = Vec::new();
     let mut running_sum = 0;
 
@@ -76,20 +74,10 @@ async fn upload_to_cas(
         running_sum += leaf.len();
         chunk_boundaries.push(running_sum as u64);
     }
-    let res = cas.put(prefix, casroot.hash(), buf, chunk_boundaries).await;
-    if let Err(e) = res {
-        match e {
-            // Xorb Rejected is not an error. This is OK. This means
-            // that the Xorb already exists on remote.
-            CasClientError::XORBRejected => return Ok(()),
-            e => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("{e:?}"),
-                ));
-            }
-        }
-    }
+
+    cas.put(prefix, casroot.hash(), buf, chunk_boundaries)
+        .await?;
+
     Ok(())
 }
 

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -38,7 +38,6 @@ use crate::summaries::analysis::FileAnalyzers;
 use crate::summaries::csv::CSVAnalyzer;
 use crate::summaries::libmagic::LibmagicAnalyzer;
 use crate::summaries_plumb::WholeRepoSummary;
-use cas_client::CasClientError;
 
 pub use crate::data_processing_v1::*;
 
@@ -54,31 +53,6 @@ struct CASDataAggregator {
     // an entry once the cas block is finalized and uploaded.  These correspond to the indices given
     // alongwith the file info.
     pending_file_info: Vec<(MDBFileInfo, Vec<usize>)>,
-}
-
-#[allow(clippy::borrowed_box)]
-async fn upload_data_to_cas(
-    cas: &Box<dyn Staging + Send + Sync>,
-    prefix: &str,
-    cas_hash: &MerkleHash,
-    boundaries: Vec<u64>,
-    buf: Vec<u8>,
-) -> std::io::Result<()> {
-    let res = cas.put(prefix, cas_hash, buf, boundaries).await;
-    if let Err(e) = res {
-        match e {
-            // Xorb Rejected is not an error. This is OK. This means
-            // that the Xorb already exists on remote.
-            CasClientError::XORBRejected => return Ok(()),
-            e => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("{e:?}"),
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Manages the translation of files between the
@@ -468,15 +442,14 @@ impl PointerFileTranslatorV2 {
 
         if !cas_info.chunks.is_empty() {
             self.mdb.add_cas_block(cas_info).await?;
-
-            upload_data_to_cas(
-                self.cas.as_ref(),
-                &self.prefix,
-                &cas_hash,
-                chunk_boundaries,
-                take(&mut cas_data.data),
-            )
-            .await?;
+            self.cas
+                .put(
+                    &self.prefix,
+                    &cas_hash,
+                    take(&mut cas_data.data),
+                    chunk_boundaries,
+                )
+                .await?;
         } else {
             debug_assert_eq!(cas_hash, MerkleHash::default());
         }

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -142,10 +142,6 @@ impl Termination for MainReturn {
 pub fn convert_cas_error(err: CasClientError) -> Result<()> {
     match err {
         CasClientError::Grpc(_) => Err(GitXetRepoError::NetworkIOError(err)),
-        CasClientError::XORBRejected => {
-            // This simply means it's already present on put; not an error.
-            Ok(())
-        }
         _ => Err(GitXetRepoError::CasClientError(
             "CAS Error: ".to_owned() + &err.to_string(),
         )),

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -6,7 +6,6 @@ use crate::errors::GitXetRepoError;
 use crate::git_integration::git_notes_wrapper::GitNotesWrapper;
 use crate::merkledb_plumb::*;
 use crate::utils::*;
-use cas_client::CasClientError;
 use mdb_shard::shard_handle::MDBShardFile;
 use parutils::tokio_par_for_each;
 use shard_client::{GrpcShardClient, RegistrationClient, ShardConnectionConfig};
@@ -481,27 +480,14 @@ async fn sync_session_shards_to_remote(
             let data = fs::read(&si.path)?;
             let data_len = data.len();
             // Upload the shard.
-            let res = cas_ref
+            cas_ref
                 .put_bypass_stage(
                     shard_prefix_ref,
                     &si.shard_hash,
                     data,
                     vec![data_len as u64],
                 )
-                .await;
-
-            if let Err(e) = res {
-                match e {
-                    // Xorb Rejected is not an error. This is OK. This means
-                    // that the Xorb already exists on remote.
-                    CasClientError::XORBRejected => {}
-                    e => {
-                        return Err(GitXetRepoError::CasClientError(format!(
-                            "Error uploading shard to CAS: {e:?}"
-                        )));
-                    }
-                }
-            }
+                .await?;
 
             info!(
                 "Registering shard {shard_prefix_ref}/{:?} with shard server.",


### PR DESCRIPTION
It is never an error, so instead of creating it as an error in the first place, we simply log it and continue.   This means we can rip out a lot of the XORBRejected logic. 