### PR TITLE
git xet smudge -i <hash> now materializes a file, independent of repo 

### DIFF
--- a/rust/gitxetcore/src/command/summary.rs
+++ b/rust/gitxetcore/src/command/summary.rs
@@ -92,10 +92,10 @@ async fn print_summary_from_db(
         GIT_NOTES_SUMMARIES_REF_NAME,
     )
     .await?;
-    let summary = summarydb.get(pointer_file.hash()).ok_or_else(|| {
+    let summary = summarydb.get(pointer_file.hash_string()).ok_or_else(|| {
         anyhow!(
             "could not find summary for pointer file with hash {}",
-            pointer_file.hash()
+            pointer_file.hash_string()
         )
     })?;
     match summary_type {

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -286,7 +286,7 @@ pub struct PointerFileTranslator {
 impl PointerFileTranslator {
     pub async fn from_config(config: &XetConfig) -> Result<Self> {
         let version = git_repo::get_mdb_version(
-            &config
+            config
                 .repo_path_if_present
                 .as_ref()
                 .unwrap_or(&PathBuf::default()),
@@ -460,7 +460,7 @@ impl PointerFileTranslator {
 
     pub async fn smudge_file_from_pointer(
         &self,
-        path: &PathBuf,
+        path: &Path,
         pointer: &PointerFile,
         writer: &mut impl std::io::Write,
         range: Option<(usize, usize)>,

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -285,7 +285,13 @@ pub struct PointerFileTranslator {
 
 impl PointerFileTranslator {
     pub async fn from_config(config: &XetConfig) -> Result<Self> {
-        let version = git_repo::get_mdb_version(config.repo_path()?)?;
+        let version = git_repo::get_mdb_version(
+            &config
+                .repo_path_if_present
+                .as_ref()
+                .unwrap_or(&PathBuf::default()),
+        )?;
+
         match version {
             ShardVersion::V1 => Ok(Self {
                 pft: PFTRouter::V1(PointerFileTranslatorV1::from_config(config).await?),
@@ -393,10 +399,10 @@ impl PointerFileTranslator {
     }
 
     /// Queries merkle db for construction info for a pointer file.
-    pub async fn derive_blocks(&self, pointer: &PointerFile) -> Result<Vec<ObjectRange>> {
+    pub async fn derive_blocks(&self, hash: &MerkleHash) -> Result<Vec<ObjectRange>> {
         match &self.pft {
-            PFTRouter::V1(ref p) => p.derive_blocks(pointer).await,
-            PFTRouter::V2(ref p) => p.derive_blocks(pointer).await,
+            PFTRouter::V1(ref p) => p.derive_blocks(hash).await,
+            PFTRouter::V2(ref p) => p.derive_blocks(hash).await,
         }
     }
 
@@ -468,6 +474,19 @@ impl PointerFileTranslator {
                 p.smudge_file_from_pointer(path, pointer, writer, range)
                     .await
             }
+        }
+    }
+
+    pub async fn smudge_file_from_hash(
+        &self,
+        path: Option<PathBuf>,
+        file_id: &MerkleHash,
+        writer: &mut impl std::io::Write,
+        range: Option<(usize, usize)>,
+    ) -> Result<()> {
+        match &self.pft {
+            PFTRouter::V1(ref p) => p.smudge_file_from_hash(path, file_id, writer, range).await,
+            PFTRouter::V2(ref p) => p.smudge_file_from_hash(path, file_id, writer, range).await,
         }
     }
 

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -414,8 +414,7 @@ impl PointerFileTranslatorV1 {
         if start >= pointer.filesize() {
             return Ok(true);
         }
-        let hash = MerkleHash::from_hex(pointer.hash())
-            .map_err(|_| GitXetRepoError::StreamParseError("Unable to parse hash".to_string()))?;
+        let hash = pointer.hash()?;
         // if we are prefetching, or we have prefetched recently, return ok
         if self.prefetched.lock().await.contains(&(hash, chunknum)) {
             return Ok(false);
@@ -431,7 +430,7 @@ impl PointerFileTranslatorV1 {
 
         // unlock to compute the blocks. This may take a while
         let blocks = self
-            .derive_blocks(pointer)
+            .derive_blocks(&hash)
             .instrument(info_span!("derive_blocks"))
             .await?;
         let blocks =
@@ -679,43 +678,55 @@ impl PointerFileTranslatorV1 {
         }
     }
 
-    pub async fn derive_blocks(&self, pointer: &PointerFile) -> Result<Vec<ObjectRange>> {
-        let hash = MerkleHash::from_hex(pointer.hash()).map_err(|e| {
-            GitXetRepoError::StreamParseError(format!("Error getting hex hash value: {e:?}"))
-        })?;
-        if let Some(res) = self.derive_blocks_cache.lock().await.get(&hash) {
+    pub async fn derive_blocks(&self, hash: &MerkleHash) -> Result<Vec<ObjectRange>> {
+        if let Some(res) = self.derive_blocks_cache.lock().await.get(hash) {
             return Ok(res.clone());
         }
 
         let mut block_v = {
             let mdb = self.mdb.lock().await;
 
-            debug!("Extracting object for hash {:?}", pointer.hash());
+            debug!("Extracting object for hash {hash:?}");
             let node = mdb.find_node(&hash).ok_or(GitXetRepoError::HashNotFound)?;
             mdb.reconstruct_from_cas(&[node])?
         };
         if block_v.len() != 1 {
             return Err(GitXetRepoError::Other(format!(
-                "Unable to reconstruct CAS information for hash {:?}",
-                pointer.hash()
+                "Unable to reconstruct CAS information for hash {hash:?}"
             )));
         }
         let res = std::mem::take(&mut block_v[0].1);
-        self.derive_blocks_cache.lock().await.put(hash, res.clone());
+        self.derive_blocks_cache
+            .lock()
+            .await
+            .put(*hash, res.clone());
         Ok(res)
     }
 
     pub async fn smudge_file_from_pointer(
         &self,
-        path: &PathBuf,
+        path: &Path,
         pointer: &PointerFile,
         writer: &mut impl std::io::Write,
         range: Option<(usize, usize)>,
     ) -> Result<()> {
-        info!("Smudging file {:?}", &path);
+        self.smudge_file_from_hash(Some(path.to_path_buf()), &pointer.hash()?, writer, range)
+            .await
+    }
+
+    pub async fn smudge_file_from_hash(
+        &self,
+        path: Option<PathBuf>,
+        hash: &MerkleHash,
+        writer: &mut impl std::io::Write,
+        range: Option<(usize, usize)>,
+    ) -> Result<()> {
+        if let Some(p) = &path {
+            info!("Smudging file {p:?}");
+        }
 
         let blocks = self
-            .derive_blocks(pointer)
+            .derive_blocks(&hash)
             .instrument(info_span!("derive_blocks"))
             .await?;
 
@@ -736,7 +747,9 @@ impl PointerFileTranslatorV1 {
 
         data_from_chunks_to_writer(&self.cas, self.prefix.clone(), ranged_blocks, writer).await?;
 
-        debug!("Done smudging file {:?}", &path);
+        if let Some(p) = &path {
+            debug!("Done smudging file {p:?}");
+        }
 
         Ok(())
     }
@@ -753,7 +766,12 @@ impl PointerFileTranslatorV1 {
     ) -> usize {
         info!("Smudging file {:?}", &path);
 
-        let blocks = match self.derive_blocks(pointer).await {
+        let Ok(hash) = pointer.hash() else {
+            error!("Unable to parse hash {:?} in pointer file for path {:?}", pointer.hash_string(), path);
+            return 0;
+        };
+
+        let blocks = match self.derive_blocks(&hash).await {
             Ok(b) => b,
             Err(e) => {
                 if let Err(e) = writer.send(Err(e)).await {
@@ -1114,7 +1132,7 @@ mod tests {
         // check that the cleaned file parses correctly
         let ptr_file = PointerFile::init_from_string(std::str::from_utf8(&cleaned).unwrap(), "");
         // the empty file has a merklehash of 0s
-        assert_eq!(*ptr_file.hash(), MerkleHash::default().hex());
+        assert_eq!(ptr_file.hash().unwrap(), MerkleHash::default());
         assert!(ptr_file.is_valid());
     }
     #[tokio::test]

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -687,7 +687,7 @@ impl PointerFileTranslatorV1 {
             let mdb = self.mdb.lock().await;
 
             debug!("Extracting object for hash {hash:?}");
-            let node = mdb.find_node(&hash).ok_or(GitXetRepoError::HashNotFound)?;
+            let node = mdb.find_node(hash).ok_or(GitXetRepoError::HashNotFound)?;
             mdb.reconstruct_from_cas(&[node])?
         };
         if block_v.len() != 1 {
@@ -726,7 +726,7 @@ impl PointerFileTranslatorV1 {
         }
 
         let blocks = self
-            .derive_blocks(&hash)
+            .derive_blocks(hash)
             .instrument(info_span!("derive_blocks"))
             .await?;
 

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -966,7 +966,7 @@ impl PointerFileTranslatorV2 {
     pub async fn derive_blocks(&self, hash: &MerkleHash) -> Result<Vec<ObjectRange>> {
         if let Some((file_info, _shard_hash)) = self
             .file_reconstructor
-            .get_file_reconstruction_info(&hash)
+            .get_file_reconstruction_info(hash)
             .await?
         {
             Ok(file_info

--- a/rust/gitxetcore/src/diff/fetcher.rs
+++ b/rust/gitxetcore/src/diff/fetcher.rs
@@ -111,7 +111,7 @@ impl SummaryFetcher {
         // file is either a pass-through or a pointer file.
         let content = blob.content();
         let summary = if let Some(pointer_file) = is_valid_pointer_file(content) {
-            self.hash_to_summary(Some(pointer_file.hash()))
+            self.hash_to_summary(Some(pointer_file.hash_string()))
                 .unwrap_or_default()
         } else {
             // file is a pass-through, calculate the summary:

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -20,6 +20,9 @@ pub enum GitXetRepoError {
     #[error("CAS Communication Error : {0}")]
     NetworkIOError(#[from] CasClientError),
 
+    #[error("Unable to parse string as hex hash value.")]
+    HashStringParsingFailure(#[from] merklehash::DataHashHexParseError),
+
     #[error("MerkleDBError : {0}")]
     MerkleDBError(#[from] merkledb::error::MerkleDBError),
 

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -122,6 +122,9 @@ pub fn get_merkledb_notes_name(version: &ShardVersion) -> &'static str {
 }
 
 pub fn get_mdb_version(repo_path: &Path) -> Result<ShardVersion> {
+    if !repo_path.exists() {
+        return Ok(ShardVersion::get_max());
+    }
     let v = merkledb_shard_plumb::match_repo_mdb_version(
         repo_path,
         get_merkledb_notes_name,

--- a/rust/gitxetcore/src/merkledb_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_plumb.rs
@@ -390,7 +390,7 @@ pub fn find_cas_nodes_for_blob(
         if let Ok(utf) = std::str::from_utf8(blob.content()) {
             let pointer = PointerFile::init_from_string(utf, "");
             if pointer.is_valid() {
-                if let Some(node) = mdb.find_node(&MerkleHash::from_hex(pointer.hash())?) {
+                if let Some(node) = mdb.find_node(&pointer.hash()?) {
                     // compute the minhash signature which is
                     // an inplace min over all the leaves
                     for n in mdb.find_all_leaves(&node).unwrap() {

--- a/rust/gitxetcore/src/smudge_query_interface.rs
+++ b/rust/gitxetcore/src/smudge_query_interface.rs
@@ -50,15 +50,13 @@ pub async fn shard_manager_from_config(
         shard_manager
             .register_shards_by_path(&[&config.merkledb_v2_cache], true)
             .await?;
+    } else if config.merkledb_v2_cache == PathBuf::default() {
+        info!("No Merkle DB Cache specified.");
     } else {
-        if config.merkledb_v2_cache == PathBuf::default() {
-            info!("No Merkle DB Cache specified.");
-        } else {
-            warn!(
-                "Merkle DB Cache path {:?} does not exist, skipping registration.",
-                config.merkledb_v2_cache
-            );
-        }
+        warn!(
+            "Merkle DB Cache path {:?} does not exist, skipping registration.",
+            config.merkledb_v2_cache
+        );
     }
 
     Ok(shard_manager)

--- a/rust/gitxetcore/src/xetmnt/xetfs_write.rs
+++ b/rust/gitxetcore/src/xetmnt/xetfs_write.rs
@@ -109,7 +109,7 @@ async fn checkout_xetfile(
         let mut f = BufWriter::new(&mut tempfile);
 
         pfilereader
-            .smudge_file_from_pointer(&fullpath.to_path_buf(), pointer, &mut f, None)
+            .smudge_file_from_pointer(fullpath, pointer, &mut f, None)
             .await?;
     }
 

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 
 use crate::shard_format::MDB_SHARD_MIN_TARGET_SIZE;
 use crate::{cas_structs::*, file_structs::*, shard_in_memory::MDBInMemoryShard};
@@ -16,7 +16,7 @@ use crate::{cas_structs::*, file_structs::*, shard_in_memory::MDBInMemoryShard};
 #[derive(Debug)]
 struct MDBShardFlushGuard {
     shard: MDBInMemoryShard,
-    session_directory: PathBuf,
+    session_directory: Option<PathBuf>,
 }
 
 impl Drop for MDBShardFlushGuard {
@@ -25,19 +25,20 @@ impl Drop for MDBShardFlushGuard {
             return;
         }
 
-        // Check if the flushing directory exists.
-        if !self.session_directory.is_dir() {
-            error!(
-                "Error flushing reconstruction data on shutdown: {:?} is not a directory or doesn't exist",
-                self.session_directory
+        if let Some(sd) = &self.session_directory {
+            // Check if the flushing directory exists.
+            if !sd.is_dir() {
+                error!(
+                "Error flushing reconstruction data on shutdown: {sd:?} is not a directory or doesn't exist"
             );
-            return;
-        }
+                return;
+            }
 
-        self.flush().unwrap_or_else(|e| {
-            error!("Error flushing reconstruction data on shutdown: {e:?}");
-            None
-        });
+            self.flush().unwrap_or_else(|e| {
+                error!("Error flushing reconstruction data on shutdown: {e:?}");
+                None
+            });
+        }
     }
 }
 
@@ -69,18 +70,29 @@ pub struct ShardFileManager {
 impl ShardFileManager {
     /// Construct a new shard file manager that uses session_directory as the temporary dumping  
     pub async fn new(session_directory: &Path) -> Result<Self> {
+        let session_directory = {
+            if session_directory == PathBuf::default() {
+                None
+            } else {
+                Some(std::fs::canonicalize(session_directory).map_err(|e| {
+                    error!("Error accessing session directory {session_directory:?}: {e:?}");
+                    e
+                })?)
+            }
+        };
+
         let s = Self {
             shard_file_lookup: Arc::new(RwLock::new(HashMap::new())),
             current_state: Arc::new(RwLock::new(MDBShardFlushGuard {
                 shard: MDBInMemoryShard::default(),
-                session_directory: std::fs::canonicalize(session_directory)?,
+                session_directory: session_directory.clone(),
             })),
             target_shard_min_size: MDB_SHARD_MIN_TARGET_SIZE,
         };
 
-        s.register_shards_by_path(&[session_directory], false)
-            .await?;
-
+        if let Some(sd) = &session_directory {
+            s.register_shards_by_path(&[sd], false).await?;
+        }
         Ok(s)
     }
 
@@ -294,11 +306,17 @@ impl MDBShardFlushGuard {
             return Ok(None);
         }
 
-        let path = self.shard.write_to_directory(&self.session_directory)?;
+        if let Some(sd) = &self.session_directory {
+            let path = self.shard.write_to_directory(sd)?;
+            self.shard = MDBInMemoryShard::default();
 
-        self.shard = MDBInMemoryShard::default();
+            info!("Shard manager flushed new shard to {path:?}.");
 
-        Ok(Some(path))
+            Ok(Some(path))
+        } else {
+            info!("Shard manager in ephemeral mode; skipping flush to disk.");
+            Ok(None)
+        }
     }
 }
 

--- a/rust/pointer_file/Cargo.toml
+++ b/rust/pointer_file/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 toml = "0.5"
 tracing = "0.1.31"
+merklehash = {path = "../merklehash"}
 
 [features]
 strict = []


### PR DESCRIPTION
This PR: 
- Adds checks in data_processing, shard manager, and other places to allow limited operation without a repo present. 
- Added --id/-i flag to git-xet smudge to take a raw hash instead of a pointer file and smudge based on that.  Thus:

```
git xet smudge -i <hash> -o <output_file> 
```

will materialize the file given by the hash ID to the output_file given.  