### PR TITLE
Added deduplication against current chunks in the CAS aggregator.

### DIFF
--- a/rust/merklehash/src/data_hash.rs
+++ b/rust/merklehash/src/data_hash.rs
@@ -107,6 +107,10 @@ impl DataHash {
         )
     }
 
+    pub const fn from_const(v: [u64; 4]) -> Self {
+        Self(v)
+    }
+
     /// Parses a hexadecimal string as a DataHash, returning
     /// Err(DataHashHexParseError) on failure.
     pub fn from_hex(h: &str) -> Result<DataHash, DataHashHexParseError> {


### PR DESCRIPTION
With this change, deduplication also happens against chunks stored in the common CAS aggregator, fixing the issue where many small files wouldn't see much deduplication.