### PR TITLE
Smudge now passes bad file reconstruction lookups through as pointers.

### DIFF
--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -735,7 +735,8 @@ impl PointerFileTranslatorV2 {
     /// If passthrough is false, this function will fail on an invalid pointer
     /// file returning an Err.
     ///
-    /// If passthrough is set, a failed parse of the pointer file will pass
+    /// If passthrough is true, a failed parse of the pointer file or
+    /// a failed lookup of the file reconstruction information will pass
     /// through all the contents directly to the writer.
     pub async fn smudge_file(
         &self,
@@ -749,74 +750,89 @@ impl PointerFileTranslatorV2 {
 
         let (fi, data) =
             pointer_file_from_reader(path, &mut reader, self.cfg.force_no_smudge).await?;
-        match fi {
-            Some(ptr) => {
-                self.smudge_file_from_pointer(path, &ptr, writer, range)
-                    .await
+
+        if let Some(ptr) = fi {
+            let result = self
+                .smudge_file_from_pointer(path, &ptr, writer, range)
+                .await;
+
+            if let Err(GitXetRepoError::FileReconstructionFailed(_)) = &result {
+                error!(
+                    "File reconstruction failed for file {path:?}, hash={}",
+                    &ptr.hash()
+                );
+                if range.is_some() || !passthrough {
+                    return result;
+                } else {
+                    info!("Passing through pointer file after failed reconstruction lookup.");
+                }
+            } else {
+                return result;
             }
-            None => {
-                if !passthrough {
-                    error!("Invalid Pointer File");
-                    return Err(GitXetRepoError::Other("Invalid Pointer File".into()));
-                }
+        } else {
+            // Now, the file gets passed through.
+            if passthrough {
                 info!("{:?} is not a valid pointer file. Passing through", path);
-                // this did not parse as a pointer file. We dump it straight
-                // back out to the writer
-                // we first dump the data we tried to parse as a pointer
-                match range {
-                    // we have been supplied a range to write, so write the requested byte range
-                    Some((start, end)) => {
-                        // we expect callers to validate the range, but just in case, check it anyway.
-                        if end < start {
-                            let msg = format!("End range value requested ({end}) is less than start range value ({start})");
-                            error!(msg);
-                            return Err(GitXetRepoError::Other(msg));
-                        }
-
-                        let mut st = start;
-                        let mut dat = data;
-
-                        // skip ahead to the start of the requested range
-                        while st > 0 {
-                            let skipped = std::cmp::min(st, dat.len());
-                            st -= skipped;
-                            if skipped < dat.len() {
-                                dat = (dat[skipped..]).to_vec();
-                            } else {
-                                dat = reader.next().await?.ok_or_else(|| {
-                                    GitXetRepoError::Other(
-                                        "Start range value requested is larger than the file size"
-                                            .into(),
-                                    )
-                                })?;
-                            }
-                        }
-
-                        // write the rest of the bytes in the range
-                        let mut len = end - start;
-                        while len > 0 {
-                            let write = std::cmp::min(len, dat.len());
-                            writer.write_all(&dat[0..write])?;
-
-                            match reader.next().await? {
-                                Some(buf) => dat = buf,
-                                None => break,
-                            }
-                            len -= write;
-                        }
-                    }
-                    // we haven't been given a range, so write out all bytes
-                    None => {
-                        writer.write_all(&data)?;
-                        // then loop over the reader writing straight out to writer
-                        while let Some(data) = reader.next().await? {
-                            writer.write_all(&data)?;
-                        }
-                    }
-                }
-                Ok(())
+            } else {
+                error!("Invalid Pointer File");
+                return Err(GitXetRepoError::Other("Invalid Pointer File".into()));
             }
         }
+
+        // this did not parse as a pointer file. We dump it straight
+        // back out to the writer
+        // we first dump the data we tried to parse as a pointer
+        match range {
+            // we have been supplied a range to write, so write the requested byte range
+            Some((start, end)) => {
+                // we expect callers to validate the range, but just in case, check it anyway.
+                if end < start {
+                    let msg = format!("End range value requested ({end}) is less than start range value ({start})");
+                    error!(msg);
+                    return Err(GitXetRepoError::Other(msg));
+                }
+
+                let mut st = start;
+                let mut dat = data;
+
+                // skip ahead to the start of the requested range
+                while st > 0 {
+                    let skipped = std::cmp::min(st, dat.len());
+                    st -= skipped;
+                    if skipped < dat.len() {
+                        dat = (dat[skipped..]).to_vec();
+                    } else {
+                        dat = reader.next().await?.ok_or_else(|| {
+                            GitXetRepoError::Other(
+                                "Start range value requested is larger than the file size".into(),
+                            )
+                        })?;
+                    }
+                }
+
+                // write the rest of the bytes in the range
+                let mut len = end - start;
+                while len > 0 {
+                    let write = std::cmp::min(len, dat.len());
+                    writer.write_all(&dat[0..write])?;
+
+                    match reader.next().await? {
+                        Some(buf) => dat = buf,
+                        None => break,
+                    }
+                    len -= write;
+                }
+            }
+            // we haven't been given a range, so write out all bytes
+            None => {
+                writer.write_all(&data)?;
+                // then loop over the reader writing straight out to writer
+                while let Some(data) = reader.next().await? {
+                    writer.write_all(&data)?;
+                }
+            }
+        }
+        Ok(())
     }
     /// Performs a prefetch heuristic assuming that the user wll be reading at
     /// the provided start position,
@@ -955,7 +971,7 @@ impl PointerFileTranslatorV2 {
                 .collect())
         } else {
             error!("File Reconstruction info for hash {hash:?} not found.");
-            Err(GitXetRepoError::HashNotFound)
+            Err(GitXetRepoError::FileReconstructionFailed(hash))
         }
     }
 
@@ -1296,6 +1312,57 @@ mod tests {
         let mut smudged_bytes: Vec<u8> = Vec::new();
         smudged.read_to_end(&mut smudged_bytes).unwrap();
         assert_eq!("lo ".bytes().collect::<Vec<u8>>(), smudged_bytes);
+    }
+
+    #[tokio::test]
+    async fn test_clean_smudge_round_trip_with_bad_file_lookup() {
+        // build an input of "hello world"
+        let input_bytes: Vec<u8> = "hello world".bytes().collect();
+        let input = std::io::Cursor::new(input_bytes.clone());
+        let async_input = AsyncFileIterator::new(input, GIT_MAX_PACKET_SIZE);
+
+        // make a translator
+        let stagedir = TempDir::new().unwrap();
+        let repo = PointerFileTranslatorV2::new_temporary(stagedir.path())
+            .await
+            .unwrap();
+
+        // clean the file
+        let cleaned = repo.clean_file(&PathBuf::new(), async_input).await.unwrap();
+        repo.finalize_cleaning().await.unwrap();
+
+        let clean_cursor = std::io::Cursor::new(cleaned.clone());
+        let async_clean_input = AsyncFileIterator::new(clean_cursor, GIT_MAX_PACKET_SIZE);
+
+        // smudge with passthrough flagged
+        let mut smudged = std::io::Cursor::new(Vec::new());
+        repo.smudge_file(&PathBuf::new(), async_clean_input, &mut smudged, true, None)
+            .await
+            .unwrap();
+
+        // result should be identical
+        smudged.set_position(0);
+        let mut smudged_bytes: Vec<u8> = Vec::new();
+        smudged.read_to_end(&mut smudged_bytes).unwrap();
+        assert_eq!(input_bytes, smudged_bytes);
+
+        let clean_cursor = std::io::Cursor::new(cleaned.clone());
+        let async_clean_input = AsyncFileIterator::new(clean_cursor, GIT_MAX_PACKET_SIZE);
+
+        // Now attempt with the lookup cleared.
+        repo.shard_manager.clear().await;
+
+        // smudge with passthrough flagged
+        let mut smudged = std::io::Cursor::new(Vec::new());
+        repo.smudge_file(&PathBuf::new(), async_clean_input, &mut smudged, true, None)
+            .await
+            .unwrap();
+
+        // result should be identical to the pointer file
+        smudged.set_position(0);
+        let mut smudged_bytes: Vec<u8> = Vec::new();
+        smudged.read_to_end(&mut smudged_bytes).unwrap();
+        assert_eq!(cleaned, smudged_bytes);
     }
     #[tokio::test]
     async fn test_clean_smudge_round_trip_with_small_file_range() {

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -4,6 +4,7 @@ use std::num::ParseIntError;
 use std::path::PathBuf;
 use std::process::{ExitCode, Termination};
 
+use merklehash::MerkleHash;
 use s3::XetS3Error;
 use thiserror::Error;
 
@@ -27,6 +28,9 @@ pub enum GitXetRepoError {
 
     #[error("CAS Error : {0}")]
     CasClientError(String),
+
+    #[error("File Reconstruction Failed")]
+    FileReconstructionFailed(MerkleHash),
 
     #[error("Hash not found")]
     HashNotFound,

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -84,6 +84,12 @@ impl ShardFileManager {
         Ok(s)
     }
 
+    // Clear out everything; used mainly for debugging.
+    pub async fn clear(&self) {
+        self.shard_file_lookup.write().await.clear();
+        self.current_state.write().await.shard = <_>::default();
+    }
+
     /// Sets the target value of a shard file size.  By default, it is given by MDB_SHARD_MIN_TARGET_SIZE
     pub fn set_target_shard_min_size(&mut self, s: u64) {
         self.target_shard_min_size = s;


### PR DESCRIPTION
Previously, a bad file hash lookup caused an unrecoverable error.  Now, when looking up file reconstruction information fails, an error is printed but the original pointer file is passed through instead. 

