### PR TITLE
localhost cas skips register shard 

### DIFF
--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -509,7 +509,9 @@ pub async fn sync_session_shards_to_remote(
         };
 
         let shard_file_client = {
-            if config.cas.endpoint.starts_with("local://") {
+            if config.cas.endpoint.starts_with("local://")
+                || config.cas.endpoint.contains("localhost")
+            {
                 None
             } else {
                 Some(GrpcShardClient::from_config(shard_connection_config).await?)


### PR DESCRIPTION
The endpoint for a local cas is http://localhost:4000. Adding the condition to check for "localhost" so local cas doesn't try to talk to DynamoDB.