### PR TITLE
unset readonly flag

### DIFF
--- a/rust/cas_client/src/local_client.rs
+++ b/rust/cas_client/src/local_client.rs
@@ -188,6 +188,17 @@ impl LocalClient {
     /// Deletes an entry
     pub fn delete(&self, prefix: &str, hash: &MerkleHash) {
         let file_path = self.get_path_for_entry(prefix, hash);
+
+        // unset read-only for Windows to delete
+        #[cfg(windows)]
+        {
+            if let Ok(metadata) = std::fs::metadata(&file_path) {
+                let mut permissions = metadata.permissions();
+                permissions.set_readonly(false);
+                let _ = std::fs::set_permissions(&file_path, permissions);
+            }
+        }
+
         let _ = std::fs::remove_file(file_path);
     }
 }


### PR DESCRIPTION
`std::fs::remove_file` currently corresponds to the `unlink` function on Unix and the `DeleteFile` function on Windows. `unlink` will succeed as long as having write access to the directory. `DeleteFile` fails if the file is read-only.
This PR unsets the read-only attribute for staging files before deletion.

Fix https://github.com/xetdata/xethub/issues/3891