### PR TITLE
MDBv2 Mount optimizations

### DIFF
--- a/rust/gitxetcore/src/command/mount.rs
+++ b/rust/gitxetcore/src/command/mount.rs
@@ -4,6 +4,7 @@ use crate::git_integration::git_repo::{verify_user_config, GitRepo};
 use crate::git_integration::git_wrap::{get_git_executable, run_git_captured};
 use crate::xetmnt::{check_for_mount_program, perform_mount_and_wait_for_ctrlc};
 use clap::Args;
+use mdb_shard::shard_version::ShardVersion;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::{thread, time};
@@ -471,7 +472,9 @@ pub async fn mount_curdir_command(cfg: XetConfig, args: &MountCurdirArgs) -> err
     verify_user_config(None)?;
     eprintln!("Setting up mount point...");
     let gitrepo = GitRepo::open(cfg.clone())?;
-    gitrepo.sync_notes_to_dbs().await?;
+    if gitrepo.mdb_version == ShardVersion::V1 {
+        gitrepo.sync_notes_to_dbs().await?;
+    }
     perform_mount_and_wait_for_ctrlc(
         cfg,
         &PathBuf::from("."),

--- a/rust/gitxetcore/src/constants.rs
+++ b/rust/gitxetcore/src/constants.rs
@@ -62,3 +62,7 @@ pub const MINIMUM_GIT_VERSION: &str = "2.29";
 
 /// The current version
 pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Maximum number of entries in the file construction cache
+/// which stores File Hash -> reconstruction instructions
+pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;

--- a/rust/gitxetcore/src/smudge_query_interface.rs
+++ b/rust/gitxetcore/src/smudge_query_interface.rs
@@ -14,7 +14,7 @@ use tracing::info;
 use crate::constants::FILE_RECONSTRUCTION_CACHE_SIZE;
 use crate::data_processing_v2::GIT_XET_VERION;
 use shard_client::GrpcShardClient;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
 
 #[derive(PartialEq, Default, Clone, Debug, Copy)]
 pub enum SmudgeQueryPolicy {
@@ -154,7 +154,7 @@ impl FileReconstructor for FileReconstructionInterface {
         file_hash: &merklehash::MerkleHash,
     ) -> std::result::Result<Option<(MDBFileInfo, Option<MerkleHash>)>, MDBShardError> {
         {
-            let mut reader = self.reconstruction_cache.lock().await;
+            let mut reader = self.reconstruction_cache.lock().unwrap();
             if let Some(res) = reader.get(file_hash) {
                 return Ok(Some(res.clone()));
             }
@@ -166,7 +166,7 @@ impl FileReconstructor for FileReconstructionInterface {
                 // we only cache real stuff
                 self.reconstruction_cache
                     .lock()
-                    .await
+                    .unwrap()
                     .put(*file_hash, contents.clone());
                 Ok(Some(contents))
             }

--- a/rust/gitxetcore/src/xetmnt/mod.rs
+++ b/rust/gitxetcore/src/xetmnt/mod.rs
@@ -6,7 +6,6 @@ pub mod xetfs_write;
 
 use crate::config::XetConfig;
 use crate::errors::{GitXetRepoError, Result};
-use cas::output_bytes;
 use nfsserve::tcp::*;
 use prometheus;
 use prometheus_dict_encoder::DictEncoder;
@@ -379,11 +378,6 @@ pub async fn perform_mount_and_wait_for_ctrlc(
     } else {
         info!("Using XetFSBare implementation");
         let xfs = xetfs_bare::XetFSBare::new(xet, &cfg, reference, prefetch).await?;
-        eprintln!(
-            "{} in {} objects mounted",
-            output_bytes(xfs.total_object_size() as usize),
-            xfs.num_objects()
-        );
         let listener = NFSTcpListener::bind(&ip, xfs).await?;
         Box::new(listener)
     };

--- a/rust/mdb_shard/src/shard_file_reconstructor.rs
+++ b/rust/mdb_shard/src/shard_file_reconstructor.rs
@@ -5,6 +5,9 @@ use crate::{error::MDBShardError, file_structs::MDBFileInfo};
 
 #[async_trait]
 pub trait FileReconstructor {
+    /// Returns a pair of (file reconstruction information,  maybe shard ID)
+    /// Err(_) if an error occured
+    /// Ok(None) if the file is not found.
     async fn get_file_reconstruction_info(
         &self,
         file_hash: &MerkleHash,


### PR DESCRIPTION
This reduces llama2 mount time from a couple of minutes on my home internet to 3.5s.

 - Do not download shards on MDBv2 repos.
 - Cache reconstruction lookups
 - some documentation
 - removed a misleading printout with number of objects / bytes (since the NFS is now lazily constructed... we do not actually have this number.)
Note that further optimizations like directly using the xetblob interface rather than the git methods, can reduce this to instant.
