### PR TITLE
Run cargo fmt on repo

### DIFF
--- a/rust/cache/src/xorb_cache.rs
+++ b/rust/cache/src/xorb_cache.rs
@@ -324,12 +324,18 @@ mod test {
         // the block(s) are stored correctly.
         let test_put_content = |size: usize| async move {
             let mut mock_remote = MockRemote::new();
-            mock_remote.expect_fetch()
+            mock_remote
+                .expect_fetch()
                 .times(0)
-                .returning(|_,_| Err(anyhow!("not expected to call remote")));
+                .returning(|_, _| Err(anyhow!("not expected to call remote")));
             let mut rng = StdRng::seed_from_u64(0);
             let dir_prefix = format!("__tmp_xorb_put_{size}");
-            let (_dir, test_xc) = new_test_xc(&dir_prefix, block_size as u64, u64::MAX, Arc::new(mock_remote));
+            let (_dir, test_xc) = new_test_xc(
+                &dir_prefix,
+                block_size as u64,
+                u64::MAX,
+                Arc::new(mock_remote),
+            );
             let mut data = vec![0u8; size];
             rng.fill_bytes(&mut data[..]);
             let test_key = Key::default();

--- a/rust/gitxetcore/src/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries_plumb.rs
@@ -178,8 +178,8 @@ async fn merge_db_from_git(
                     bincode::deserialize::<WholeRepoSummary>(&blob).map_err(|e| {
                         error!("Error unpacking file content summary information; discarding (Error = {:?})", &e);
                         e
-                    }).unwrap_or_default() 
-                } else { 
+                    }).unwrap_or_default()
+                } else {
                     WholeRepoSummary::default()
                 }
             }),

--- a/rust/gitxetcore/src/xetmnt/watch/metadata.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata.rs
@@ -18,8 +18,8 @@ use crate::xetmnt::watch::contents::EntryContent;
 use crate::xetmnt::watch::metadata::filesystem::{FileSystem, LookupStrategy};
 
 mod cache;
-mod symbol;
 mod filesystem;
+mod symbol;
 
 const STAT_CACHE_SIZE: usize = 65536;
 
@@ -52,8 +52,11 @@ impl FSMetadata {
     pub fn new(src_path: &Path, root_oid: Oid) -> Result<Self, anyhow::Error> {
         info!("Opening FSTree at: {src_path:?}");
         let symbol_table = Symbols::new();
-        let default_sym = symbol_table.default_symbol().map_err(|_| anyhow!("unknown issue with Symbol Table"))?;
-        let fs = FileSystem::new(src_path, root_oid, default_sym).map_err(|_| anyhow!("couldn't build the internal filesystem"))?;
+        let default_sym = symbol_table
+            .default_symbol()
+            .map_err(|_| anyhow!("unknown issue with Symbol Table"))?;
+        let fs = FileSystem::new(src_path, root_oid, default_sym)
+            .map_err(|_| anyhow!("couldn't build the internal filesystem"))?;
         Ok(Self {
             fs: RwLock::new(fs),
             symbol_table,
@@ -76,13 +79,11 @@ impl FSMetadata {
 
     /// Checks the given fileId to see if it is expanded or not
     pub fn is_expanded(&self, id: fileid3) -> Result<bool, nfsstat3> {
-        self.lock_read_fs()
-            .and_then(|fs| fs.is_expanded(id))
+        self.lock_read_fs().and_then(|fs| fs.is_expanded(id))
     }
 
     pub fn set_expanded(&self, id: fileid3) -> Result<(), nfsstat3> {
-        self.lock_write_fs()
-            .and_then(|mut fs| fs.set_expanded(id))
+        self.lock_write_fs().and_then(|mut fs| fs.set_expanded(id))
     }
 
     pub fn get_entry(&self, id: fileid3) -> Result<FSObject, nfsstat3> {
@@ -121,7 +122,8 @@ impl FSMetadata {
         let fs = self.lock_read_fs()?;
         let (children, end) = fs.list_children(dirid, start_after, max_entries)?;
         // translate children ids to DirEntries
-        let entries = children.iter()
+        let entries = children
+            .iter()
             .map(|id| {
                 let entry = fs.get_entry_ref(*id)?;
                 let name = self.symbol_table.decode_symbol(entry.name)?;
@@ -133,7 +135,7 @@ impl FSMetadata {
                 })
             })
             .collect::<Result<Vec<DirEntry>, nfsstat3>>()?;
-        Ok(ReadDirResult {entries,end})
+        Ok(ReadDirResult { entries, end })
     }
 
     /// Gets file attributes for the indicated file, using an internal cache to store commonly

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/cache.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/cache.rs
@@ -1,8 +1,8 @@
-use std::sync::{Mutex, MutexGuard};
-use lru::LruCache;
-use nfsserve::nfs::{fattr3, fileid3, nfsstat3};
-use nfsserve::nfs::nfsstat3::NFS3ERR_IO;
 use crate::log::ErrorPrinter;
+use lru::LruCache;
+use nfsserve::nfs::nfsstat3::NFS3ERR_IO;
+use nfsserve::nfs::{fattr3, fileid3, nfsstat3};
+use std::sync::{Mutex, MutexGuard};
 
 /// Thread-safe Cache for file attributes (i.e. stat).
 ///
@@ -13,7 +13,6 @@ pub struct StatCache {
 }
 
 impl StatCache {
-
     /// Creates a new StatCache with the given capacity.
     pub fn new(capacity: usize) -> Self {
         Self {
@@ -25,8 +24,7 @@ impl StatCache {
     pub fn get(&self, id: fileid3) -> Result<Option<fattr3>, nfsstat3> {
         // annoyingly this LRU cache implementation is not thread-safe and thus, requires mut
         // on a read. Ostensibly to update the read count.
-        self.lock()
-            .map(|mut cache| cache.get(&id).cloned())
+        self.lock().map(|mut cache| cache.get(&id).cloned())
     }
 
     /// Associate the id with the given attribute.
@@ -44,9 +42,7 @@ impl StatCache {
     }
 
     /// Lock the statcache, returning an error if the lock is poisoned (and logging the error).
-    fn lock(
-        &self,
-    ) -> Result<MutexGuard<'_, LruCache<fileid3, fattr3>>, nfsstat3> {
+    fn lock(&self) -> Result<MutexGuard<'_, LruCache<fileid3, fattr3>>, nfsstat3> {
         self.cache
             .lock()
             .log_error("Couldn't open StatCache lock")
@@ -56,9 +52,8 @@ impl StatCache {
 
 #[cfg(test)]
 mod cache_tests {
-    use nfsserve::nfs::{ftype3, size3};
     use super::*;
-
+    use nfsserve::nfs::{ftype3, size3};
 
     fn get_test_attr(fileid: fileid3, size: size3) -> fattr3 {
         fattr3 {
@@ -166,5 +161,4 @@ mod cache_tests {
         assert!(cache.get(2).unwrap().is_none());
         assert!(cache.get(3).unwrap().is_none());
     }
-
 }

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/filesystem.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/filesystem.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 use git2::Oid;
 use intaglio::Symbol;
 use itertools::Itertools;
-use nfsserve::nfs::{fattr3, fileid3, filename3, nfsstat3};
 use nfsserve::nfs::nfsstat3::{NFS3ERR_BAD_COOKIE, NFS3ERR_IO, NFS3ERR_NOENT, NFS3ERR_NOTDIR};
+use nfsserve::nfs::{fattr3, fileid3, filename3, nfsstat3};
 use tracing::error;
 
 use crate::log::ErrorPrinter;
 use crate::xetmnt::watch::contents::{DirectoryMetadata, EntryContent};
-use crate::xetmnt::watch::metadata::FSObject;
 use crate::xetmnt::watch::metadata::symbol::Symbols;
+use crate::xetmnt::watch::metadata::FSObject;
 use crate::xetmnt::watch::metrics::MOUNT_NUM_OBJECTS;
 
 /// Contains metadata about the filesystem and its internal layout.
@@ -50,7 +50,12 @@ impl FileSystem {
     /// the root of the mount.
     ///
     /// Returns the (FSObject list, root node id).
-    fn init_root_nodes(src_path: &Path, root_oid: Oid, sym: Symbol, version: u64) -> (Vec<FSObject>, fileid3) {
+    fn init_root_nodes(
+        src_path: &Path,
+        root_oid: Oid,
+        sym: Symbol,
+        version: u64,
+    ) -> (Vec<FSObject>, fileid3) {
         let mut fs = Vec::new();
         let dir_meta = DirectoryMetadata {
             path: src_path.to_path_buf(),
@@ -81,7 +86,6 @@ impl FileSystem {
         });
         (fs, rootid)
     }
-
 
     /// Get FileSystem metadata from the indicated src_path (typically the FS root).
     fn get_fs_metadata(src_path: &Path) -> Result<Metadata, nfsstat3> {
@@ -116,8 +120,7 @@ impl FileSystem {
 
     /// Checks the given fileId to see if it is expanded or not
     pub fn is_expanded(&self, id: fileid3) -> Result<bool, nfsstat3> {
-       self.get_entry_ref(id)
-            .map(|entry| entry.expanded)
+        self.get_entry_ref(id).map(|entry| entry.expanded)
     }
 
     /// Sets the expanded field for the indicated file.
@@ -127,8 +130,7 @@ impl FileSystem {
     }
 
     pub fn get_entry_ref(&self, id: fileid3) -> Result<&FSObject, nfsstat3> {
-        self.try_get_entry(id)
-            .ok_or(NFS3ERR_NOENT)
+        self.try_get_entry(id).ok_or(NFS3ERR_NOENT)
     }
 
     fn try_get_entry(&self, id: fileid3) -> Option<&FSObject> {
@@ -136,13 +138,18 @@ impl FileSystem {
     }
 
     fn get_entry_ref_mut(&mut self, id: fileid3) -> Result<&mut FSObject, nfsstat3> {
-        self.fs.get_mut(id as usize)
-            .ok_or(NFS3ERR_NOENT)
+        self.fs.get_mut(id as usize).ok_or(NFS3ERR_NOENT)
     }
 
     /// Insert a new object in to the filesystem with the indicated parent id and metadata.
     /// The file id for the new object will be returned.
-    pub fn insert(&mut self, parent_id: fileid3, name: Symbol, oid: Oid, contents: EntryContent) -> Result<fileid3, nfsstat3> {
+    pub fn insert(
+        &mut self,
+        parent_id: fileid3,
+        name: Symbol,
+        oid: Oid,
+        contents: EntryContent,
+    ) -> Result<fileid3, nfsstat3> {
         let id = self.fs.len() as fileid3;
         let parent = self.get_entry_ref_mut(parent_id)?;
         let version = parent.version;
@@ -165,8 +172,7 @@ impl FileSystem {
     /// Get file attributes for the indicated file.
     pub fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
         let entry = self.get_entry_ref(id)?;
-        entry.contents
-            .getattr(&self.fs_metadata, entry.id)
+        entry.contents.getattr(&self.fs_metadata, entry.id)
     }
 
     pub fn lookup(&self, dirid: fileid3, strategy: LookupStrategy) -> Result<fileid3, nfsstat3> {
@@ -181,7 +187,12 @@ impl FileSystem {
         strategy.lookup(entry)
     }
 
-    pub fn list_children(&self, dir_id: fileid3, start_after: fileid3, max_entries: usize) -> Result<(Vec<fileid3>, bool), nfsstat3> {
+    pub fn list_children(
+        &self,
+        dir_id: fileid3,
+        start_after: fileid3,
+        max_entries: usize,
+    ) -> Result<(Vec<fileid3>, bool), nfsstat3> {
         let entry = self.get_entry_ref(dir_id)?;
         if !entry.expanded {
             error!("BUG: directory: {dir_id:?} not expanded before calling `list_children()`");
@@ -242,16 +253,17 @@ pub enum LookupStrategy {
 }
 
 impl LookupStrategy {
-
     /// Builds a [LookupStrategy] from the filename. Since [FSObject] operates on [Symbol]s,
     /// we may need to translate the filename to a symbol using the [Symbols] table.
     /// If the filename cannot be translated, we return an error.
-    pub fn from_filename(symbol_table: &Symbols, filename: &filename3) -> Result<LookupStrategy, nfsstat3> {
+    pub fn from_filename(
+        symbol_table: &Symbols,
+        filename: &filename3,
+    ) -> Result<LookupStrategy, nfsstat3> {
         Ok(match filename[..] {
             [b'.'] => Self::CurrentDir,      // '.' => current directory
             [b'.', b'.'] => Self::ParentDir, // '..' => parent directory
-            _ => Self::Child(symbol_table.get_symbol(filename)?
-                .ok_or(NFS3ERR_NOENT)?)
+            _ => Self::Child(symbol_table.get_symbol(filename)?.ok_or(NFS3ERR_NOENT)?),
         })
     }
 
@@ -261,13 +273,14 @@ impl LookupStrategy {
         Ok(match self {
             LookupStrategy::CurrentDir => entry.id,
             LookupStrategy::ParentDir => entry.parent,
-            LookupStrategy::Child(sym) => entry.children.get(sym)
+            LookupStrategy::Child(sym) => entry
+                .children
+                .get(sym)
                 .map(|(fid, _)| *fid)
-                .ok_or(NFS3ERR_NOENT)?
+                .ok_or(NFS3ERR_NOENT)?,
         })
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -304,8 +317,8 @@ mod tests {
 
 #[cfg(test)]
 mod test_lookup_strategy {
-    use std::path::PathBuf;
     use super::*;
+    use std::path::PathBuf;
 
     // TODO: allow filename3 to implement From<&str> (needs external repo/crate change)
     fn to_filename(s: &str) -> filename3 {
@@ -357,7 +370,9 @@ mod test_lookup_strategy {
             oid: Oid::zero(),
             parent: 1,
             name: cur_sym,
-            contents: EntryContent::Directory(DirectoryMetadata {path: PathBuf::new() }),
+            contents: EntryContent::Directory(DirectoryMetadata {
+                path: PathBuf::new(),
+            }),
             children,
             expanded: true,
             version: 1,
@@ -391,13 +406,17 @@ mod test_lookup_strategy {
             oid: Oid::zero(),
             parent: 1,
             name: cur_sym,
-            contents: EntryContent::Directory(DirectoryMetadata {path: PathBuf::new() }),
+            contents: EntryContent::Directory(DirectoryMetadata {
+                path: PathBuf::new(),
+            }),
             children,
             expanded: true,
             version: 1,
         };
 
-        let err = LookupStrategy::Child(Symbol::new(56)).lookup(&entry).unwrap_err();
+        let err = LookupStrategy::Child(Symbol::new(56))
+            .lookup(&entry)
+            .unwrap_err();
         assert!(matches!(err, NFS3ERR_NOENT));
     }
 }

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/symbol.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/symbol.rs
@@ -1,11 +1,11 @@
-use nfsserve::nfs::{filename3, nfsstat3};
-use intaglio::Symbol;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use intaglio::osstr::SymbolTable;
-use std::ffi::{OsStr, OsString};
-use nfsserve::nfs::nfsstat3::{NFS3ERR_INVAL, NFS3ERR_IO};
-use std::str::FromStr;
 use crate::log::ErrorPrinter;
+use intaglio::osstr::SymbolTable;
+use intaglio::Symbol;
+use nfsserve::nfs::nfsstat3::{NFS3ERR_INVAL, NFS3ERR_IO};
+use nfsserve::nfs::{filename3, nfsstat3};
+use std::ffi::{OsStr, OsString};
+use std::str::FromStr;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// A thread-safe symbol table. This table will intern UTF8-compatible [filename3]s into
 /// [Symbol]s that can be more efficiently managed.
@@ -14,7 +14,6 @@ pub struct Symbols {
 }
 
 impl Symbols {
-
     pub fn new() -> Self {
         Self {
             table: RwLock::new(SymbolTable::new()),
@@ -25,8 +24,7 @@ impl Symbols {
     pub fn default_symbol(&self) -> Result<Symbol, nfsstat3> {
         let default_str = OsString::default();
         self.lock_write()
-            .and_then(|mut table| table.intern(default_str)
-                .map_err(|_|NFS3ERR_IO))
+            .and_then(|mut table| table.intern(default_str).map_err(|_| NFS3ERR_IO))
     }
 
     /// Encode the filename into a Symbol. Will return an [NFS3ERR_INVAL] if the
@@ -53,8 +51,7 @@ impl Symbols {
     /// Will return an [NFS3ERR_INVAL] if the filename is not valid UTF-8.
     pub fn get_symbol(&self, name: &filename3) -> Result<Option<Symbol>, nfsstat3> {
         let os_str = Self::filename_to_os_string(name)?;
-        self.lock_read()
-            .map(|table| table.check_interned(&os_str))
+        self.lock_read().map(|table| table.check_interned(&os_str))
     }
 
     /// Converts the filename to an OsString, retunrning [NFS3ERR_INVAL] if the filename
@@ -84,10 +81,10 @@ impl Symbols {
 
 #[cfg(test)]
 mod symbol_tests {
+    use super::Symbols;
     use intaglio::Symbol;
     use nfsserve::nfs::filename3;
     use nfsserve::nfs::nfsstat3::{NFS3ERR_INVAL, NFS3ERR_IO};
-    use super::Symbols;
 
     // TODO: have filename3 impl From<&str> (requires external repo/crate changes)
     fn to_filename(s: &str) -> filename3 {
@@ -150,5 +147,4 @@ mod symbol_tests {
         let maybe_symbol = table.get_symbol(&filename).unwrap();
         assert!(maybe_symbol.is_none());
     }
-
 }

--- a/rust/parutils/src/parallel_utils.rs
+++ b/rust/parutils/src/parallel_utils.rs
@@ -175,9 +175,7 @@ mod parallel_tests {
     }
     #[tokio::test(flavor = "multi_thread")]
     async fn test_simple_parallel() -> Result<(), Box<dyn std::error::Error>> {
-        let data: Vec<String> = (0..400)
-            .map(|i| format!("Number = {}", &i))
-            .collect();
+        let data: Vec<String> = (0..400).map(|i| format!("Number = {}", &i)).collect();
 
         let data_ref: Vec<String> = data
             .iter()

--- a/rust/s3/src/client.rs
+++ b/rust/s3/src/client.rs
@@ -337,7 +337,7 @@ impl S3Client {
                         debug_assert_lt!(obj_start, obj_end);
                         debug_assert_lt!(obj_end, obj.size);
                     }
-                    
+
                     info!(
                         " Download Unit {:?} / {:?}: Downloading part {:?} / {:?} of file {:?}: s3://{:?}/{:?}, range={:?}-{:?}",
                         i, &num_units, &part, num_parts, &obj.dest_file, &bucket_ref, &obj.key, &obj_start, &obj_end
@@ -373,7 +373,7 @@ impl S3Client {
                         if current_completed_part == (*num_parts - 1) {
                             // In this case, all the other workers have written out their
                             // data already, so the .download file is complete.
-                            
+
                             info!(
                                 " Download Unit {:?} / {:?}: s3://{:?}/{:?} file complete, renaming {:?} to {:?}.",  
                                 i, &num_units,  &bucket_ref, &obj.key, &obj.dest_temp_file, &obj.dest_file


### PR DESCRIPTION
Currently, there were a handful of files (many quite old) in which cargo fmt was not fully run, and I ended up having issues with this in an unrelated PR.  This PR cleans up all these issues in one go. 

There are no code changes outside of whitespace and formatting. 