### PR TITLE
Allow xet cli /pyxet to work with incomplete git config (no email, or username)

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -138,11 +138,6 @@ pub fn open_libgit2_repo(
         Some(path) => Repository::discover(path)?,
         None => Repository::open_from_env()?,
     };
-
-    // Now, need to check some things that can mess libgit up in various testing
-    // situations.
-    verify_user_config(repo_path)?;
-
     Ok(repo)
 }
 

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -151,8 +151,18 @@ impl XetRepo {
         if remotes.is_empty() {
             return Err(anyhow!("No remote defined"));
         }
+        if remotes.is_empty() {
+            return Err(anyhow!(
+                "Unable to infer remote. There may be a problem with git configuration"
+            ));
+        }
         // we just pick the 1st remote
         let remote = remotes[0].clone();
+        if remote.is_empty() {
+            return Err(anyhow!(
+                "Unable to infer remote. There may be a problem with git configuration"
+            ));
+        }
         // associate auth and make a bbq base path
         let remote = config.build_authenticated_remote_url(&remote);
         let url = git_remote_to_base_url(&remote)?;


### PR DESCRIPTION
We are much too aggressive about checking user.email and user.name. Those are only necessary if you need to write to a git repo. For pyxet / xetcli, we only need ever need to pull. Hence it is optional and not required.
The only places where we really need to check this is in `git xet mount` and `git xet clone` which already checks it explicitly.