### PR TITLE
Potential fix for wrong Python binary detection

### DIFF
--- a/rust/gitxetcore/src/command/mount.rs
+++ b/rust/gitxetcore/src/command/mount.rs
@@ -341,20 +341,20 @@ If you use a git UI, point it to the raw path.
         )?;
     }
 
-    // use std::env::current_exe to find ourselves if we have it
+    // If invoked from Python, we use argv[1]
+    // else use std::env::current_exe to find ourselves if we have it
     // otherwise run "git xet"
-    let mut command = if let Ok(curexe) = std::env::current_exe() {
-        let mut command = Command::new(curexe);
-        if args.invoked_from_python {
-            let argv: Vec<String> = std::env::args().collect();
-            if argv.len() < 2 {
-                return Err(errors::GitXetRepoError::Other(
-                    "Unable to find python script to invoke".into(),
-                ));
-            }
-            command.arg(&argv[1]);
+    let mut command = if args.invoked_from_python {
+        // we will shell exec the script
+        let argv: Vec<String> = std::env::args().collect();
+        if argv.len() < 2 {
+            return Err(errors::GitXetRepoError::Other(
+                "Unable to find python script to invoke".into(),
+            ));
         }
-        command
+        Command::new(argv[1].clone())
+    } else if let Ok(curexe) = std::env::current_exe() {
+        Command::new(curexe)
     } else {
         let mut command = Command::new(get_git_executable());
         command.arg("xet");

--- a/rust/gitxetcore/src/command/mount.rs
+++ b/rust/gitxetcore/src/command/mount.rs
@@ -81,9 +81,9 @@ pub struct MountArgs {
 
     /// Do not use. Used only the python xet mount feature
     /// required so that the when we re-exec with mount-curdir
-    /// we know to pick up argv[1] as well as argv[0] is python
+    /// we know which python exe to pick up
     #[clap(short, long, hide = true)]
-    pub invoked_from_python: bool,
+    pub invoked_from_python: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -344,7 +344,7 @@ If you use a git UI, point it to the raw path.
     // If invoked from Python, we use argv[1]
     // else use std::env::current_exe to find ourselves if we have it
     // otherwise run "git xet"
-    let mut command = if args.invoked_from_python {
+    let mut command = if let Some(ref pythonexe) = args.invoked_from_python {
         // we will shell exec the script
         let argv: Vec<String> = std::env::args().collect();
         if argv.len() < 2 {
@@ -352,7 +352,9 @@ If you use a git UI, point it to the raw path.
                 "Unable to find python script to invoke".into(),
             ));
         }
-        Command::new(argv[1].clone())
+        let mut command = Command::new(pythonexe.clone());
+        command.arg(argv[1].clone());
+        command
     } else if let Ok(curexe) = std::env::current_exe() {
         Command::new(curexe)
     } else {


### PR DESCRIPTION
It is difficult to reliably identify the location of the python binary which was used to run the 'xet' command. This is required to "relaunch" xet as a daemon. Here, instead we directly relaunch the 'xet' command directly, hoping that the system will "do the right thing" (i.e. exec the script with the shebang command at the start of 'xet').