### PR TITLE
Faster xetblob download to disk

### DIFF
--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -176,7 +176,7 @@ pub async fn data_from_chunks_to_writer(
         let prefix = prefix.clone();
         get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
     }))
-    .buffer_unordered(64);
+    .buffered(64);
 
     while let Some(buf) = strm.next().await {
         let buf = buf?;

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -551,12 +551,12 @@ impl PointerFileTranslator {
 
         match &self.pft {
             PFTRouter::V1(ref p) => Ok(MiniPointerFileSmudger {
-                cas: cas,
+                cas,
                 prefix: p.get_prefix(),
                 blocks,
             }),
             PFTRouter::V2(ref p) => Ok(MiniPointerFileSmudger {
-                cas: cas,
+                cas,
                 prefix: p.get_prefix(),
                 blocks,
             }),

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -183,7 +183,7 @@ pub async fn data_from_chunks_to_writer(
         bytes_smudged += buf.len() as u64;
         let s = info_span!("write_chunk");
         let _ = s.enter();
-        //writer.write_all(&buf)?;
+        writer.write_all(&buf)?;
     }
 
     FILTER_BYTES_SMUDGED.inc_by(bytes_smudged);

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -176,7 +176,7 @@ pub async fn data_from_chunks_to_writer(
         let prefix = prefix.clone();
         get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
     }))
-    .buffer_unordered(MAX_CONCURRENT_DOWNLOADS);
+    .buffer_unordered(64);
 
     while let Some(buf) = strm.next().await {
         let buf = buf?;

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -176,7 +176,7 @@ pub async fn data_from_chunks_to_writer(
         let prefix = prefix.clone();
         get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
     }))
-    .buffered(MAX_CONCURRENT_DOWNLOADS);
+    .buffered(64);
 
     while let Some(buf) = strm.next().await {
         let buf = buf?;

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -183,7 +183,7 @@ pub async fn data_from_chunks_to_writer(
         bytes_smudged += buf.len() as u64;
         let s = info_span!("write_chunk");
         let _ = s.enter();
-        writer.write_all(&buf)?;
+        //writer.write_all(&buf)?;
     }
 
     FILTER_BYTES_SMUDGED.inc_by(bytes_smudged);

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -176,7 +176,7 @@ pub async fn data_from_chunks_to_writer(
         let prefix = prefix.clone();
         get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
     }))
-    .buffered(64);
+    .buffered(MAX_CONCURRENT_DOWNLOADS);
 
     while let Some(buf) = strm.next().await {
         let buf = buf?;

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -193,6 +193,10 @@ impl PointerFileTranslatorV1 {
         Ok(cas_bytes_produced)
     }
 
+    pub fn get_config(&self) -> XetConfig {
+        self.cfg.clone()
+    }
+
     pub fn get_cas(&self) -> Arc<dyn Staging + Send + Sync> {
         self.cas.clone()
     }

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -163,6 +163,10 @@ impl PointerFileTranslatorV2 {
         })
     }
 
+    pub fn get_config(&self) -> XetConfig {
+        self.cfg.clone()
+    }
+
     pub fn get_cas(&self) -> Arc<dyn Staging + Send + Sync> {
         self.cas.clone()
     }

--- a/rust/xetblob/src/bin/xetcmd.rs
+++ b/rust/xetblob/src/bin/xetcmd.rs
@@ -162,7 +162,7 @@ async fn run() -> anyhow::Result<()> {
             let remote_path = split_remote_url(&cp.src)?;
             let repo = repo_manager.get_repo(None, &remote_path.remote).await?;
             let remote_file = repo
-                .open_for_read(&remote_path.branch, &remote_path.path)
+                .open_for_read(&remote_path.branch, &remote_path.path, None)
                 .await?;
             let len = remote_file.len();
             let mut local_file = BufWriter::new(File::create(&cp.dest)?);

--- a/rust/xetblob/src/file_open_flags.rs
+++ b/rust/xetblob/src/file_open_flags.rs
@@ -1,0 +1,7 @@
+pub type FileOpenFlags = u32;
+// Flag definitions borrow from https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
+
+pub const FILE_FLAG_DEFAULT: u32 = 0x0;
+// The file is being opened with no caching for data reads and writes.
+// This flag does not affect hard disk caching.
+pub const FILE_FLAG_NO_BUFFERING: u32 = 0x20000000;

--- a/rust/xetblob/src/lib.rs
+++ b/rust/xetblob/src/lib.rs
@@ -1,5 +1,6 @@
 mod atomic_commit_queries;
 mod bbq_queries;
+mod file_open_flags;
 mod retry_policy;
 mod rfile_object;
 mod wfile_object;
@@ -10,6 +11,7 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 
+pub use file_open_flags::*;
 pub use rfile_object::XetRFileObject;
 pub use wfile_object::XetWFileObject;
 pub use xet_repo::XetRepo;

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -70,9 +70,7 @@ impl XetRFileObject {
         match &self.content {
             FileContent::Bytes(b) => writer.write_all(&b)?,
             FileContent::Pointer((_, translator)) => {
-                translator
-                    .smudge_to_writer(&mut writer, Some((0, self.len())))
-                    .await?;
+                translator.smudge_to_writer(&mut writer, None).await?;
             }
         }
 

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -65,7 +65,7 @@ impl XetRFileObject {
     /// Downloads the contents of a file and write them to disk
     /// at location specified by path.
     pub async fn get(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
-        let mut writer = BufWriter::with_capacity(1 * 1024 * 1024, std::fs::File::create(path)?);
+        let mut writer = BufWriter::new(std::fs::File::create(path)?);
 
         match &self.content {
             FileContent::Bytes(b) => writer.write_all(&b)?,

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -65,7 +65,7 @@ impl XetRFileObject {
     /// Downloads the contents of a file and write them to disk
     /// at location specified by path.
     pub async fn get(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
-        let mut writer = BufWriter::new(std::fs::File::create(path)?);
+        let mut writer = BufWriter::with_capacity(1 * 1024 * 1024, std::fs::File::create(path)?);
 
         match &self.content {
             FileContent::Bytes(b) => writer.write_all(&b)?,

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -6,13 +6,6 @@ use std::{
 use gitxetcore::data_processing::*;
 use pointer_file::PointerFile;
 
-/// The channel limit for the write side of the handler.
-/// The smudge task may write messages up to 16 MB,
-/// and the default pyxet concurrent write limit is 32;
-/// this limits the single channel volume to 128 MB, and total
-/// channel volumn to 4 GB.
-const BLOB_WRITE_MPSC_CHANNEL_SIZE: usize = 8;
-
 #[derive(Clone)]
 pub enum FileContent {
     Pointer((PointerFile, MiniPointerFileSmudger)),
@@ -76,18 +69,4 @@ impl XetRFileObject {
 
         Ok(())
     }
-
-    // Downloads the contents of a file and write them through a queue
-    // to disk at location specified by path.
-    // pub async fn get_through_queue(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
-    //     match &self.content {
-    //         FileContent::Bytes(_) => self.get(path),
-    //         FileContent::Pointer((_, translator)) => {
-    //             let (sender, receiver) = mpsc::channel::<Vec<u8>>(BLOB_WRITE_MPSC_CHANNEL_SIZE);
-    //             let taskhandle = tokio::spawn(async move {
-    //                 translator
-    //             })
-    //         }
-    //     }
-    // }
 }

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -1,5 +1,11 @@
+use std::{
+    io::{BufWriter, Write},
+    path::Path,
+};
+
 use gitxetcore::data_processing::*;
 use pointer_file::PointerFile;
+use tokio::io::AsyncRead;
 
 #[derive(Clone)]
 pub enum FileContent {
@@ -48,5 +54,22 @@ impl XetRFileObject {
                 Ok((output, eof))
             }
         }
+    }
+
+    /// Downloads the contents of a file and write them to disk
+    /// at location specified by path.
+    pub async fn get(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+        let mut writer = BufWriter::new(std::fs::File::create(path)?);
+
+        match &self.content {
+            FileContent::Bytes(b) => writer.write_all(&b)?,
+            FileContent::Pointer((_, translator)) => {
+                translator
+                    .smudge_to_writer(&mut writer, Some((0, self.len())))
+                    .await?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -61,7 +61,7 @@ impl XetRFileObject {
         let mut writer = BufWriter::new(std::fs::File::create(path)?);
 
         match &self.content {
-            FileContent::Bytes(b) => writer.write_all(&b)?,
+            FileContent::Bytes(b) => writer.write_all(b)?,
             FileContent::Pointer((_, translator)) => {
                 translator.smudge_to_writer(&mut writer, None).await?;
             }

--- a/rust/xetblob/src/rfile_object.rs
+++ b/rust/xetblob/src/rfile_object.rs
@@ -5,7 +5,13 @@ use std::{
 
 use gitxetcore::data_processing::*;
 use pointer_file::PointerFile;
-use tokio::io::AsyncRead;
+
+/// The channel limit for the write side of the handler.
+/// The smudge task may write messages up to 16 MB,
+/// and the default pyxet concurrent write limit is 32;
+/// this limits the single channel volume to 128 MB, and total
+/// channel volumn to 4 GB.
+const BLOB_WRITE_MPSC_CHANNEL_SIZE: usize = 8;
 
 #[derive(Clone)]
 pub enum FileContent {
@@ -72,4 +78,18 @@ impl XetRFileObject {
 
         Ok(())
     }
+
+    // Downloads the contents of a file and write them through a queue
+    // to disk at location specified by path.
+    // pub async fn get_through_queue(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
+    //     match &self.content {
+    //         FileContent::Bytes(_) => self.get(path),
+    //         FileContent::Pointer((_, translator)) => {
+    //             let (sender, receiver) = mpsc::channel::<Vec<u8>>(BLOB_WRITE_MPSC_CHANNEL_SIZE);
+    //             let taskhandle = tokio::spawn(async move {
+    //                 translator
+    //             })
+    //         }
+    //     }
+    // }
 }

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -155,6 +155,8 @@ impl XetRepo {
         };
         // disable staging
         config.staging_path = None;
+        // disable cache
+        config.cache.enabled = false;
         let remotes = config.remote_repo_paths();
         if remotes.is_empty() {
             return Err(anyhow!("No remote defined"));

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -155,8 +155,6 @@ impl XetRepo {
         };
         // disable staging
         config.staging_path = None;
-        // disable cache
-        config.cache.enabled = false;
         let remotes = config.remote_repo_paths();
         if remotes.is_empty() {
             return Err(anyhow!("No remote defined"));

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -2,6 +2,7 @@ use super::bbq_queries::*;
 use super::rfile_object::FileContent;
 use super::*;
 use crate::atomic_commit_queries::*;
+use crate::file_open_flags::*;
 use anyhow::anyhow;
 
 use cas::gitbaretools::{Action, JSONCommand};
@@ -155,8 +156,6 @@ impl XetRepo {
         };
         // disable staging
         config.staging_path = None;
-        // disable cache
-        config.cache.enabled = false;
         let remotes = config.remote_repo_paths();
         if remotes.is_empty() {
             return Err(anyhow!("No remote defined"));
@@ -226,6 +225,7 @@ impl XetRepo {
         &self,
         branch: &str,
         filename: &str,
+        flags: Option<FileOpenFlags>,
     ) -> anyhow::Result<XetRFileObject> {
         let body = self
             .bbq_client
@@ -251,8 +251,14 @@ impl XetRepo {
                 error!("Unable to smudge file at {branch}/{filename}");
                 FileContent::Bytes(body.to_vec())
             } else {
+                let disable_cache =
+                    match flags.unwrap_or(FILE_FLAG_DEFAULT) & FILE_FLAG_NO_BUFFERING {
+                        0 => None, // don't change the existing behavior
+                        _ => Some(true),
+                    };
+
                 let mini_smudger = translator
-                    .make_mini_smudger(&PathBuf::default(), blocks.unwrap())
+                    .make_mini_smudger(&PathBuf::default(), blocks.unwrap(), disable_cache)
                     .await?;
                 FileContent::Pointer((ptr_file, mini_smudger))
             }


### PR DESCRIPTION
Adds a `get` function to download an entire file to disk.
Adds a file open options to disable caching when downloading an entire file.