### PR TITLE
Path slash issue

### DIFF
--- a/rust/mdb_shard/src/utils.rs
+++ b/rust/mdb_shard/src/utils.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 lazy_static! {
     static ref MERKLE_DB_FILE_PATTERN: Regex =
-        Regex::new(r"((^)|(.*/))(?P<hash>[0-9a-fA-F]{64})\.mdb$").unwrap();
+        Regex::new(r"((^)|(.*[/\\]))(?P<hash>[0-9a-fA-F]{64})\.mdb$").unwrap();
 }
 
 /// Parses a shard filename.  If the filename matches the shard filename pattern,


### PR DESCRIPTION
On windows, paths do not use / as the separator, but \.  This fixes a bug in which shard paths with \ are not parsed correctly. 