### PR TITLE
Add User-Agent header to BBQ client for xet-cli or pyxet

### DIFF
--- a/rust/xetblob/src/bbq_queries.rs
+++ b/rust/xetblob/src/bbq_queries.rs
@@ -248,15 +248,15 @@ impl BbqClient {
 /// xet binary (detected via "xet" binary path in the 2nd arg) then it is detected as xet-cli, otherwise
 /// defaults to pyxet.
 fn detect_downstream_client() -> String {
-    let is_xet_cli = env::args_os().nth(1).and_then(|x| {
+    let is_xet_cli = env::args_os().nth(1).map(|x| {
         let path = Path::new(&x);
-        Some(path.ends_with("xet") & path.is_file())
+        path.ends_with("xet") && path.is_file()
     }).unwrap_or(false);
-    return if is_xet_cli {
+    if is_xet_cli {
         "xet-cli".to_string()
     } else {
         "pyxet".to_string()
-    };
+    }
 }
 
 /// Normalize git remote urls for the bbq query, stripping the .git if provided


### PR DESCRIPTION
This PR adds `User-Agent` header to BBQ clients that detect the different clients from which it was run (xet-cli or pyxet), which provides us a mechanism to detect the client type on server-side. A separate PR for Xetea will be sent out for the server-side change to detect `User-Agent` 