### PR TITLE
mount watch import os unix only on non-windows

### DIFF
--- a/rust/gitxetcore/src/xetmnt/watch/contents.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/contents.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
 use std::fs;
 use std::fs::Permissions;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use anyhow::anyhow;
 use git2::{self, ObjectType, Oid};


### PR DESCRIPTION
Automated windows build failed due to inability to import `std::os::unix::fs::{MetadataExt, PermissionsExt}`.

This PR changes that import to be conditional on target os not being windows. Confirmed on windows self-hosted runner machine that compilation is successful and can clone a repo with compiled debug binary with this change.