### PR TITLE
Fix unit test failure in main

### DIFF
--- a/rust/xet_config/src/console_ser.rs
+++ b/rust/xet_config/src/console_ser.rs
@@ -728,7 +728,7 @@ mod test {
 cache.path=/tmp/cache
 cache.size={}
 log.level={}
-axe.enabled=true
+axe.enabled=false
 axe.axe_code=5454
 "#,
             cfg::DEFAULT_CACHE_SIZE,


### PR DESCRIPTION
After merging #136, a unit test now fails in main. This is due to a change in the hardcoded value `axe.enabled`.