### PR TITLE
Temporary forward to get xethub to compile.

### DIFF
--- a/rust/mdb_shard/src/lib.rs
+++ b/rust/mdb_shard/src/lib.rs
@@ -12,3 +12,13 @@ pub mod shard_format;
 pub mod shard_in_memory;
 pub mod shard_version;
 pub mod utils;
+
+pub use intershard_reference_structs::IntershardReferenceSequence;
+pub use shard_file_handle::MDBShardFile;
+pub use shard_file_manager::ShardFileManager;
+pub use shard_format::{
+    MDBShardFileFooter, MDBShardFileHeader, MDBShardInfo, MDB_SHARD_TARGET_SIZE,
+};
+
+// Temporary to transition dependent code to new location
+pub mod shard_file;

--- a/rust/mdb_shard/src/shard_file.rs
+++ b/rust/mdb_shard/src/shard_file.rs
@@ -1,0 +1,2 @@
+// Temporary to transition dependent code to new location
+pub use crate::shard_format::*;


### PR DESCRIPTION
Turns out dependent packages depend on shard_file, which got renamed to shard_format in a previous commit.  This PR adds in a temporary shard_file.rs with forward imports from shard_format to get dependencies to compile until that changes.