### PR TITLE
Write transaction temp session dir

### DIFF
--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -67,6 +67,8 @@ pub struct XetRepoWriteTransaction {
     bbq_client: BbqClient,
     translator: Arc<PointerFileTranslator>,
     mdb: XRWTMdbSwitch,
+
+    #[allow(dead_code)]
     shard_session_dir: TempDir,
 }
 


### PR DESCRIPTION
Since pyxet will create multiple write transactions and they run in parallel, a temporary session dir should be created for each write transaction, instead of each xet repo.