### PR TITLE
background puts support for CASClient, implemented in PassthroughStagingClient

### DIFF
--- a/rust/cas_client/src/caching_client.rs
+++ b/rust/cas_client/src/caching_client.rs
@@ -88,6 +88,11 @@ impl<T: Client + Debug + Sync + Send> Client for CachingClient<T> {
         self.client.put(prefix, hash, data, chunk_boundaries).await
     }
 
+    async fn flush(&self) -> Result<(), CasClientError> {
+        // forward flush to the underlying client
+        self.client.flush().await
+    }
+
     async fn get(&self, prefix: &str, hash: &MerkleHash) -> Result<Vec<u8>, CasClientError> {
         // get the length, reduce to range read of the entire length.
         debug!("CachingClient Get of {}/{}", prefix, hash);

--- a/rust/cas_client/src/local_client.rs
+++ b/rust/cas_client/src/local_client.rs
@@ -327,6 +327,11 @@ impl Client for LocalClient {
         Ok(())
     }
 
+    async fn flush(&self) -> Result<(), CasClientError> {
+        // this client does not background so no flush is needed
+        Ok(())
+    }
+
     async fn get(&self, prefix: &str, hash: &MerkleHash) -> Result<Vec<u8>, CasClientError> {
         Ok(self.get_detailed(prefix, hash).await?.1)
     }

--- a/rust/cas_client/src/passthrough_staging_client.rs
+++ b/rust/cas_client/src/passthrough_staging_client.rs
@@ -113,7 +113,7 @@ impl Client for PassthroughStagingClient {
         chunk_boundaries: Vec<u64>,
     ) -> Result<(), CasClientError> {
         let prefix = prefix.to_string();
-        let hash = hash.clone();
+        let hash = *hash;
         let client = self.client.clone();
         let mut put_futures = self.put_futures.lock().await;
         while put_futures.len() >= PASSTHROUGH_STAGING_MAX_CONCURRENT_UPLOADS {

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -411,6 +411,11 @@ impl Client for RemoteClient {
         res
     }
 
+    async fn flush(&self) -> Result<(), CasClientError> {
+        // this client does not background so no flush is needed
+        Ok(())
+    }
+
     async fn get(&self, prefix: &str, hash: &MerkleHash) -> Result<Vec<u8>, CasClientError> {
         self.get_impl_h2(prefix, hash).await
     }

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -376,6 +376,7 @@ impl PointerFileTranslatorV1 {
     /// Can be safely called even if no cleaning happened.
     pub async fn finalize_cleaning(&self) -> Result<()> {
         self.summarydb.lock().await.flush()?;
+        self.cas.flush().await?;
         let mut casacc = self.cas_accumulator.lock().await;
         let cas_bytes_produced = self.try_flush_accumulator(&mut casacc, true).await?;
         FILTER_CAS_BYTES_PRODUCED.inc_by(cas_bytes_produced as u64);

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -622,6 +622,7 @@ impl PointerFileTranslatorV2 {
             self.register_new_cas_block(&mut global_cas_data).await?;
         }
         // TODO: when we have aggregated CAS stuff, handle that.
+        self.cas.flush().await?;
         Ok(())
     }
 

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -572,6 +572,7 @@ pub async fn sync_session_shards_to_remote(
             }
             parutils::ParallelError::TaskError(e) => e,
         })?;
+        cas_ref.flush().await?;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR changes a fundamental interface component of the CAS Client. It allows the put() method to be backgrounded. The background put() capability has been implemented in the PassthroughStagingClient (at the moment that is the most convenient location to enable the xetblob and hence Python API to get parallel uploads).

This means that for corectness, all puts() must be followed by a flush(). I fixed all the locations I can find.