### PR TITLE
Allows dedup against previous chunks within the same CAS block on clean.

### DIFF
--- a/rust/merkledb/src/aggregate_hashes.rs
+++ b/rust/merkledb/src/aggregate_hashes.rs
@@ -8,7 +8,7 @@ use crate::MerkleNode;
 use crate::{merkledbbase::MerkleDBBase, MerkleMemDB};
 
 // Given a list of hashes and sizes, compute the aggregate hash for a cas node.
-pub fn cas_node_hash(chunks: &[(MerkleHash, usize)]) -> Result<MerkleHash> {
+pub fn cas_node_hash(chunks: &[(MerkleHash, (usize, usize))]) -> Result<MerkleHash> {
     // Create an ephemeral MDB.
     if chunks.is_empty() {
         return Ok(MerkleHash::default());
@@ -18,7 +18,7 @@ pub fn cas_node_hash(chunks: &[(MerkleHash, usize)]) -> Result<MerkleHash> {
 
     let nodes: Vec<MerkleNode> = chunks
         .iter()
-        .map(|(h, size)| mdb.maybe_add_node(h, *size, Vec::default()).0)
+        .map(|(h, (lb, ub))| mdb.maybe_add_node(h, ub - lb, Vec::default()).0)
         .collect();
 
     let m = mdb.merge_to_cas(&nodes[..]);


### PR DESCRIPTION
Dedup against previous chunks in the same CAS block, preventing a sequence of identical chunks to fill up a CAS block and cause lookup table irregularities. 