### PR TITLE
fix cas shard upload order for mdbv2

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1434,8 +1434,8 @@ impl GitRepo {
         // in case the other db has issues, we are guaranteed to at least
         // get the bytes off the machine before anything else gets actually
         // pushed
-        self.sync_dbs_to_notes().await?;
         self.upload_all_staged().await?;
+        self.sync_dbs_to_notes().await?;
         self.sync_notes_to_remote(remote)?;
 
         Ok(())


### PR DESCRIPTION
Unlike MDBv1, `sync_dbs_to_notes` for MDBv2 also upload shard files and register them at shard server, they should happen after cas blocks are uploaded.