### PR TITLE
Patch to catch corrupt File Reconstruction issues.

### DIFF
--- a/rust/mdb_shard/src/file_structs.rs
+++ b/rust/mdb_shard/src/file_structs.rs
@@ -161,4 +161,14 @@ impl MDBFileInfo {
         (size_of::<FileDataSequenceHeader>()
             + self.segments.len() * size_of::<FileDataSequenceEntry>()) as u64
     }
+
+    pub fn has_dedup_incorrectness_bug(&self) -> bool {
+        // Due to early dedup incorrectness bug, check here.
+        for fi_entry in self.segments.iter() {
+            if fi_entry.cas_hash == MerkleHash::default() && fi_entry.unpacked_segment_bytes != 0 {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/rust/mdb_shard/src/file_structs.rs
+++ b/rust/mdb_shard/src/file_structs.rs
@@ -169,6 +169,6 @@ impl MDBFileInfo {
                 return true;
             }
         }
-        return false;
+        false
     }
 }

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -183,7 +183,7 @@ impl FileReconstructor for ShardFileManager {
             trace!("Querying for hash {file_hash:?} in {:?}.", si.path);
             if let Some(fi) = si.get_file_reconstruction_info(file_hash)? {
                 if fi.has_dedup_incorrectness_bug() {
-                    info!("Dedup Incorrectness bug encountered in shard File reconconstruction info for file {file_hash:?} of shard {:?}; ignoring.", si.shard_hash);
+                    info!("Known and fixed dedup incorrectness bug encountered in old shard; file reconstruction info for file {file_hash:?} of shard {:?} has this issue; ignoring entry.  If this results in an error, re-adding the file will fix the issue or contact support.", si.shard_hash);
                 }
                 return Ok(Some((fi, Some(si.shard_hash))));
             }

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::shard_format::MDB_SHARD_MIN_TARGET_SIZE;
 use crate::{cas_structs::*, file_structs::*, shard_in_memory::MDBInMemoryShard};
@@ -182,6 +182,9 @@ impl FileReconstructor for ShardFileManager {
         for (si, _) in current_shards.values() {
             trace!("Querying for hash {file_hash:?} in {:?}.", si.path);
             if let Some(fi) = si.get_file_reconstruction_info(file_hash)? {
+                if fi.has_dedup_incorrectness_bug() {
+                    info!("Dedup Incorrectness bug encountered in shard File reconconstruction info for file {file_hash:?} of shard {:?}; ignoring.", si.shard_hash);
+                }
                 return Ok(Some((fi, Some(si.shard_hash))));
             }
         }


### PR DESCRIPTION
This patch catches corrupt file reconstruction entries introduced by a previous dedup bug.  If this dedup entry is encountered, it is ignored with a possible warning to the user.

This should work using the following mechanic:
1. If the user has a file with a bad FI entry, and file reconstruction fails, then the user gets an error message asking them to either re-add the file or contact support.
2. If the user re-commits the file, a new FI entry is inserted into a new shard and into the shard server.  As the old entry will be ignored everywhere, this effectively rewrites it, fixing the issue.