### PR TITLE
git-xet accepts xet url

### DIFF
--- a/rust/gitxetcore/src/command/mount.rs
+++ b/rust/gitxetcore/src/command/mount.rs
@@ -1,6 +1,7 @@
 use crate::config::XetConfig;
 use crate::errors;
 use crate::git_integration::git_repo::GitRepo;
+use crate::git_integration::git_url::parse_remote_url;
 use crate::git_integration::git_wrap::{get_git_executable, run_git_captured};
 use crate::xetmnt::{check_for_mount_program, perform_mount_and_wait_for_ctrlc};
 use clap::Args;
@@ -133,19 +134,6 @@ pub struct MountCurdirArgs {
     pub watch: Option<humantime::Duration>,
 }
 
-#[allow(dead_code)]
-fn repo_name_from_remote(remote: &str) -> Option<PathBuf> {
-    let last = remote.split('/').last().to_owned();
-    last.map(|f| {
-        if let Some(stripped) = f.strip_suffix(".git") {
-            stripped
-        } else {
-            f
-        }
-    })
-    .map(|f| f.into())
-}
-
 #[cfg(not(target_os = "windows"))]
 fn is_windows_home_edition() -> errors::Result<bool> {
     Ok(false)
@@ -205,8 +193,8 @@ pub async fn mount_command(cfg: &XetConfig, args: &MountArgs) -> errors::Result<
         {
             let mut path = if let Some(ref path) = args.path {
                 path.clone()
-            } else if let Some(path) = repo_name_from_remote(&args.remote) {
-                path
+            } else if let Ok((_, repo, _)) = parse_remote_url(&args.remote) {
+                repo.into()
             } else {
                 return Err(errors::GitXetRepoError::Other("Unable to derive repository name from remote. Please explicitly specify the target mount path".into()));
             };
@@ -282,13 +270,13 @@ If you use a git UI, point it to the raw path.
         std::fs::create_dir(&clone_path)?;
     }
 
-    let ref_override;
+    let branch;
 
     if !args.writable {
         eprintln!("Cloning into temporary directory {clone_path:?}");
         // In the path [tempdir]
         // > git clone --mirror [remote] repo
-        ref_override = GitRepo::clone(
+        (_, branch) = GitRepo::clone(
             Some(cfg),
             &["--mirror", &args.remote, "repo"],
             false,             // no smudge
@@ -304,7 +292,7 @@ If you use a git UI, point it to the raw path.
         // > git clone [remote] repo
         if args.reference == "HEAD" {
             // XET_NO_SMUDGE=true git clone $remote repo
-            ref_override = GitRepo::clone(
+            (_, branch) = GitRepo::clone(
                 Some(cfg),
                 &[&args.remote, "."],
                 true,              // no smudge
@@ -314,7 +302,7 @@ If you use a git UI, point it to the raw path.
             )?; // check result
         } else {
             // XET_NO_SMUDGE=true git clone -b $branch $remote repo
-            ref_override = GitRepo::clone(
+            (_, branch) = GitRepo::clone(
                 Some(cfg),
                 &["-b", &args.reference, &args.remote, "."],
                 true,              // no smudge
@@ -376,8 +364,8 @@ If you use a git UI, point it to the raw path.
         command.arg("--writable");
     }
     command.arg("--reference");
-    if let Some(r) = ref_override {
-        command.arg(r);
+    if let Some(br) = branch {
+        command.arg(br);
     } else {
         command.arg(&args.reference);
     }
@@ -503,29 +491,4 @@ pub async fn mount_curdir_command(cfg: XetConfig, args: &MountCurdirArgs) -> err
     )
     .await
     .map_err(|e| errors::GitXetRepoError::Other(format!("{e:?}")))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_repo_name_from_remote() {
-        assert_eq!(
-            repo_name_from_remote("https://xethub.com/user/blah.git")
-                .unwrap()
-                .into_os_string()
-                .into_string()
-                .unwrap(),
-            "blah"
-        );
-        assert_eq!(
-            repo_name_from_remote("xet@xethub.com:user/bloof.git")
-                .unwrap()
-                .into_os_string()
-                .into_string()
-                .unwrap(),
-            "bloof"
-        );
-    }
 }

--- a/rust/gitxetcore/src/config/mod.rs
+++ b/rust/gitxetcore/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub use self::cas::CasSettings;
 pub use axe::AxeSettings;
 pub use cache::CacheSettings;
+pub use env::PROD_XETEA_DOMAIN;
 pub use errors::ConfigError;
 pub use git_path::{remote_to_repo_info, ConfigGitPathOption, RepoInfo};
 pub use log::{LogFormat, LogSettings};

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -142,7 +142,7 @@ impl From<GitXetRepoError> for ExitCode {
             GitXetRepoError::InvalidOperation(_) => 20,
             GitXetRepoError::RepoNotDiscoverable => 21,
             GitXetRepoError::RepoHasNoRemotes => 22,
-            GitXetRepoError::InvalidRemote => 23,
+            GitXetRepoError::InvalidRemote(_) => 23,
             GitXetRepoError::InvalidLocalCasPath(_) => 24,
             GitXetRepoError::InvalidLogPath(_, _) => 25,
             GitXetRepoError::FileNotFound(_) => 26,

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -78,8 +78,8 @@ pub enum GitXetRepoError {
     #[error("no remotes found for current repo")]
     RepoHasNoRemotes,
 
-    #[error("invalid remote")]
-    InvalidRemote,
+    #[error("invalid remote: {0}")]
+    InvalidRemote(String),
 
     #[error("local CAS path: {0} invalid")]
     InvalidLocalCasPath(String),

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -32,6 +32,7 @@ use crate::merkledb_shard_plumb;
 use crate::summaries_plumb::{merge_summaries_from_git, update_summaries_to_git};
 
 use super::git_notes_wrapper::GitNotesWrapper;
+use super::git_url::{authenticate_remote_url, is_unauthenticated_repo_remote_url};
 
 // For each reference update that was added to the transaction, the hook receives
 // on standard input a line of the format:
@@ -297,15 +298,18 @@ impl GitRepo {
         let mut git_args = git_args.iter().map(|x| x.to_string()).collect::<Vec<_>>();
         // attempt to rewrite URLs with authentication information
         // if config provided
+        let mut more_args: Option<Vec<String>> = None;
         if let Some(config) = config {
             for ent in &mut git_args {
-                if ent.starts_with("https://") || ent.starts_with("http://") {
-                    // this is the remote
-                    let repo_info = remote_to_repo_info(ent);
-                    let localized_config = config.switch_repo_info(repo_info, None)?;
-                    (*ent) = localized_config.build_authenticated_remote_url(ent);
+                if is_unauthenticated_repo_remote_url(ent) {
+                    let (remote, opt_args) = authenticate_remote_url(ent, config)?;
+                    *ent = remote;
+                    more_args = opt_args;
                 }
             }
+        }
+        if let Some(args) = more_args {
+            git_args.extend(args);
         }
 
         // First, make sure that everything is properly installed and that the git-xet filter will be run correctly.

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::config::ConfigGitPathOption;
-use crate::config::{remote_to_repo_info, XetConfig};
+use crate::config::XetConfig;
 use git2::Repository;
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -32,7 +32,7 @@ use crate::merkledb_shard_plumb;
 use crate::summaries_plumb::{merge_summaries_from_git, update_summaries_to_git};
 
 use super::git_notes_wrapper::GitNotesWrapper;
-use super::git_url::{authenticate_remote_url, is_unauthenticated_repo_remote_url};
+use super::git_url::{is_unauthenticated_repo_remote_url, parse_and_authenticate_remote_url};
 
 // For each reference update that was added to the transaction, the hook receives
 // on standard input a line of the format:
@@ -287,6 +287,7 @@ impl GitRepo {
     }
 
     /// Clone a repo -- just a pass-through to git clone.
+    /// Return a branch field if that exists in the remote url.
     pub fn clone(
         config: Option<&XetConfig>,
         git_args: &[&str],
@@ -294,22 +295,22 @@ impl GitRepo {
         base_dir: Option<&PathBuf>,
         pass_through: bool,
         check_result: bool,
-    ) -> Result<()> {
+    ) -> Result<Option<String>> {
         let mut git_args = git_args.iter().map(|x| x.to_string()).collect::<Vec<_>>();
         // attempt to rewrite URLs with authentication information
         // if config provided
-        let mut more_args: Option<Vec<String>> = None;
+        let mut branch: Option<String> = None;
         if let Some(config) = config {
             for ent in &mut git_args {
                 if is_unauthenticated_repo_remote_url(ent) {
-                    let (remote, opt_args) = authenticate_remote_url(ent, config)?;
+                    let (remote, opt_br) = parse_and_authenticate_remote_url(ent, config)?;
                     *ent = remote;
-                    more_args = opt_args;
+                    branch = opt_br;
                 }
             }
         }
-        if let Some(args) = more_args {
-            git_args.extend(args);
+        if let Some(ref br) = branch {
+            git_args.extend(vec!["--branch".to_owned(), br.clone()]);
         }
 
         // First, make sure that everything is properly installed and that the git-xet filter will be run correctly.
@@ -335,7 +336,7 @@ impl GitRepo {
             git_wrap::run_git_captured(base_dir, "clone", &git_args_ref, check_result, smudge_arg)?;
         }
 
-        Ok(())
+        Ok(branch)
     }
 
     pub fn get_remote_urls(path: Option<&Path>) -> Result<Vec<String>> {

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -32,7 +32,7 @@ use crate::merkledb_shard_plumb;
 use crate::summaries_plumb::{merge_summaries_from_git, update_summaries_to_git};
 
 use super::git_notes_wrapper::GitNotesWrapper;
-use super::git_url::{is_unauthenticated_repo_remote_url, parse_and_authenticate_remote_url};
+use super::git_url::{authenticate_remote_url, is_remote_url, parse_remote_url};
 
 // For each reference update that was added to the transaction, the hook receives
 // on standard input a line of the format:
@@ -287,7 +287,7 @@ impl GitRepo {
     }
 
     /// Clone a repo -- just a pass-through to git clone.
-    /// Return a branch field if that exists in the remote url.
+    /// Return repo name and a branch field if that exists in the remote url.
     pub fn clone(
         config: Option<&XetConfig>,
         git_args: &[&str],
@@ -295,17 +295,18 @@ impl GitRepo {
         base_dir: Option<&PathBuf>,
         pass_through: bool,
         check_result: bool,
-    ) -> Result<Option<String>> {
+    ) -> Result<(String, Option<String>)> {
         let mut git_args = git_args.iter().map(|x| x.to_string()).collect::<Vec<_>>();
         // attempt to rewrite URLs with authentication information
         // if config provided
-        let mut branch: Option<String> = None;
+
+        let mut repo = String::default();
+        let mut branch = None;
         if let Some(config) = config {
             for ent in &mut git_args {
-                if is_unauthenticated_repo_remote_url(ent) {
-                    let (remote, opt_br) = parse_and_authenticate_remote_url(ent, config)?;
-                    *ent = remote;
-                    branch = opt_br;
+                if is_remote_url(ent) {
+                    (*ent, repo, branch) = parse_remote_url(ent)?;
+                    *ent = authenticate_remote_url(ent, config)?;
                 }
             }
         }
@@ -336,7 +337,7 @@ impl GitRepo {
             git_wrap::run_git_captured(base_dir, "clone", &git_args_ref, check_result, smudge_arg)?;
         }
 
-        Ok(branch)
+        Ok((repo, branch))
     }
 
     pub fn get_remote_urls(path: Option<&Path>) -> Result<Vec<String>> {

--- a/rust/gitxetcore/src/git_integration/git_url.rs
+++ b/rust/gitxetcore/src/git_integration/git_url.rs
@@ -1,0 +1,318 @@
+use crate::config::{remote_to_repo_info, XetConfig, PROD_XETEA_DOMAIN};
+use crate::errors::{GitXetRepoError, Result};
+
+use url::Url;
+
+/// Env key for domain override
+const XET_ENDPOINT: &str = "XET_ENDPOINT";
+
+pub fn is_unauthenticated_repo_remote_url(ent: &str) -> bool {
+    ent.starts_with("https://") || ent.starts_with("http://") || ent.starts_with("xet://")
+}
+
+pub fn authenticate_remote_url(
+    url: &str,
+    config: &XetConfig,
+) -> Result<(String, Option<Vec<String>>)> {
+    let mut remote = url.to_owned();
+    let mut opt_args = None;
+
+    if remote.starts_with("xet://") {
+        (remote, opt_args) = xet_to_git_url(&remote)?;
+    }
+
+    let repo_info = remote_to_repo_info(&remote);
+    let localized_config = config.switch_repo_info(repo_info, None)?;
+
+    Ok((
+        localized_config.build_authenticated_remote_url(&remote),
+        opt_args,
+    ))
+}
+
+/// Parse a xet url in format 'xet://[domain/?][user]/[repo][/branch/path?]'.
+/// Return remote in format https://[domain]/user/repo and optional
+/// '--branch' args for clone and checkout.
+fn xet_to_git_url(url: &str) -> Result<(String, Option<Vec<String>>)> {
+    let parsed = parse_xet_url(url)?;
+
+    let opt_args = if parsed.branch.is_empty() {
+        None
+    } else {
+        Some(vec!["--branch".to_owned(), parsed.branch])
+    };
+
+    Ok((parsed.remote, opt_args))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct XetPathInfo {
+    remote: String,
+    branch: String,
+    path: String,
+}
+
+impl XetPathInfo {
+    /// Parse a xet URL in format 'xet://[domain/?][user]/[repo][/branch/path?]' and return
+    /// XetPathInfo.
+    /// [domain] is 'xethub.com' by default.
+    /// The logic is mostly borrowed from pyxet.
+    pub fn parse(url: &str, force_domain: &str) -> Result<Self> {
+        let url = url.strip_prefix('/').unwrap_or(url);
+
+        let mut parse =
+            Url::parse(url).map_err(|e| GitXetRepoError::InvalidRemote(e.to_string()))?;
+        if parse.scheme() == "" {
+            parse.set_scheme("xet").map_err(|_| {
+                GitXetRepoError::InvalidRemote("Failed to reset scheme to xet".to_owned())
+            })?;
+        }
+
+        let mut domain = force_domain.to_owned();
+        // support force_domain with a scheme (http/https)
+        let domain_split: Vec<_> = domain.split("://").collect();
+        let mut scheme = "https".to_owned();
+        if domain_split.len() == 2 {
+            scheme = domain_split[0].to_owned();
+            domain = domain_split[1].to_owned();
+        }
+
+        if parse.scheme() != "xet" {
+            return Err(GitXetRepoError::InvalidRemote(
+                "Invalid protocol".to_owned(),
+            ));
+        }
+
+        // Handle the case where we are xet://user/repo. In which case the domain
+        // parsed is not xethub.com and domain="user".
+        // we rewrite the parse the handle this case early.
+        if let Some(host) = parse.host() {
+            let host_str = host.to_string();
+            if host_str != domain {
+                if host_str == "xethub.com" {
+                    parse.set_host(Some(&domain)).map_err(|_| {
+                        GitXetRepoError::InvalidRemote(format!("Invalid domain {domain}"))
+                    })?;
+                } else {
+                    // this is of the for xet://user/repo/...
+                    // join user back with path
+                    let newpath = format!("{}{}", host_str, parse.path());
+                    // replace the host
+                    parse.set_host(Some(&domain)).map_err(|_| {
+                        GitXetRepoError::InvalidRemote(format!("Invalid domain {domain}"))
+                    })?;
+                    parse.set_path(&newpath);
+                }
+            }
+        }
+
+        // Split the known path and try to split out the user/repo/branch/path components
+        let path = parse.path();
+        let components: Vec<_> = path.split('/').collect();
+        // path always begin with a '/', so 1st component is always empty
+        // so the minimum for a remote is xethub.com/user/repo
+        if components.len() < 3 {
+            return Err(GitXetRepoError::InvalidRemote(
+                "Invalid Xet URL format: Expecting xet://user/repo/[branch]/[path]".to_owned(),
+            ));
+        }
+
+        let branch = if components.len() >= 4 {
+            components[3].to_owned()
+        } else {
+            "".to_owned()
+        };
+
+        let path = if components.len() >= 5 {
+            components[4..].join("/")
+        } else {
+            "".to_owned()
+        };
+
+        // we leave url with the first 3 components. i.e. "/user/repo"
+        let replacement_parse_path = components[..3].join("/");
+
+        return Ok(XetPathInfo {
+            remote: format!(
+                "{scheme}://{}{replacement_parse_path}",
+                parse.host().unwrap().to_string()
+            ),
+            branch: branch,
+            path: path,
+        });
+    }
+}
+
+fn parse_xet_url(url: &str) -> Result<XetPathInfo> {
+    // Get domain override
+    let domain_override = std::env::var(XET_ENDPOINT).unwrap_or(PROD_XETEA_DOMAIN.to_owned());
+
+    XetPathInfo::parse(url, &domain_override)
+}
+
+pub mod test_routines {
+    use super::{parse_xet_url, XetPathInfo};
+    use crate::errors::Result;
+
+    pub fn assert_xet_url_parse_result(xeturl: &str, expected: &XetPathInfo) -> Result<()> {
+        let parsed = parse_xet_url(xeturl)?;
+
+        assert_eq!(&parsed, expected);
+
+        Ok(())
+    }
+
+    pub fn assert_xet_url_with_domain_override_parse_result(
+        xeturl: &str,
+        domain_override: &str,
+        expected: &XetPathInfo,
+    ) -> Result<()> {
+        let parsed = XetPathInfo::parse(xeturl, domain_override)?;
+
+        assert_eq!(&parsed, expected);
+
+        Ok(())
+    }
+
+    pub fn assert_xet_url_parse_err(xeturl: &str) {
+        let parsed = parse_xet_url(xeturl);
+
+        assert!(parsed.is_err());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        test_routines::{
+            assert_xet_url_parse_err, assert_xet_url_parse_result,
+            assert_xet_url_with_domain_override_parse_result,
+        },
+        XetPathInfo,
+    };
+    use crate::errors::Result;
+
+    #[test]
+    fn test_parse_xet_url() -> Result<()> {
+        assert_xet_url_parse_result(
+            "xet://xethub.com/user/repo/branch/hello/world",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "hello/world".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://xethub.com/user/repo/branch/hello/world/",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "hello/world/".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://xethub.com/user/repo/branch/",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://xethub.com/user/repo/branch",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://xethub.com/user/repo",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://xethub.com/user/repo/branch",
+            "xetbeta.com",
+            &XetPathInfo {
+                remote: "https://xetbeta.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_err("xet://xethub.com/user");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_xet_url_truncated() -> Result<()> {
+        assert_xet_url_parse_result(
+            "xet://user/repo/branch/hello/world",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "hello/world".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://user/repo/branch/hello/world/",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "hello/world/".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://user/repo/branch/",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://user/repo/branch",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_result(
+            "xet://user/repo",
+            &XetPathInfo {
+                remote: "https://xethub.com/user/repo".to_owned(),
+                branch: "".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://user/repo/branch",
+            "xetbeta.com",
+            &XetPathInfo {
+                remote: "https://xetbeta.com/user/repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_parse_err("xet://user");
+
+        Ok(())
+    }
+}

--- a/rust/gitxetcore/src/git_integration/mod.rs
+++ b/rust/gitxetcore/src/git_integration/mod.rs
@@ -2,4 +2,5 @@ pub mod git_file_tools;
 pub mod git_integration_plumb;
 pub mod git_notes_wrapper;
 pub mod git_repo;
+pub mod git_url;
 pub mod git_wrap;


### PR DESCRIPTION
With this PR git-xet clone and mount work with xet urls in format `xet://[user]/[repo]/[branch]`
1. Path after branch is ignored.
2. If branch is not specified the default branch is used.
3. Branch in the xet url has priority, i.e., `--branch` in git xet clone or `--reference` in git xet mount is ignored if branch exists in the xet url.

The xet url parsing logic is mostly taken from pyxet.

Resolves https://github.com/xetdata/xethub/issues/3859.

Example usage:
`git xet clone xet://[user]/[repo]/[branch]`
`git xet mount xet://[user]/[repo]/[branch]`

Clone Tests:
1. clone with default branch (main) -> main
```
di@di-mbp ~/tt % git xet clone xet://seanses/bsf13 2>/dev/null && cd bsf13 && git branch
* main
```
2. clone with branch p1 in xet url -> p1
```
di@di-mbp ~/tt % git xet clone xet://seanses/bsf13/p1 2>/dev/null && cd bsf13 && git branch
* p1
```
3. clone with branch p1 in xet url and branch args (main) -> p1
```
di@di-mbp ~/tt % git xet clone xet://seanses/bsf13/p1 -- --branch main 2>/dev/null && cd bsf13 && git branch
* p1
```
4. clone with path under branch p1 in xet url -> p1
```
di@di-mbp ~/tt/bb % git xet clone xet://seanses/bsf13/p1/aie 2>/dev/null && cd bsf13 && git branch
* p1
```
5. clone with domain override
```
di@di-mbp ~/tt/bb % XET_ENDPOINT=hub.xetsvc.com git xet clone xet://seanses-dev/some-basic
Preparing to clone Xet repository.
Cloning into 'some-basic'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 6 (delta 0), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (6/6), done.
git-xet 0.11.4 filter started
Xet: Retrieving data blocks: 1 MiB | 1 MiB/s, done.
```

Mount tests:
(There is only a .gitattributes file under the test repo main branch, an addition d0 file under the test repo p1 branch.)
1. mount with default branch (main) -> main
```
di@di-mbp ~/tt % git xet mount xet://seanses/bsf13 && cd bsf13 && ll
Mounting to "/Users/di/tt/bsf13"
Cloning into temporary directory "/var/folders/kq/dstj45l13w5f982lk40nxbn40000gn/T/.tmpXQMnIG"
Mounting as a background task...
Setting up mount point...
Mount at "/Users/di/tt/bsf13" successful. Unmount with 'umount "/Users/di/tt/bsf13"'
Mount complete in 3.997646s
total 1
d---------   2 di  staff    0 Sep 20 01:07 .
drwxr-xr-x  24 di  staff  768 Sep 20 01:07 ..
-r--r--r--   1 di  staff   79 Sep 20 01:07 .gitattributes
```
2. mount with branch p1 in xet url -> p1
```
di@di-mbp ~/tt % git xet mount xet://seanses/bsf13/p1 && cd bsf13 && ll
Mounting to "/Users/di/tt/bsf13"
Cloning into temporary directory "/var/folders/kq/dstj45l13w5f982lk40nxbn40000gn/T/.tmprts9ec"
Mounting as a background task...
Setting up mount point...
Mount at "/Users/di/tt/bsf13" successful. Unmount with 'umount "/Users/di/tt/bsf13"'
Mount complete in 3.473811s
total 3
d---------   2 di  staff     0 Sep 20 01:08 .
drwxr-xr-x  24 di  staff   768 Sep 20 01:08 ..
-r--r--r--   1 di  staff    79 Sep 20 01:08 .gitattributes
-r--r--r--   1 di  staff  1024 Sep 20 01:08 d0
```
3. mount with branch p1 in xet url and reference args (main) -> p1
```
di@di-mbp ~/tt % git xet mount xet://seanses/bsf13/p1 --reference main && cd bsf13 && ll
Mounting to "/Users/di/tt/bsf13"
Cloning into temporary directory "/var/folders/kq/dstj45l13w5f982lk40nxbn40000gn/T/.tmp9Wj7Wk"
Mounting as a background task...
Setting up mount point...
Mount at "/Users/di/tt/bsf13" successful. Unmount with 'umount "/Users/di/tt/bsf13"'
Mount complete in 3.55342s
total 3
d---------   2 di  staff     0 Sep 20 01:09 .
drwxr-xr-x  24 di  staff   768 Sep 20 01:09 ..
-r--r--r--   1 di  staff    79 Sep 20 01:09 .gitattributes
-r--r--r--   1 di  staff  1024 Sep 20 01:09 d0
```
4. mount with path under branch p1 in xet url -> p1
```
di@di-mbp ~/tt % git xet mount xet://seanses/bsf13/p1/vaie && cd bsf13 && ll
Mounting to "/Users/di/tt/bsf13"
Cloning into temporary directory "/var/folders/kq/dstj45l13w5f982lk40nxbn40000gn/T/.tmpiq9SBi"
Mounting as a background task...
Setting up mount point...
Mount at "/Users/di/tt/bsf13" successful. Unmount with 'umount "/Users/di/tt/bsf13"'
Mount complete in 3.436438s
total 3
d---------   2 di  staff     0 Sep 20 01:10 .
drwxr-xr-x  24 di  staff   768 Sep 20 01:10 ..
-r--r--r--   1 di  staff    79 Sep 20 01:10 .gitattributes
-r--r--r--   1 di  staff  1024 Sep 20 01:10 d0
```
5. mount with domain override
```
di@di-mbp ~/tt/bb % XET_ENDPOINT=hub.xetsvc.com git xet mount xet://seanses-dev/some-basic
Mounting to "/Users/di/tt/bb/some-basic"
Cloning into temporary directory "/var/folders/kq/dstj45l13w5f982lk40nxbn40000gn/T/.tmphdzSs1"
Mounting as a background task...
Setting up mount point...
Mount at "/Users/di/tt/bb/some-basic" successful. Unmount with 'umount "/Users/di/tt/bb/some-basic"'
Mount complete in 0.894516s
```