### PR TITLE
Disable AXE by default

### DIFF
--- a/rust/gitxetcore/src/config/axe.rs
+++ b/rust/gitxetcore/src/config/axe.rs
@@ -11,7 +11,7 @@ pub struct AxeSettings {
 impl Default for AxeSettings {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             axe_code: PROD_AXE_CODE.to_string(),
         }
     }

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -19,7 +19,7 @@ pub const DEFAULT_CACHE_SIZE: u64 = 10_737_418_240; // 10GiB
 
 pub const DEFAULT_LOG_LEVEL: &str = "warn";
 
-pub const DEFAULT_AXE_ENABLED: &str = "true";
+pub const DEFAULT_AXE_ENABLED: &str = "false";
 
 /// A struct to represent the Config file for git-xet.
 ///


### PR DESCRIPTION
This flips the default behavior for AXE from enabled-by-default to disabled-by-default. The same env variable XET_AXE_ENABLED is still respected.

Tested locally:

* With no env variable set, no AXE requests are sent
* With env variable XET_AXE_ENABLED=1, AXE requests are sent