### PR TITLE
git xet init for bare repo

### DIFF
--- a/rust/gitxetcore/src/command/init.rs
+++ b/rust/gitxetcore/src/command/init.rs
@@ -27,18 +27,27 @@ pub struct InitArgs {
     /// The merkledb version to use, 2 is MDB Shard.
     #[clap(long, short, default_value_t = 2)]
     mdb_version: u64,
+
+    /// If set, initial for bare repo, skipping setting global or local configs.
+    /// Ignores all options except "mdb_version".
+    #[clap(long, short)]
+    bare: bool,
 }
 
 pub async fn init_command(config: XetConfig, args: &InitArgs) -> errors::Result<()> {
     let mut repo = GitRepo::open(config)?;
-    repo.install_gitxet(
-        args.global_config,
-        args.force_local_config,
-        args.preserve_gitattributes,
-        args.force,
-        args.enable_locking,
-        args.mdb_version,
-    )
-    .await?;
+    if args.bare {
+        repo.install_gitxet_for_bare_repo(args.mdb_version).await?;
+    } else {
+        repo.install_gitxet(
+            args.global_config,
+            args.force_local_config,
+            args.preserve_gitattributes,
+            args.force,
+            args.enable_locking,
+            args.mdb_version,
+        )
+        .await?;
+    }
     Ok(())
 }

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -495,6 +495,25 @@ impl GitRepo {
         Ok(changed)
     }
 
+    /// Set up a bare repo with xet specific information.
+    ///
+    /// May be run multiple times without changing the current configuration.
+    pub async fn install_gitxet_for_bare_repo(&self, mdb_version: u64) -> Result<()> {
+        info!(
+            "Configure Merkle DB and repo salt associated with repo {:?}",
+            self.repo_dir
+        );
+
+        let mdb_version = ShardVersion::try_from(mdb_version)?;
+        self.set_repo_mdb(&mdb_version).await?;
+
+        if mdb_version.need_salt() {
+            self.set_repo_salt()?;
+        }
+
+        Ok(())
+    }
+
     // Write out all the initial configurations and hooks.
     //
     // Returns two flags.  The first is true if any changes were made,

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -6,9 +6,6 @@ use crate::errors::GitXetRepoError;
 use crate::git_integration::git_notes_wrapper::GitNotesWrapper;
 use crate::merkledb_plumb::*;
 use crate::utils::*;
-use mdb_shard::shard_handle::MDBShardFile;
-use parutils::tokio_par_for_each;
-use shard_client::{GrpcShardClient, RegistrationClient, ShardConnectionConfig};
 
 use anyhow::Context;
 use bincode::Options;
@@ -17,10 +14,13 @@ use git2::Oid;
 use mdb_shard::merging::consolidate_shards_in_directory;
 use mdb_shard::shard_file_manager::ShardFileManager;
 use mdb_shard::shard_file_reconstructor::FileReconstructor;
+use mdb_shard::shard_handle::MDBShardFile;
 use mdb_shard::{shard_file::*, shard_version::ShardVersion};
 use merkledb::MerkleMemDB;
 use merklehash::{HashedWrite, MerkleHash};
+use parutils::tokio_par_for_each;
 use serde::{Deserialize, Serialize};
+use shard_client::{GrpcShardClient, RegistrationClient, ShardConnectionConfig};
 use std::{
     collections::HashSet,
     fs,


### PR DESCRIPTION
Based on #35. 

Let `git xet init` work for bare repo with `-b or --bare` option. Used for repo initialization (setting Merkle DB version and/or repo salt)on Xetea.