### PR TITLE
Update the current progress reporting class for pyxet use.

### DIFF
--- a/rust/cas_client/src/staging_client.rs
+++ b/rust/cas_client/src/staging_client.rs
@@ -116,10 +116,10 @@ impl StagingUpload for StagingClient {
         );
 
         let pb = if self.progressbar && !entries.is_empty() {
-            let mut pb =
-                DataProgressReporter::new("Xet: Uploading data blocks", Some(entries.len()));
+            let pb =
+                DataProgressReporter::new("Xet: Uploading data blocks", Some(entries.len()), None);
 
-            pb.register_progress(Some(0), 0); // draw the bar immediately
+            pb.register_progress(Some(0), Some(0)); // draw the bar immediately
 
             Some(Arc::new(Mutex::new(pb)))
         } else {
@@ -159,7 +159,9 @@ impl StagingUpload for StagingClient {
                     stage.delete(&entry.prefix, &entry.hash);
                 }
                 if let Some(bar) = &pb {
-                    bar.lock().await.register_progress(Some(1), xorb_length);
+                    bar.lock()
+                        .await
+                        .register_progress(Some(1), Some(xorb_length));
                 }
                 Ok(())
             }

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -378,7 +378,7 @@ impl PointerFileTranslator {
         &self,
         path: &Path,
         reader: impl AsyncIterator + Send + Sync,
-        progress_indicator: &Option<Arc<Mutex<(bool, DataProgressReporter)>>>,
+        progress_indicator: &Option<Arc<DataProgressReporter>>,
     ) -> Result<Vec<u8>> {
         match &self.pft {
             PFTRouter::V1(ref p) => {
@@ -438,7 +438,7 @@ impl PointerFileTranslator {
         reader: impl AsyncIterator,
         writer: &Sender<Result<Vec<u8>>>,
         ready: &Option<watch::Sender<bool>>,
-        progress_indicator: &Option<Arc<Mutex<(bool, DataProgressReporter)>>>,
+        progress_indicator: &Option<Arc<DataProgressReporter>>,
     ) -> usize {
         match &self.pft {
             PFTRouter::V1(ref p) => {
@@ -479,7 +479,7 @@ impl PointerFileTranslator {
         pointer: &PointerFile,
         writer: &Sender<Result<Vec<u8>>>,
         ready: &Option<watch::Sender<bool>>,
-        progress_indicator: &Option<Arc<Mutex<(bool, DataProgressReporter)>>>,
+        progress_indicator: &Option<Arc<DataProgressReporter>>,
     ) -> usize {
         match &self.pft {
             PFTRouter::V1(ref p) => {

--- a/rust/progress_reporting/src/data_progress.rs
+++ b/rust/progress_reporting/src/data_progress.rs
@@ -243,7 +243,7 @@ impl DataProgressReporter {
                     "{}: {}% ({} / {}) | {}/s{}",
                     self.message,
                     if is_final { 100 } else { percentage },
-                    &output_bytes(current_bytes),
+                    &output_bytes(if is_final { total_bytes } else { current_bytes }),
                     &output_bytes(total_bytes),
                     &output_bytes(byte_rate),
                     if is_final { ", done." } else { "." }

--- a/rust/progress_reporting/src/main.rs
+++ b/rust/progress_reporting/src/main.rs
@@ -3,21 +3,88 @@ use progress_reporting::DataProgressReporter;
 use std::thread::sleep;
 
 fn main() {
-    let mut pb = DataProgressReporter::new("Testing progress bar", Some(10));
+    let pb = DataProgressReporter::new("Testing progress bar (no totals, no bytes)", None, None);
 
-    pb.register_progress(Some(1), 25 * 1024);
+    pb.register_progress(Some(1), None);
     sleep(time::Duration::from_millis(500));
-    pb.register_progress(Some(8), 50 * 1024);
+    pb.register_progress(Some(2), None);
     sleep(time::Duration::from_millis(500));
-
+    pb.register_progress(Some(1), None);
+    sleep(time::Duration::from_millis(500));
     pb.finalize();
 
-    let mut pb = DataProgressReporter::new("Testing progress bar, bytes only", None);
-
-    pb.register_progress(None, 25 * 1024);
+    let pb = DataProgressReporter::new(
+        "Testing progress bar (total count, no bytes)",
+        Some(5),
+        None,
+    );
+    pb.register_progress(Some(1), None);
     sleep(time::Duration::from_millis(500));
-    pb.register_progress(None, 50 * 1024);
+    pb.register_progress(Some(2), None);
     sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(1), None);
+    sleep(time::Duration::from_millis(500));
+    pb.finalize();
 
+    let pb = DataProgressReporter::new("Testing progress bar (no totals, only bytes)", None, None);
+
+    pb.register_progress(None, Some(5000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(None, Some(6000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(None, Some(4000));
+    sleep(time::Duration::from_millis(500));
+    pb.finalize();
+
+    let pb = DataProgressReporter::new(
+        "Testing progress bar (only bytes + total)",
+        None,
+        Some(20000),
+    );
+
+    pb.register_progress(None, Some(5000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(None, Some(6000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(None, Some(4000));
+    sleep(time::Duration::from_millis(500));
+    pb.finalize();
+
+    let pb = DataProgressReporter::new(
+        "Testing progress bar (no totals, both count + bytes)",
+        None,
+        None,
+    );
+
+    pb.register_progress(Some(5), Some(5000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(10), Some(6000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(12), Some(4000));
+    sleep(time::Duration::from_millis(500));
+    pb.finalize();
+
+    let pb = DataProgressReporter::new("Testing progress bar (Total count)", Some(30), None);
+
+    pb.register_progress(Some(5), Some(5000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(10), Some(6000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(12), Some(4000));
+    sleep(time::Duration::from_millis(500));
+    pb.finalize();
+
+    let pb = DataProgressReporter::new(
+        "Testing progress bar (Total count + total bytes)",
+        Some(30),
+        Some(20000),
+    );
+
+    pb.register_progress(Some(5), Some(5000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(10), Some(6000));
+    sleep(time::Duration::from_millis(500));
+    pb.register_progress(Some(12), Some(4000));
+    sleep(time::Duration::from_millis(500));
     pb.finalize();
 }


### PR DESCRIPTION
This PR updates the current progress bar used by the git_stream functions and CAS uploading routines to avoid &mut self, thus allowing it to be easily wrapped by pyxet and passed between python and rust.  This has the additional advantage of avoiding a mutex, as was the case in git_stream.  The base functionality and format has not changed.

To test out the different formats and use cases, run the produced executable test_progress_reporting.   See progress_reporting/src/main.rs for example code.  

```
Testing progress bar (no totals, no bytes): 4 completed, done.
Testing progress bar (total count, no bytes): 100% (5 / 5), done.
Testing progress bar (no totals, only bytes): 14.65 KiB | 9.69 KiB/s, done.
Testing progress bar (only bytes + total): 100% (19.53 KiB / 19.53 KiB) | 9.70 KiB/s, done.
Testing progress bar (no totals, both count + bytes): 27 / 27, 14.65 KiB | 9.69 KiB/s, done.
Testing progress bar (Total count): 100% (30 / 30), 14.65 KiB | 9.69 KiB/s, done.
Testing progress bar (Total count + total bytes): 100% (30 / 30), 19.53 KiB | 9.68 KiB/s, done.
```
