### PR TITLE
push mdb v1 diff when it is a standalone pointer

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1440,6 +1440,7 @@ impl GitRepo {
         // pushed
         self.upload_all_staged().await?;
         self.sync_dbs_to_notes().await?;
+        self.upload_all_staged().await?;
         self.sync_notes_to_remote(remote)?;
 
         Ok(())

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1438,8 +1438,13 @@ impl GitRepo {
         // in case the other db has issues, we are guaranteed to at least
         // get the bytes off the machine before anything else gets actually
         // pushed
+
+        // the first upload staged is to ensure all xorbs are synced
+        // so shard registration (in MDBv2) in sync_dbs_to_notes will find them.
         self.upload_all_staged().await?;
         self.sync_dbs_to_notes().await?;
+        // the second upload staged is to ensure xorbs associated with large MDBv1
+        // diff as standalone pointer file as synced.
         self.upload_all_staged().await?;
         self.sync_notes_to_remote(remote)?;
 


### PR DESCRIPTION
In MDBv1 when a mdb diff is big, a xorb is created for this mdb diff, and this happens inside `sync_dbs_to_notes`, after `upload_all_staged`. This calls `upload_all_staged` again after `sync_dbs_to_notes` to push that xorb.