### PR TITLE
Added tool to verify MerkleDB shard.

### DIFF
--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -6,11 +6,10 @@ use crate::merkledb_plumb as mdbv1;
 use crate::merkledb_shard_plumb::{self as mdbv2, verify_mdb_shard};
 
 use clap::{Args, Subcommand};
-use mdb_shard::shard_handle::MDBShardFile;
 use std::path::PathBuf;
 
 use mdb_shard::shard_version::ShardVersion;
-use tracing::{error, info};
+use tracing::info;
 
 /*
 Clap CLI Argument definitions

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -743,7 +743,7 @@ pub fn verify_mdb_shard_on_disk(shard_file: &Path) {
 pub async fn verify_mdb_shard_in_cas(
     config: &XetConfig,
     shard_hash: &MerkleHash,
-    dest_dir: Option<PathBuf>,
+    dest_dir: &Option<PathBuf>,
 ) {
     let cas = create_cas_client(config)
         .await
@@ -756,7 +756,7 @@ pub async fn verify_mdb_shard_in_cas(
     // Create a temp directory
     let stagedir = TempDir::new().unwrap();
 
-    let cache_dir = dest_dir.unwrap_or(stagedir.path().to_path_buf());
+    let cache_dir = dest_dir.clone().unwrap_or(stagedir.path().to_path_buf());
 
     let shard_file = download_shard(config, &cas, shard_hash, &cache_dir)
         .await
@@ -769,7 +769,7 @@ pub async fn verify_mdb_shard_in_cas(
     verify_mdb_shard_on_disk(&shard_file);
 }
 
-pub async fn verify_mdb_shard(config: &XetConfig, shard: &str) {
+pub async fn verify_mdb_shard(config: &XetConfig, shard: &str, cache_dir: &Option<PathBuf>) {
     if shard.starts_with("cas://") {
         let shard_hash = MerkleHash::from_hex(&shard["cas://".len()..])
             .map_err(|e| {
@@ -778,7 +778,7 @@ pub async fn verify_mdb_shard(config: &XetConfig, shard: &str) {
             })
             .unwrap();
 
-        verify_mdb_shard_in_cas(config, &shard_hash, None).await;
+        verify_mdb_shard_in_cas(config, &shard_hash, cache_dir).await;
     } else {
         verify_mdb_shard_on_disk(&PathBuf::from_str(shard).unwrap())
     }

--- a/rust/mdb_shard/src/shard_file.rs
+++ b/rust/mdb_shard/src/shard_file.rs
@@ -693,9 +693,13 @@ impl MDBShardInfo {
             }
 
             let byte_start = reader.stream_position()?;
+            eprintln!(
+                "File Hash {:?}: {:?} entries starting at position {:?}",
+                &header.file_hash, &header.num_entries, &byte_start
+            );
 
             reader.seek(SeekFrom::Current(
-                (header.num_entries * (size_of::<FileDataSequenceEntry>() as u32)) as i64,
+                ((header.num_entries as i64) * (size_of::<FileDataSequenceEntry>() as i64)) as i64,
             ))?;
             let byte_end = reader.stream_position()?;
 

--- a/rust/mdb_shard/src/utils.rs
+++ b/rust/mdb_shard/src/utils.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 lazy_static! {
     static ref MERKLE_DB_FILE_PATTERN: Regex =
-        Regex::new(r"((^)|(.*/))(?P<hash>[0-9a-fA-F]{64})\.mdb$").unwrap();
+        Regex::new(r"((^)|(.*[/-]))(?P<hash>[0-9a-fA-F]{64})\.mdb$").unwrap();
 }
 
 /// Parses a shard filename.  If the filename matches the shard filename pattern,


### PR DESCRIPTION
For some reason, some shards appear to not parse correctly on the shard server, hitting an EOF when asked to read the file reconstruction range.   This PR is an attempt to understand why.

Usage: 

git xet merkledb verify <path> 