### PR TITLE
Clean up Xetblob read logic with MDB v2

### DIFF
--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -25,7 +25,6 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tracing::{error, info, info_span};
-use tracing_futures::Instrument;
 
 pub async fn create_cas_client(config: &XetConfig) -> Result<Box<dyn Staging + Send + Sync>> {
     info!(
@@ -492,14 +491,9 @@ impl PointerFileTranslator {
     pub async fn make_mini_smudger(
         &self,
         path: &PathBuf,
-        pointer: &PointerFile,
+        blocks: Vec<ObjectRange>,
     ) -> Result<MiniPointerFileSmudger> {
         info!("Mini Smudging file {:?}", &path);
-
-        let blocks = self
-            .derive_blocks(pointer)
-            .instrument(info_span!("derive_blocks"))
-            .await?;
 
         match &self.pft {
             PFTRouter::V1(ref p) => Ok(MiniPointerFileSmudger {

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1280,6 +1280,23 @@ impl GitRepo {
         Ok(())
     }
 
+    /// Sync minimal notes to Merkle DB for Xetblob operations
+    pub async fn sync_notes_to_dbs_for_xetblob(&self) -> Result<()> {
+        info!("XET sync_notes_to_dbs_for_xetblob.");
+
+        debug!("XET sync_notes_to_dbs_for_xetblob: merging MDB");
+        if self.mdb_version == ShardVersion::V1 {
+            merge_merkledb_from_git(
+                &self.xet_config,
+                &self.merkledb_file,
+                GIT_NOTES_MERKLEDB_V1_REF_NAME,
+            )
+            .await?
+        }
+
+        Ok(())
+    }
+
     /// Syncronizes any fetched note refs to the local notes
     pub fn sync_note_refs_to_local(&self, note_suffix: &str, notes_ref_suffix: &str) -> Result<()> {
         for xet_p in ["xet", "xet_alt"] {
@@ -1338,6 +1355,23 @@ impl GitRepo {
         self.sync_note_refs_to_local("merkledb", GIT_NOTES_MERKLEDB_V1_REF_SUFFIX)?;
         self.sync_note_refs_to_local("merkledbv2", GIT_NOTES_MERKLEDB_V2_REF_SUFFIX)?;
         self.sync_note_refs_to_local("summaries", GIT_NOTES_SUMMARIES_REF_SUFFIX)?;
+
+        Ok(())
+    }
+
+    /// Sync minimal remote notes to local for Xetblob operations
+    pub fn sync_remote_to_notes_for_xetblob(&self, remote: &str) -> Result<()> {
+        info!("XET sync_remote_to_notes_for_xetblob: remote = {}", &remote);
+
+        self.run_git_checked_in_repo(
+            "fetch",
+            &[
+                remote,
+                "--refmap=",
+                "--no-write-fetch-head",
+                "+refs/notes/xet/merkledb*:refs/notes/xet/merkledb*",
+            ],
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
1. Only fetch minimal ref notes for read logic, this means it will only fetch mdb ref notes if a derive_blocks call failed (and this will never happen for mdb v2 because shard client makes a back up query).

2. After fetching new ref notes, just reloads merkle db (for v1) instead of creating a new translator.

3. Reduce calling derive_blocks from 3 times (even when the first call succeeds, regardless of v1 or v2) to 1 call for v2 and at most 2 calls for v1.


Tested with 
1. xetcmd download one file from a v1/v2 repo.
2. push a new file using git-xet to that repo.
3. xetcmd download the new file from that repo.