### PR TITLE
begin_write_transaction now lets the synchronize step be optional.

### DIFF
--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -292,14 +292,16 @@ impl XetRepo {
             .map_err(|_| anyhow::anyhow!("Branch does not exist"));
 
         // Let's download all shards for now, delete this when shard hint lists work.
-        self.pull().await?;
-        sync_mdb_shards_from_git(
-            &self.config,
-            &self.config.merkledb_v2_cache,
-            GIT_NOTES_MERKLEDB_V2_REF_NAME,
-            true,
-        )
-        .await?;
+        if std::env::var_os("XET_FETCH_ALL_SHARDS").is_some() {
+            self.pull().await?;
+            sync_mdb_shards_from_git(
+                &self.config,
+                &self.config.merkledb_v2_cache,
+                GIT_NOTES_MERKLEDB_V2_REF_NAME,
+                true,
+            )
+            .await?;
+        }
 
         let mut transaction_config = self.config.clone();
         let shard_session_dir =
@@ -345,10 +347,12 @@ impl XetRepo {
         reference_files: &[(&str, &str)],
         min_dedup_byte_threshhold: usize,
     ) -> anyhow::Result<()> {
-
         let PFTRouter::V2(ref tr_v2) = &self.translator.pft else { return Ok(()) };
-        
-        debug!("fetch_hinted_shards_for_dedup: Called with reference files {:?}.", reference_files); 
+
+        debug!(
+            "fetch_hinted_shards_for_dedup: Called with reference files {:?}.",
+            reference_files
+        );
 
         // Go through and fetch all the shards needed for deduplication, building a list of new shards.
         let shard_download_info = Arc::new(Mutex::new(HashMap::<MerkleHash, usize>::new()));
@@ -375,7 +379,7 @@ impl XetRepo {
                         PointerFile::init_from_string(file_string, filename);
 
                     if ptr_file.is_valid() {
-                        let filename = filename.to_owned(); 
+                        let filename = filename.to_owned();
 
                         info!("fetch_hinted_shards_for_dedup: Retrieving shard hints associated with {filename}");
 

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -311,13 +311,16 @@ impl XetRepo {
 
         if fetch_shards {
             self.pull().await?;
-            sync_mdb_shards_from_git(
-                &self.config,
-                &self.config.merkledb_v2_cache,
-                GIT_NOTES_MERKLEDB_V2_REF_NAME,
-                true,
-            )
-            .await?;
+
+            if let &PFTRouter::V2(_) = &self.translator.pft {
+                sync_mdb_shards_from_git(
+                    &self.config,
+                    &self.config.merkledb_v2_cache,
+                    GIT_NOTES_MERKLEDB_V2_REF_NAME,
+                    true,
+                )
+                .await?;
+            }
         }
 
         let oldsummaries = translator.get_summarydb().lock().await.clone();


### PR DESCRIPTION
While we're still figuring this out, the "Synchronize with remote" step is now enabled only if the environment variable XET_FETCH_ALL_SHARDS is set.  If this is not set, then this step is skipped, and all dedup relies on the shard hints mechanism.  However, this may have unforeseen consequences, so for now it may still be enabled for debugging and profiling.  