### PR TITLE
merkledb print + file_entry_rewrite command

### DIFF
--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -199,9 +199,12 @@ pub async fn handle_merkledb_plumb_command(
         }
         MerkleDBCommand::Diff(args) => mdbv1::diff_merkledb(&args.older, &args.newer, &args.result)
             .map_err(GitXetRepoError::from),
-        MerkleDBCommand::Print(args) => {
-            mdbv1::print_merkledb(&args.input).map_err(GitXetRepoError::from)
-        }
+        MerkleDBCommand::Print(args) => match version {
+            ShardVersion::V1 => mdbv1::print_merkledb(&args.input).map_err(GitXetRepoError::from),
+            ShardVersion::V2 => {
+                mdbv2::print_merkledb(&cfg.merkledb_v2_cache).map_err(GitXetRepoError::from)
+            }
+        },
         MerkleDBCommand::Query(args) => match version {
             ShardVersion::V1 => {
                 mdbv1::query_merkledb(&args.input, &args.hash).map_err(GitXetRepoError::from)

--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -315,13 +315,11 @@ pub async fn handle_merkledb_plumb_command(
             ShardVersion::V1 => unreachable!("Invalid command for V1 repo"),
             ShardVersion::V2 => {
                 let file_hash = MerkleHash::from_hex(&args.file_hash).map_err(|_| {
-                    GitXetRepoError::Other(
-                        format!("Invalid MerkleHash {:?}", &args.file_hash).to_owned(),
-                    )
+                    GitXetRepoError::Other(format!("Invalid MerkleHash {:?}", &args.file_hash))
                 })?;
                 let cas_hash = match &args.cas_hash {
                     Some(h) => Some(MerkleHash::from_hex(h).map_err(|_| {
-                        GitXetRepoError::Other(format!("Invalid MerkleHash {:?}", h).to_owned())
+                        GitXetRepoError::Other(format!("Invalid MerkleHash {:?}", h))
                     })?),
                     None => None,
                 };

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -779,6 +779,7 @@ pub fn print_merkledb(cache_dir: &Path) -> anyhow::Result<()> {
 }
 
 /// Rewrites a FileDataSequenceEntry in a Shard file.
+#[allow(clippy::too_many_arguments)]
 pub async fn file_entry_rewrite(
     shard_path: &str,
     file_hash: MerkleHash,

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -764,6 +764,20 @@ pub async fn cas_stat_git(config: &XetConfig) -> errors::Result<()> {
     Ok(())
 }
 
+/// Prints a merkledb to stdout
+pub fn print_merkledb(cache_dir: &Path) -> anyhow::Result<()> {
+    let dir_walker = fs::read_dir(cache_dir)?;
+
+    for file in dir_walker.flatten() {
+        println!("File {:?}", file.path());
+        let shard = MDBShardFile::load_from_file(file.path().as_path())?;
+        let mut reader = shard.get_reader()?;
+        shard.shard.print(&mut reader)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use rand::{rngs::SmallRng, RngCore, SeedableRng};

--- a/rust/mdb_shard/src/shard_format.rs
+++ b/rust/mdb_shard/src/shard_format.rs
@@ -892,10 +892,11 @@ impl MDBShardInfo {
             )));
         }
 
-        return Ok(None);
+        Ok(None)
     }
 
     /// Rewrite a FileDataSequenceEntry for a file of hash 'file_hash' at index 'entry_index'
+    #[allow(clippy::too_many_arguments)]
     pub async fn file_entry_rewrite<RW: Read + Write + Seek>(
         &self,
         rw: &mut RW,


### PR DESCRIPTION
This PR provides two merkledb plumbing commands for debugging.

1. Print command for merkledb v2. This will print all shards in `.git/xet/merkledbv2-cache` into stdout.

Example usage:
Under a git repo,
1. `git-xet merkledb extract-git`
2. `git-xet merkledb print . > shard_print.txt`

2. File entry rewrite command for merkledb v2. This is rewrite a certain `FileDataSequenceEntry` in a certain shard.

Example usage:
`git-xet merkledb file-entry-rewrite -s fcfe54091bfbd3d27ddd92dbf07b4dfcccd246d2b028ea7971c5502363d6d601.mdb --file-hash 0390dc4a9b4efced56a06c47a204d004a0df98fe0777d3d5cb6c390bd5c0da1c --entry-index 27 --cas-hash e81f23b10422792a9f657aa8c7d741c33fa23044763165605c9521ef555064d8 --chunk-byte-range-start 677306 --chunk-byte-range-end 692059`
This will rewrite the `FileDataSequenceEntry` in shard file `fcfe54091bfbd3d27ddd92dbf07b4dfcccd246d2b028ea7971c5502363d6d601.mdb` under file info with hash `0390dc4a9b4efced56a06c47a204d004a0df98fe0777d3d5cb6c390bd5c0da1c` at index `27` with the provided information that follows.