### PR TITLE
Better dedup ratio message

### DIFF
--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -388,10 +388,10 @@ impl PointerFileTranslatorV1 {
         if bytes_cleaned > 0 {
             let ratio: f64 = 100.0 * cas_bytes_produced as f64 / bytes_cleaned as f64;
             eprintln!(
-                "{} added, Deduped to {}. Ratio: {:.1}%",
+                "{} added, stored {} ({:.1}% reduction)",
                 output_bytes(bytes_cleaned as usize),
                 output_bytes(cas_bytes_produced as usize),
-                ratio
+                100.0 - ratio
             );
         }
     }

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -631,10 +631,10 @@ impl PointerFileTranslatorV2 {
         if bytes_cleaned > 0 {
             let ratio: f64 = 100.0 * cas_bytes_produced as f64 / bytes_cleaned as f64;
             eprintln!(
-                "{} added, Deduped to {}. Ratio: {:.1}%",
+                "{} added, stored {} ({:.1}% reduction)",
                 output_bytes(bytes_cleaned as usize),
                 output_bytes(cas_bytes_produced as usize),
-                ratio
+                100.0 - ratio
             );
         }
     }


### PR DESCRIPTION
Fix https://github.com/xetdata/xethub/issues/2421

```
di@di-mbp ~/tt/bb % git init && git xet init -m1 -f && git add .
Initialized empty Git repository in /Users/di/tt/bb/.git/
git-xet 0.11.2 filter started
Xet: Deduplicating data blocks: 123.05 MiB | 15.38 MiB/s, done.
123.05 MiB added, stored 123.05 MiB (0.0% reduction)
```
```
di@di-mbp ~/tt/bb % git init && git xet init -m2 -f && git add .
Initialized empty Git repository in /Users/di/tt/bb/.git/
git-xet 0.11.2 filter started
Xet: Deduplicating data blocks: 123.05 MiB | 15.38 MiB/s, done.
123.05 MiB added, stored 123.05 MiB (0.0% reduction)
```