### PR TITLE
Fix: environment variables starting with XET_* corrupt configs.  

### DIFF
--- a/rust/gitxetcore/src/command/login.rs
+++ b/rust/gitxetcore/src/command/login.rs
@@ -3,7 +3,6 @@ use crate::errors;
 use crate::user::{XeteaAuth, XeteaLoginProbe};
 use anyhow::anyhow;
 use clap::Args;
-use std::collections::HashMap;
 use tracing::{error, warn};
 use xet_config::{Axe, Cas, Cfg, User};
 
@@ -129,10 +128,7 @@ pub async fn login_command(_: XetConfig, args: &LoginArgs) -> errors::Result<()>
         // this goes into a sub-profile
         //
         // create the profile hashmap if there is not one already
-        if cfg.profiles.is_none() {
-            cfg.profiles = Some(HashMap::new());
-        }
-        let prof = cfg.profiles.as_mut().unwrap();
+        let prof = &mut cfg.profiles;
 
         // search the list of profiles for a key that matches the host
         let mut config_applied = false;

--- a/rust/gitxetcore/src/config/cas.rs
+++ b/rust/gitxetcore/src/config/cas.rs
@@ -4,6 +4,7 @@ use crate::constants::LOCAL_CAS_SCHEME;
 use http::Uri;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tracing::debug;
 use xet_config::{Cas, DEFAULT_CAS_PREFIX, PROD_CAS_ENDPOINT};
 
 /// safe and special handling chars from: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
@@ -33,6 +34,7 @@ impl TryFrom<Option<&Cas>> for CasSettings {
             Some(x) => {
                 let endpoint = match &x.server {
                     Some(server) if !server.is_empty() => {
+                        debug!("Cas Settings config: Remote server is {server}");
                         check_uri(server)?;
                         Some(server)
                     }
@@ -41,6 +43,7 @@ impl TryFrom<Option<&Cas>> for CasSettings {
 
                 let prefix = match &x.prefix {
                     Some(prefix) => {
+                        debug!("Cas Settings config: prefix = {prefix}");
                         if !prefix.chars().all(is_valid_prefix_char) {
                             return Err(InvalidCasPrefix(
                                 prefix.clone(),

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -476,25 +476,22 @@ fn load_profile<'a>(
         // User provided a specific profile to use. Try to find that or error out.
         return cfg
             .profiles
-            .as_ref()
-            .and_then(|m| m.get(profile_name))
+            .get(profile_name)
             .map(Some)
             .ok_or_else(|| ProfileNotFound(profile_name.clone()));
     }
     // Search in the cfg profiles for one that matches the Xetea environment for the repo
     let mut candidates: Vec<Option<&'a Cfg>> = vec![];
-    if let Some(profiles) = cfg.profiles.as_ref() {
-        for prof in profiles.values() {
-            if let Some(endpoint) = &prof.endpoint {
-                if repo_info.env == XetEnv::Custom {
-                    for remote_url in &repo_info.remote_urls {
-                        if remote_url.contains(endpoint) {
-                            candidates.push(Some(prof));
-                        }
+    for prof in cfg.profiles.values() {
+        if let Some(endpoint) = &prof.endpoint {
+            if repo_info.env == XetEnv::Custom {
+                for remote_url in &repo_info.remote_urls {
+                    if remote_url.contains(endpoint) {
+                        candidates.push(Some(prof));
                     }
-                } else if XetEnv::from_xetea_url(endpoint) == repo_info.env {
-                    candidates.push(Some(prof));
                 }
+            } else if XetEnv::from_xetea_url(endpoint) == repo_info.env {
+                candidates.push(Some(prof));
             }
         }
     }
@@ -583,7 +580,7 @@ mod config_create_tests {
     fn test_load_requested_profile() {
         let mut cfg = Cfg::with_default_values();
         let expected_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         let key = "dev".to_string();
         profiles.insert(key.clone(), expected_profile.clone());
         let repo_info = RepoInfo::default();
@@ -596,7 +593,7 @@ mod config_create_tests {
         let mut cfg = Cfg::with_default_values();
         let prod_profile = get_test_prod_profile();
         let dev_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         let dev_key = "dev".to_string();
         let prod_key = "prod".to_string();
         profiles.insert(dev_key, dev_profile);
@@ -620,7 +617,7 @@ mod config_create_tests {
     fn test_load_profile_endpoint() {
         let mut cfg = Cfg::with_default_values();
         let expected_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         let key = "dev".to_string();
         profiles.insert(key, expected_profile.clone());
         let repo_info = RepoInfo {
@@ -636,7 +633,7 @@ mod config_create_tests {
     fn test_load_profile_endpoint_custom_key() {
         let mut cfg = Cfg::with_default_values();
         let expected_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         let key = "something_else".to_string();
         profiles.insert(key, expected_profile.clone());
         let repo_info = RepoInfo {
@@ -652,7 +649,7 @@ mod config_create_tests {
         let mut cfg = Cfg::with_default_values();
         let expected_profile = get_test_custom_profile();
         let dev_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("custom".to_string(), expected_profile.clone());
         profiles.insert("dev".to_string(), dev_profile);
         let repo_info = RepoInfo {
@@ -668,7 +665,7 @@ mod config_create_tests {
     fn test_load_profile_endpoint_not_found() {
         let mut cfg = Cfg::with_default_values();
         let prod_profile = get_test_prod_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         let key = "my_prod".to_string();
         profiles.insert(key, prod_profile);
         let repo_info = RepoInfo {
@@ -685,7 +682,7 @@ mod config_create_tests {
         let mut cfg = Cfg::with_default_values();
         let dev_profile = get_test_dev_profile();
         let dev1_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("prod".to_string(), dev_profile);
         profiles.insert("prod1".to_string(), dev1_profile);
         let repo_info = RepoInfo {
@@ -700,7 +697,7 @@ mod config_create_tests {
     fn test_load_profile_succeed_multiple_identical_profiles() {
         let mut cfg = Cfg::with_default_values();
         let dev_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("prod".to_string(), dev_profile);
         {
             let repo_info = RepoInfo {
@@ -744,7 +741,7 @@ mod config_create_tests {
             ..Default::default()
         });
         let dev_profile = get_test_dev_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("dev".to_string(), dev_profile);
 
         let tmp_repo = TestRepoPath::new("config_with_profiles").unwrap();
@@ -778,7 +775,7 @@ mod config_create_tests {
             ..Default::default()
         });
         let prod_profile = get_test_prod_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("prod".to_string(), prod_profile);
 
         let tmp_repo = TestRepoPath::new("config_with_profiles").unwrap();
@@ -812,7 +809,7 @@ mod config_create_tests {
             ..Default::default()
         });
         let prod_profile = get_test_prod_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("prod".to_string(), prod_profile);
 
         let tmp_repo = TestRepoPath::new("config_with_profiles").unwrap();
@@ -871,7 +868,7 @@ mod config_create_tests {
             ..Default::default()
         });
         let prod_profile = get_test_prod_profile();
-        let profiles = cfg.profiles.as_mut().unwrap();
+        let profiles = &mut cfg.profiles;
         profiles.insert("prod".to_string(), prod_profile);
 
         let cloned_cfg = cfg.clone();

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -98,20 +98,12 @@ where
             let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
 
             while let Ok(Some(key)) = access.next_key::<String>() {
-                let value: Result<CfgValueEntry, _> = access.next_value();
+                let value: Result<Cfg, _> = access.next_value();
                 match value {
-                    Ok(valid_value) => {
-                        match valid_value {
-                            CfgValueEntry::String(s) => {
-                                eprint!("Cfg deserialize: Found {key} = {s} (string), discarding.");
-                            }
-                            CfgValueEntry::Cfg(cfg) => {
-                                eprint!(
-                                    "Cfg deserialze: Found {key} = {cfg:?} (Config), inserting."
-                                );
-                                map.insert(key, cfg);
-                            }
-                        };
+                    Ok(cfg) => {
+                        eprintln!("Cfg deserialze: Found {key} = {cfg:?} (Config), inserting.");
+
+                        map.insert(key, cfg);
                     }
                     Err(_) => {
                         debug!("Cfg deserialize: skipped {key}; value could not be put in a Cfg struct.");

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -64,28 +64,20 @@ pub struct Cfg {
     /// will be converted to lower-case (i.e. XET_DEV_ENDPOINT will
     /// store a value under the key "dev").
     #[serde(flatten, deserialize_with = "deserialize_profile_map")]
-    pub profiles: Option<HashMap<String, Cfg>>,
-}
-
-#[derive(Deserialize)]
-enum CfgValueEntry {
-    String(String),
-    Cfg(Cfg),
+    pub profiles: HashMap<String, Cfg>,
 }
 
 use serde::de::{Deserializer, MapAccess, Visitor};
 use std::fmt;
 
-fn deserialize_profile_map<'de, D>(
-    deserializer: D,
-) -> Result<Option<HashMap<String, Cfg>>, D::Error>
+fn deserialize_profile_map<'de, D>(deserializer: D) -> Result<HashMap<String, Cfg>, D::Error>
 where
     D: Deserializer<'de> + Sized,
 {
     struct FilteredMapVisitor;
 
     impl<'de> Visitor<'de> for FilteredMapVisitor {
-        type Value = Option<HashMap<String, Cfg>>;
+        type Value = HashMap<String, Cfg>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a map with Cfg values")
@@ -101,7 +93,7 @@ where
                 let value: Result<Cfg, _> = access.next_value();
                 match value {
                     Ok(cfg) => {
-                        eprintln!("Cfg deserialze: Found {key} = {cfg:?} (Config), inserting.");
+                        debug!("Cfg deserialze: Found {key} = {cfg:?} (Config), inserting.");
 
                         map.insert(key, cfg);
                     }
@@ -113,11 +105,7 @@ where
                 }
             }
 
-            if map.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(map))
-            }
+            Ok(map)
         }
     }
 
@@ -166,7 +154,7 @@ impl Cfg {
                 enabled: Some(DEFAULT_AXE_ENABLED.to_string()),
                 axe_code: Some("5454".to_string()),
             }),
-            profiles: Some(HashMap::new()), // Default serialization of the flattened map is to return Some empty map
+            profiles: HashMap::default(), // Default serialization of the flattened map is to return Some empty map
         }
     }
 
@@ -228,7 +216,7 @@ impl Default for Cfg {
             log: None,
             user: None,
             axe: None,
-            profiles: None,
+            profiles: HashMap::default(),
         }
     }
 }
@@ -366,7 +354,7 @@ mod serialization_tests {
                 enabled: Some("true".to_string()),
                 axe_code: Some("5454".to_string()),
             }),
-            profiles: None,
+            profiles: HashMap::default(),
         };
         let toml_string = toml::to_string(&cfg).unwrap();
         let expected = r#"version = 1
@@ -414,7 +402,7 @@ axe_code = "5454"
                 ..Default::default()
             }),
             axe: None,
-            profiles: Some(HashMap::from([(
+            profiles: HashMap::from([(
                 "dev".to_string(),
                 Cfg {
                     endpoint: Some("xethub.com".to_string()),
@@ -425,7 +413,7 @@ axe_code = "5454"
                     }),
                     ..Default::default()
                 },
-            )])),
+            )]),
         };
         let toml_string = toml::to_string(&cfg).unwrap();
         let expected = r#"version = 1
@@ -461,7 +449,7 @@ token = "abc123"
                 ..Default::default()
             }),
             axe: None,
-            profiles: Some(HashMap::from([(
+            profiles: HashMap::from([(
                 "dev".to_string(),
                 Cfg {
                     endpoint: Some("xetbeta.com".to_string()),
@@ -472,7 +460,7 @@ token = "abc123"
                     }),
                     ..Default::default()
                 },
-            )])),
+            )]),
         };
         let data = r#"version = 1
 smudge = false
@@ -526,7 +514,7 @@ token = "abc123"
                 enabled: Some("true".to_string()),
                 axe_code: Some("5454".to_string()),
             }),
-            profiles: None,
+            profiles: HashMap::default(),
         };
         let data = r#"version = 1
 smudge = true
@@ -618,7 +606,7 @@ pth = "localhost"
                 enabled: Some("true".to_string()),
                 axe_code: Some("5454".to_string()),
             }),
-            profiles: None,
+            profiles: HashMap::default(),
         };
 
         let cfg_dev = Cfg {
@@ -645,11 +633,11 @@ pth = "localhost"
                 enabled: Some("false".to_string()),
                 axe_code: Some("5454".to_string()),
             }),
-            profiles: None,
+            profiles: HashMap::default(),
         };
         let mut profiles = HashMap::new();
         profiles.insert("dev".to_string(), cfg_dev);
-        cfg_root.profiles = Some(profiles);
+        cfg_root.profiles = profiles;
         let data = r#"version = 1
 smudge = true
 

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(cfg.cache.as_ref().unwrap().blocksize.unwrap(), 12345);
         assert_eq!(cfg.log.as_ref().unwrap().level.as_ref().unwrap(), "debug");
         assert!(cfg.log.as_ref().unwrap().path.is_none());
-        let dev_override = cfg.profiles.as_ref().unwrap().get("dev").unwrap();
+        let dev_override = cfg.profiles.get("dev").unwrap();
         assert_eq!(
             dev_override.user.as_ref().unwrap().name.as_ref().unwrap(),
             "user_dev"
@@ -277,7 +277,7 @@ mod tests {
                 enabled: Some("true".to_string()),
                 axe_code: Some("123456".to_string()),
             }),
-            profiles: Some(HashMap::new()),
+            profiles: HashMap::new(),
         };
         let local_cfg = serialize_cfg_to_tmp(&test_cfg);
 

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -208,14 +208,21 @@ mod tests {
         // TODO: env::set_var will change the env for all tests.
         //       Since tests are run in parallel, this means only
         //       one test can change the env (and Level should be LOCAL for others).
-        env::set_var("XET_BLAHBLAH", "ignore me");
+        env::set_var("XET_FOO", "ignore me");
         env::set_var("XET_CAS_SERVER", "localhost:40000");
         env::set_var("XET_log_lEvEl", "debug");
         env::set_var("XET_CACHE_size", "4294967296");
         env::set_var("XET_CACHE_BLOCKSIZE", "12345");
         env::set_var("XET_dev_USER_NAME", "user_dev");
         env::set_var("XET_DEV_ENDPOINT", "xethub.com");
-        env::set_var("XET_REMOTE_BLAHBLAH", "ignore me");
+        env::set_var("XET_BLAH", "ignore me");
+        env::set_var("XET_ENDPOINT", "notgoogle.com");
+
+        // Now set a ton of others too; this way the randomized order of the hash table
+        // actually makes it all work.
+        for i in 0..500 {
+            env::set_var(format!("XET_TEST_{i}"), format!("{i}"));
+        }
 
         let loader = XetConfigLoader::new("".into(), "".into());
         let cfg = loader.load_config(Level::ENV).unwrap();

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -221,7 +221,7 @@ mod tests {
         // Now set a ton of others too; this way the randomized order of the hash table
         // actually makes it all work.
         for i in 0..500 {
-            env::set_var(format!("XET_TEST_{i}"), format!("{i}"));
+            env::set_var(format!("XET_BLAH_{i}"), format!("{i}"));
         }
 
         let loader = XetConfigLoader::new("".into(), "".into());

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use config::builder::DefaultState;
 use config::{Config, ConfigBuilder, ConfigError, Environment, File, FileFormat, Value, ValueKind};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::cfg::Cfg;
 use crate::error::CfgError;
@@ -65,6 +65,7 @@ impl XetConfigLoader {
         let mut settings = Config::builder();
         settings = self.add_config(settings, level);
         let config = settings.build()?;
+        debug!("Config built: {config:?}");
         Ok(config.try_deserialize()?)
     }
 
@@ -207,12 +208,14 @@ mod tests {
         // TODO: env::set_var will change the env for all tests.
         //       Since tests are run in parallel, this means only
         //       one test can change the env (and Level should be LOCAL for others).
+        env::set_var("XET_BLAHBLAH", "ignore me");
         env::set_var("XET_CAS_SERVER", "localhost:40000");
         env::set_var("XET_log_lEvEl", "debug");
         env::set_var("XET_CACHE_size", "4294967296");
         env::set_var("XET_CACHE_BLOCKSIZE", "12345");
         env::set_var("XET_dev_USER_NAME", "user_dev");
         env::set_var("XET_DEV_ENDPOINT", "xethub.com");
+        env::set_var("XET_REMOTE_BLAHBLAH", "ignore me");
 
         let loader = XetConfigLoader::new("".into(), "".into());
         let cfg = loader.load_config(Level::ENV).unwrap();


### PR DESCRIPTION
This fixes an issue in which XET_* environment variables are dumped into the serialized config variables, however they can't be parsed by the cfg loader on load, causing the config loading to be incorrect.  This fixes this issue. 