### PR TITLE
Convenience methods on shard files to reduce code duplication

### DIFF
--- a/rust/mdb_shard/src/shard_handle.rs
+++ b/rust/mdb_shard/src/shard_handle.rs
@@ -1,8 +1,10 @@
 use crate::error::{MDBShardError, Result};
+use crate::file_structs::{FileDataSequenceEntry, MDBFileInfo};
 use crate::{shard_file::MDBShardInfo, utils::parse_shard_filename};
-use merklehash::MerkleHash;
+use merklehash::{compute_data_hash, MerkleHash};
+use std::io::{BufReader, Read, Seek};
 use std::path::{Path, PathBuf};
-use tracing::info;
+use tracing::{error, info, warn};
 
 /// When a specific implementation of the  
 ///
@@ -67,5 +69,91 @@ impl MDBShardFile {
             });
         }
         Ok(ret)
+    }
+
+    #[inline]
+    pub fn get_reader(&self) -> Result<BufReader<std::fs::File>> {
+        Ok(BufReader::with_capacity(
+            2048,
+            std::fs::File::open(&self.path)?,
+        ))
+    }
+
+    #[inline]
+    pub fn get_file_reconstruction_info(
+        &self,
+        file_hash: &MerkleHash,
+    ) -> Result<Option<MDBFileInfo>> {
+        self.shard
+            .get_file_reconstruction_info(&mut self.get_reader()?, file_hash)
+    }
+
+    #[inline]
+    pub fn chunk_hash_dedup_query(
+        &self,
+        query_hashes: &[MerkleHash],
+    ) -> Result<Option<(usize, FileDataSequenceEntry)>> {
+        self.shard
+            .chunk_hash_dedup_query(&mut self.get_reader()?, query_hashes)
+    }
+
+    #[inline]
+    pub fn verify_shard_integrity_debug_only(&self) {
+        #[cfg(debug_assertions)]
+        {
+            self.verify_shard_integrity();
+        }
+    }
+
+    pub fn verify_shard_integrity(&self) {
+        info!("Verifying shard integrity for shard {:?}", &self.path);
+
+        info!("Header : {:?}", self.shard.header);
+        info!("Metadata : {:?}", self.shard.metadata);
+
+        let mut reader = self
+            .get_reader()
+            .map_err(|e| {
+                error!("Error getting reader: {e:?}");
+                e
+            })
+            .unwrap();
+
+        let mut data = Vec::with_capacity(self.shard.num_bytes() as usize);
+        reader.read_to_end(&mut data).unwrap();
+
+        // Check the hash
+        let hash = compute_data_hash(&data[..]);
+        assert_eq!(hash, self.shard_hash);
+
+        // Check the parsed shard from the filename.
+        let parsed_shard_hash = parse_shard_filename(&self.path).unwrap();
+        assert_eq!(hash, parsed_shard_hash);
+
+        reader.rewind().unwrap();
+
+        // Check the parsed shard from the filename.
+        if let Some(parsed_shard_hash) = parse_shard_filename(&self.path) {
+            if hash != parsed_shard_hash {
+                error!("Hash parsed from filename does not match the computed hash; hash from filename={parsed_shard_hash:?}, hash of file={hash:?}");
+            }
+        } else {
+            warn!("Unable to obtain hash from filename.");
+        }
+
+        // Check the file info sections
+        reader.rewind().unwrap();
+
+        let fir = MDBShardInfo::read_file_info_ranges(&mut reader)
+            .map_err(|e| {
+                error!("Error reading file info ranges : {e:?}");
+                e
+            })
+            .unwrap();
+
+        debug_assert_eq!(fir.len() as u64, self.shard.metadata.file_lookup_num_entry);
+        info!("Integrity test passed for shard {:?}", &self.path);
+
+        // TODO: More parts; but this will at least succeed on the server end.
     }
 }

--- a/rust/mdb_shard/src/utils.rs
+++ b/rust/mdb_shard/src/utils.rs
@@ -13,7 +13,10 @@ lazy_static! {
 /// then Some(hash) is returned, where hash is the CAS hash of the merkledb file.  
 /// If the filename does not match, None is returned.
 #[inline]
-pub fn parse_shard_filename(filename: &str) -> Option<MerkleHash> {
+pub fn parse_shard_filename<P: AsRef<Path>>(filename: P) -> Option<MerkleHash> {
+    let filename: &Path = filename.as_ref();
+    let filename = filename.to_str().unwrap_or("");
+
     MERKLE_DB_FILE_PATTERN
         .captures(filename)
         .map(|capture| MerkleHash::from_hex(capture.name("hash").unwrap().as_str()).unwrap())


### PR DESCRIPTION
Pulling in useful routines from https://github.com/xetdata/xet-core/pull/42 to use in our rewrite.

These add two things: 
- Give MDBShardFile the ability to create a default reader for the file correctly.. 
- Add wrapper functions in MDBShardFile that operate directly on the file. 
- Add verification routine that verifies the hash of a shard file on load when running in debug mode. 