### PR TITLE
Fixed code warnings in test (annoying in vscode)

### DIFF
--- a/rust/gitxetcore/src/xetmnt/watch/watcher.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/watcher.rs
@@ -73,7 +73,6 @@ impl RepoWatcher {
             info!("RepoWatcher: resetting the FS metadata");
             self.update_fs_to_commit(&repo, new_commit)?;
 
-
             info!("RepoWatcher: Reloading merkledb into pointer file translator");
             self.pointer_translator.reload_mdb().await;
         }
@@ -148,6 +147,8 @@ impl RepoWatcher {
     }
 }
 
+#[allow(dead_code)]
+#[allow(unused_imports)]
 #[cfg(test)]
 mod tests {
     use std::fs::File;
@@ -181,7 +182,6 @@ mod tests {
         let rev = repo.revparse_single(gitref).unwrap();
         rev.as_commit().map(Commit::tree_id).unwrap()
     }
-
 
     // TODO: this is an example way to run the watcher against some repo and manually
     //       validate that refreshing is activating properly. Would like to automate


### PR DESCRIPTION
VSCode shows test code warnings as compile errors, which is slightly annoying.   Quick fix.  