### PR TITLE
Reduce CSV Parser Warning Aggressiveness

### DIFF
--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -165,6 +165,7 @@ mod tests {
             level: Some("info".to_string()),
             format: Some("json".to_string()),
             tracing: None,
+            silentsummary: None,
         };
 
         let log_settings = LogSettings::try_from(Some(&log_cfg)).unwrap();
@@ -207,6 +208,7 @@ mod tests {
             level: Some("info".to_string()),
             format: Some("json".to_string()),
             tracing: None,
+            silentsummary: None,
         };
 
         assert_err!(LogSettings::try_from(Some(&log_cfg)));

--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -39,6 +39,7 @@ pub struct LogSettings {
     pub path: Option<PathBuf>,
     pub format: LogFormat,
     pub with_tracer: bool,
+    pub silent_summary: bool,
 }
 
 impl Default for LogSettings {
@@ -48,6 +49,7 @@ impl Default for LogSettings {
             path: None,
             format: LogFormat::Compact,
             with_tracer: false,
+            silent_summary: false,
         }
     }
 }
@@ -82,11 +84,13 @@ impl TryFrom<Option<&Log>> for LogSettings {
                 };
                 let format = log.format.as_deref().into();
                 let with_tracer = log.tracing.unwrap_or(false);
+                let silent_summary = log.silentsummary.unwrap_or(false);
                 LogSettings {
                     level,
                     path,
                     format,
                     with_tracer,
+                    silent_summary,
                 }
             }
             None => LogSettings::default(),

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -55,6 +55,7 @@ pub fn get_override_cfg(overrides: &CliOverrides) -> Cfg {
             level: verbosity_to_level(overrides.verbose),
             format: None,
             tracing: None,
+            silentsummary: None,
         })
     }
     let mut cas_overrides = None;

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -236,7 +236,7 @@ impl PointerFileTranslatorV1 {
 
         if path.extension() == Some(OsStr::new("csv")) {
             info!("Including CSV analyzer (file extension .csv)");
-            analyzers.csv = Some(CSVAnalyzer::default());
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary));
         }
 
         // we consume up to SMALL_FILE_THRESHOLD

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -285,7 +285,7 @@ impl PointerFileTranslatorV2 {
 
         if path.extension() == Some(OsStr::new("csv")) {
             info!("Including CSV analyzer (file extension .csv)");
-            analyzers.csv = Some(CSVAnalyzer::default());
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary));
         }
 
         // we consume up to SMALL_FILE_THRESHOLD

--- a/rust/gitxetcore/src/summaries/csv.rs
+++ b/rust/gitxetcore/src/summaries/csv.rs
@@ -102,6 +102,9 @@ pub struct CSVAnalyzer {
 
     /// If set there was a resumable parse error
     parse_warning: Option<(usize, String)>,
+
+    /// If set, no warnings will ever be printed
+    pub silence_warnings: bool,
 }
 
 impl CSVAnalyzer {
@@ -115,6 +118,11 @@ impl CSVAnalyzer {
         ret.headers = self.headers.clone();
         ret.summaries = summaries;
         Ok(Some(ret))
+    }
+    pub fn new(silence_warnings: bool) -> Self {
+        let mut ret = Self::default();
+        ret.silence_warnings = silence_warnings;
+        ret
     }
 }
 
@@ -131,6 +139,7 @@ impl Default for CSVAnalyzer {
             current_ends_write_index: 0,
             previous_leftover: Vec::with_capacity(1024),
             parse_warning: None,
+            silence_warnings: false,
         }
     }
 }

--- a/rust/gitxetcore/src/summaries/csv.rs
+++ b/rust/gitxetcore/src/summaries/csv.rs
@@ -120,9 +120,10 @@ impl CSVAnalyzer {
         Ok(Some(ret))
     }
     pub fn new(silence_warnings: bool) -> Self {
-        let mut ret = Self::default();
-        ret.silence_warnings = silence_warnings;
-        ret
+        CSVAnalyzer {
+            silence_warnings,
+            ..Default::default()
+        }
     }
 }
 

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -141,6 +141,7 @@ impl Cfg {
                 level: Some(DEFAULT_LOG_LEVEL.to_string()),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: None,
@@ -262,6 +263,10 @@ pub struct Log {
     pub format: Option<String>,
     /// Some(true) for jaeger trace propagation
     pub tracing: Option<bool>,
+    /// Some(true) to silence summary parser warnings
+    /// This is not silent_summary as I think that interferes with reading this
+    /// from environment variable.
+    pub silentsummary: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
@@ -341,6 +346,7 @@ mod serialization_tests {
                 level: Some("debug".to_string()),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: Some("mojombo".to_string()),
@@ -501,6 +507,7 @@ token = "abc123"
                 level: Some("debug".to_string()),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: Some("mojombo".to_string()),
@@ -593,6 +600,7 @@ pth = "localhost"
                 level: Some("debug".to_string()),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: Some("mojombo".to_string()),
@@ -620,6 +628,7 @@ pth = "localhost"
                 level: Some("debug".to_string()),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: None,

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -264,6 +264,7 @@ mod tests {
                 path: Default::default(),
                 format: None,
                 tracing: None,
+                silentsummary: None,
             }),
             user: Some(User {
                 ssh: Some("mojombo".to_string()),


### PR DESCRIPTION
Fix #3921

After 3 warnings, this will be printed:

Warnings now read:
"Summaries for "business.csv" will not be available as parsing errors were detected: [...]"
```
2023-08-25T17:20:45.048120Z  WARN gitxetcore/src/summaries/analysis.rs:67: Too many warnings. No more CSV warnings will be printed.
2023-08-25T17:20:45.048127Z  WARN gitxetcore/src/summaries/analysis.rs:68: You can run 'git xet config --local log.silentsummary true'
2023-08-25T17:20:45.048127Z  WARN gitxetcore/src/summaries/analysis.rs:69: or set the environment variable XET_LOG_SILENTSUMMARY=true to disable all parser warnings
```
Setting the requested config will silence all csv parser warnings