### PR TITLE
Fix bug in dedup against local cas aggregator

### DIFF
--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -406,6 +406,10 @@ impl PointerFileTranslatorV2 {
                         if let Some(idx) = current_cas_block_hashes.get(&chunk.hash) {
                             let (_, (data_lb, data_ub)) = cas_data.chunks[*idx];
 
+                            // This chunk will get the CAS hash updated when the local CAS block
+                            // is full and registered.
+                            current_cas_file_info_indices.push(file_info.len());
+
                             file_info.push(FileDataSequenceEntry::new(
                                 MerkleHash::default(),
                                 n_bytes,
@@ -426,6 +430,8 @@ impl PointerFileTranslatorV2 {
                             add_new_data = true;
                         } else {
                             // This block is unrelated to the previous one.
+                            // This chunk will get the CAS hash updated when the local CAS block
+                            // is full and registered.
                             current_cas_file_info_indices.push(file_info.len());
 
                             file_info.push(FileDataSequenceEntry::new(


### PR DESCRIPTION
There is a bug that if dedupping against a chunk in the local cas aggregator `cas_data`, these chunks in the constructing `file_info` are not tracked and thus not rewritten when the `cas_data` is full and registered.

Test plan:
1. Generate 10 files each of 100K random data: `for i in {0..9}; do dd if=/dev/urandom of=data100K_$i bs=100K count=1; done`.
2. Copy these 10 files 100 times in the round-robin order to a file `data`: `for k in {0..99}; do for i in {0..9}; do cat data100K_$i >> data; done; done`.
3. Under a repo, run `git add data`, `rm data`, `git checkout data`.

Test results:
With `git-xet 0.11.2-e5bdff8`, there were errors that certain cas hash in file info is 0:
```
git-xet 0.11.2 filter started
Xet: Retrieving data blocks: 1.02 MiB | 1.02 MiB/s.
2023-09-08T14:31:13.758698Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/data_transport.rs:84: Many failures Status Error: 500 Internal Server Error
2023-09-08T14:31:13.758938Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759068Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759085Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759098Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759109Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759121Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759183Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759198Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759214Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759270Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759283Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759894Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759919Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759937Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.759952Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.760043Z  WARN /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/cas_client/src/caching_client.rs:140: CachingClient Error on GetObjectRange of default/0000000000000000000000000000000000000000000000000000000000000000: OtherTaskError("RemoteError(Batch Error: Status Error: 500 Internal Server Error)")
2023-09-08T14:31:13.760262Z ERROR /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/gitxetcore/src/stream/git_stream.rs:618: XET: Error processing "data", writing error back to stream
2023-09-08T14:31:13.760290Z ERROR /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/gitxetcore/src/stream/stream_writer.rs:102: Writing error frame
2023-09-08T14:31:13.760327Z ERROR /Users/distiller/.cargo/git/checkouts/xet-core-d6815bd7e1c74654/e5bdff8/rust/gitxetcore/src/stream/git_stream.rs:322: ERROR: Error in polling process: Other("Error fetching Xorb 0000000000000000000000000000000000000000000000000000000000000000: InternalError(Fail on get object range of \"default\" 0000000000000000000000000000000000000000000000000000000000000000 range (43412, 58666)\n\nCaused by:\n    Error with other task reading block: RemoteError(Batch Error: Status Error: 500 Internal Server Error)).")
Error : Error fetching Xorb 0000000000000000000000000000000000000000000000000000000000000000: InternalError(Fail on get object range of "default" 0000000000000000000000000000000000000000000000000000000000000000 range (43412, 58666)

Caused by:
    Error with other task reading block: RemoteError(Batch Error: Status Error: 500 Internal Server Error)).
error: external filter 'git xet filter' failed
fatal: data: smudge filter xet failed
```

With git-xet from this PR:
Checkout worked fine.