### PR TITLE
Perform version check on certain commands

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,5 +18,5 @@ members = [
     "progress_reporting",
     "cas_client",
     "xet_config",
-    "xetblob"
+    "xetblob",
 ]

--- a/rust/gitxet/tests/integration_tests.rs
+++ b/rust/gitxet/tests/integration_tests.rs
@@ -169,6 +169,11 @@ mod git_integration_tests {
     }
 
     #[test]
+    fn test_xet_version_check() -> anyhow::Result<()> {
+        IntegrationTest::new(include_str!("integration_tests/test_xet_version_check.sh")).run()
+    }
+
+    #[test]
     fn test_xet_remote() -> anyhow::Result<()> {
         IntegrationTest::new(include_str!("integration_tests/test_xet_remote.sh")).run()
     }

--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -3,6 +3,7 @@
 # Set up local, self-contained config stuff to make sure the environment for the tests is hermetic.
 
 export GIT_CONFIG_GLOBAL="$PWD/.gitconfig"
+export XET_DISABLE_VERSION_CHECK="1"
 
 # This is needed as older versions of git only go to $HOME/.gitconfig and do not respect
 # the GIT_CONFIG_GLOBAL environment variable.  

--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -9,6 +9,11 @@ export XET_DISABLE_VERSION_CHECK="1"
 # the GIT_CONFIG_GLOBAL environment variable.  
 export HOME=$PWD
 
+# Set up logging
+export XET_LOG_LEVEL=debug
+export XET_LOG_FORMAT=compact
+export XET_LOG_PATH=$HOME/run_log.txt
+
 # support both Mac OS and Linux for these scripts
 if hash md5 2>/dev/null; then 
     checksum() {

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -8,9 +8,27 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 
 unset XET_DISABLE_VERSION_CHECK
 export _XET_VERSION_OVERRIDE="v0.0.0"
+export XET_VERSION_CHECK_FILENAME=`pwd`/.xet/xet_version_info
 
 remote=$(create_bare_repo)
 
 out="$(git xet clone $remote repo_1 2>&1 > /dev/null)"  # Capture just stderr
 
+
 [[ $out == *"new version"* ]] || die "Version message not in $out"
+
+cd repo_1
+out="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
+
+[[ ! $out == *"new version"* ]] || die "Version message in $out on second run."
+
+# Test that the bugfix critical version is detected.
+rm $XET_VERSION_CHECK_FILENAME
+
+export _XET_TEST_VERSION_CHECK_CRITICAL_PATTERN="repo-independent smudge command"
+
+out="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
+
+[[ $out == *"CRITICAL"* ]] || die "Version message not in $out"
+
+

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 
 unset XET_DISABLE_VERSION_CHECK
 export _XET_VERSION_OVERRIDE="v0.0.0"
-export XET_VERSION_CHECK_FILENAME=`pwd`/.xet/xet_version_info
+export XET_UPGRADE_CHECK_FILENAME=`pwd`/.xet/xet_version_info
 
 remote=$(create_bare_repo)
 
@@ -23,7 +23,7 @@ out="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
 [[ ! $out == *"new version"* ]] || die "Version message in $out on second run."
 
 # Test that the bugfix critical version is detected.
-rm $XET_VERSION_CHECK_FILENAME
+rm -f $XET_UPGRADE_CHECK_FILENAME
 
 export _XET_TEST_VERSION_CHECK_CRITICAL_PATTERN="repo-independent smudge command"
 

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+. "$SCRIPT_DIR/initialize.sh"
+
+unset XET_DISABLE_VERSION_CHECK
+export _XET_VERSION_OVERRIDE="v0.0.0"
+
+remote=$(create_bare_repo)
+
+out="$(git xet clone $remote repo_1 2>&1)"
+
+[[ $out == *"version available"* ]] || die "Version message not in $out"

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -12,7 +12,7 @@ fi
 
 
 unset XET_DISABLE_VERSION_CHECK
-export _XET_VERSION_OVERRIDE="v0.0.0"
+export _XET_TEST_VERSION_OVERRIDE="v0.0.0"
 export XET_UPGRADE_CHECK_FILENAME=`pwd`/.xet/xet_version_info
 
 env

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -5,10 +5,17 @@ set -x
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 . "$SCRIPT_DIR/initialize.sh"
 
+if [[ -z $(ping -c 1 github.com 2>&1 | grep -i "unknown host") ]] ; then 
+  echo "github.com unreachable, skipping test."
+  exit 0
+fi
+
 
 unset XET_DISABLE_VERSION_CHECK
 export _XET_VERSION_OVERRIDE="v0.0.0"
 export XET_UPGRADE_CHECK_FILENAME=`pwd`/.xet/xet_version_info
+
+env
 
 remote=$(create_bare_repo)
 
@@ -18,9 +25,9 @@ out="$(git xet clone $remote repo_1 2>&1 > /dev/null)"  # Capture just stderr
 [[ $out == *"new version"* ]] || die "Version message not in $out"
 
 cd repo_1
-out="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
+out_2="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
 
-[[ ! $out == *"new version"* ]] || die "Version message in $out on second run."
+[[ ! $out_2 == *"new version"* ]] || die "Version message in \{\{\{ $out_2 \}\}\} on second run."
 
 # Test that the bugfix critical version is detected.
 rm -f $XET_UPGRADE_CHECK_FILENAME
@@ -29,6 +36,6 @@ export _XET_TEST_VERSION_CHECK_CRITICAL_PATTERN="repo-independent smudge command
 
 out="$(git xet init --force 2>&1 > /dev/null)"  # Capture just stderr
 
-[[ $out == *"CRITICAL"* ]] || die "Version message not in $out"
+[[ $out == *"CRITICAL"* ]] || die "Critical version message not in $out"
 
 

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -5,7 +5,7 @@ set -x
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 . "$SCRIPT_DIR/initialize.sh"
 
-if [[ -z $(ping -c 1 github.com 2>&1 | grep -i "unknown host") ]] ; then 
+if [[ ! -z $(ping -c 1 github.com 2>&1 | grep -i "unknown host") ]] ; then 
   echo "github.com unreachable, skipping test."
   exit 0
 fi

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -5,6 +5,7 @@ set -x
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 . "$SCRIPT_DIR/initialize.sh"
 
+
 unset XET_DISABLE_VERSION_CHECK
 export _XET_VERSION_OVERRIDE="v0.0.0"
 

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -10,6 +10,6 @@ export _XET_VERSION_OVERRIDE="v0.0.0"
 
 remote=$(create_bare_repo)
 
-out="$(git xet clone $remote repo_1 2>&1)"
+out="$(git xet clone $remote repo_1 2>&1 > /dev/null)"  # Capture just stderr
 
-[[ $out == *"version available"* ]] || die "Version message not in $out"
+[[ $out == *"new version"* ]] || die "Version message not in $out"

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -54,7 +54,7 @@ regex = "1.5.6"
 lazy_static = "1.4.0"
 is_executable = "1.0.1"
 rand = "0.8.4"
-version-compare = "0.1.0"
+version-compare = "0.1.1"
 serde = {version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.83"
 csv-core = "0.1.10"
@@ -97,7 +97,8 @@ sysinfo = "0.26.6"
 reqwest = {version = "0.11.4", features = ["json"]}
 serde_with = "1.6.1"
 chrono = {version = "0.4.19", features = ["serde"] }
-# 
+
+ 
 # metrics
 prometheus = "0.13.0"
 prometheus_dict_encoder = { path = "../prometheus_dict_encoder" }

--- a/rust/gitxetcore/src/command.rs
+++ b/rust/gitxetcore/src/command.rs
@@ -39,6 +39,7 @@ use crate::git_integration::git_integration_plumb::{handle_hook_plumb_command, H
 use crate::git_integration::git_wrap::perform_git_version_check;
 use crate::log::{get_trace_span, initialize_tracing_subscriber};
 use crate::smudge_query_interface::SmudgeQueryPolicy;
+use crate::upgrade_checks::VersionCheckInfo;
 
 mod clone;
 mod dir_summary;
@@ -158,6 +159,9 @@ pub struct CliOverrides {
     #[clap(long, short = 'v', parse(from_occurrences))]
     pub verbose: i8,
 
+    #[clap(long, hide = true)]
+    pub disable_version_check: bool,
+
     /// Sets the output log file. Writes to stderr if not provided.
     #[clap(long, short)]
     pub log: Option<PathBuf>,
@@ -252,6 +256,34 @@ impl Command {
         ret
     }
 
+    pub fn allow_version_check(&self) -> bool {
+        match self {
+            Command::Checkout(_) => true,
+            Command::Filter => true,
+            Command::Pointer(_) => false,
+            Command::Smudge(_) => false,
+            Command::Push => true,
+            Command::Merkledb(_) => false,
+            Command::Cas(_) => false,
+            Command::Hooks(_) => false,
+            Command::Install(_) => true,
+            Command::Init(_) => true,
+            Command::Clone(_) => true,
+            Command::Config(_) => false,
+            Command::RepoSize(_) => false,
+            Command::Summary(_) => false,
+            Command::DirSummary(_) => false,
+            Command::Diff(_) => false,
+            Command::Mount(_) => true,
+            Command::MountCurdir(_) => true,
+            Command::S3(_) => true,
+            Command::Uninstall(_) => false,
+            Command::Uninit(_) => false,
+            Command::Login(_) => true,
+            Command::VisualizationDependencies(_) => false,
+        }
+    }
+
     pub fn name(&self) -> String {
         match self {
             Command::Checkout(_) => "checkout".to_string(),
@@ -302,7 +334,13 @@ impl XetApp {
         // Make sure the version of git we're using is in fact correct.
         perform_git_version_check()?;
 
-        let cli = GitXetCommand::parse();
+        let mut cli = GitXetCommand::parse();
+
+        // Disable the version check here if we need to.
+        if !cli.command.allow_version_check() {
+            cli.overrides.disable_version_check = true;
+        }
+        let cli = cli;
 
         // We don't validate the configuration for the `config` command
         // since, if the config is invalid, we want to allow fixing it.
@@ -327,12 +365,29 @@ impl XetApp {
         info!("Is Debug build: {:?}", is_debug_build());
         debug!("Config: {:?}", self.config);
 
+        let mut version_check_handle = None;
+
+        if !self.config.disable_version_check {
+            version_check_handle = Some(tokio::spawn(VersionCheckInfo::load_or_query()));
+        }
+
         let span = get_trace_span(&self.command);
-        if self.command.long_running() {
+        let ret = if self.command.long_running() {
             self.command.run(self.config.clone()).await
         } else {
             self.command.run(self.config.clone()).instrument(span).await
+        };
+
+        if let Some(jh) = version_check_handle {
+            if let Ok(Some(mut vci)) = jh.await.map_err(|e| {
+                info!("Error occurred on joining of version check: {e:?}.");
+                e
+            }) {
+                vci.notify_user_if_appropriate();
+            }
         }
+
+        ret
     }
 }
 

--- a/rust/gitxetcore/src/command.rs
+++ b/rust/gitxetcore/src/command.rs
@@ -274,7 +274,7 @@ impl Command {
             Command::Install(_) => true,
             Command::Init(_) => true,
             Command::Clone(_) => true,
-            Command::Config(_) => false,
+            Command::Config(_) => true,
             Command::RepoSize(_) => false,
             Command::Summary(_) => false,
             Command::DirSummary(_) => false,

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -170,6 +170,7 @@ mod tests {
             user_name: None,
             user_token: None,
             user_email: None,
+            disable_version_check: true,
             user_login_id: None,
         };
         let cfg = get_override_cfg(&overrides);
@@ -197,6 +198,7 @@ mod tests {
             user_token: None,
             user_email: Some("hello@hello.com".to_string()),
             user_login_id: None,
+            disable_version_check: true,
         };
         let cfg = get_override_cfg(&overrides);
         assert_eq!(

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -30,6 +30,9 @@ use xet_config::{Cfg, Level, XetConfigLoader};
 /// Custom env keys
 const XET_NO_SMUDGE_ENV: &str = "XET_NO_SMUDGE";
 
+/// Custom env keys
+const XET_DISABLE_VERSION_CHECK: &str = "XET_DISABLE_VERSION_CHECK";
+
 /// The configuration for the Xet Client Application. This struct represents the resolved and
 /// validated config to be used by the Xet client.
 ///
@@ -68,6 +71,7 @@ pub struct XetConfig {
     pub user: UserSettings,
     pub axe: AxeSettings,
     pub force_no_smudge: bool,
+    pub disable_version_check: bool,
     pub origin_cfg: Cfg,
 }
 
@@ -91,6 +95,7 @@ impl XetConfig {
             summarydb: Default::default(),
             staging_path: None,
             force_no_smudge: false,
+            disable_version_check: true,
             origin_cfg: Cfg::with_default_values(),
         }
     }
@@ -244,6 +249,7 @@ impl XetConfig {
             summarydb: Default::default(),
             staging_path: None,
             force_no_smudge: (!active_cfg.smudge.unwrap_or(true)),
+            disable_version_check: false,
             origin_cfg: active_cfg,
         })
     }
@@ -256,7 +262,7 @@ impl XetConfig {
     fn try_with_repo_info(
         self,
         repo_info: &RepoInfo,
-        overrides: Option<CliOverrides>,
+        overrides: &Option<CliOverrides>,
     ) -> Result<Self, ConfigError> {
         Ok(match repo_info.maybe_git_path.as_ref() {
             Some(repo_path) => {
@@ -277,8 +283,10 @@ impl XetConfig {
                     Some(merkledb_v2_session) => merkledb_v2_session.clone(),
                     None => git_path.join(MERKLEDB_V2_SESSION_PATH_SUBDIR),
                 };
-                let smudge_query_policy =
-                    overrides.map(|x| x.smudge_query_policy).unwrap_or_default();
+                let smudge_query_policy = overrides
+                    .as_ref()
+                    .map(|x| x.smudge_query_policy)
+                    .unwrap_or_default();
 
                 let summarydb = git_path.join(SUMMARIES_PATH_SUBDIR);
                 let staging_path = git_path.join(CAS_STAGING_SUBDIR);
@@ -289,6 +297,7 @@ impl XetConfig {
                     .try_with_summarydb(summarydb)?
                     .try_with_staging_path(staging_path)?
                     .try_with_smudge_query_policy(smudge_query_policy)?
+                    .try_with_version_check_policy(overrides)?
             }
             None => self,
         })
@@ -381,6 +390,30 @@ impl XetConfig {
         self.staging_path = Some(staging_path);
         Ok(self)
     }
+
+    fn try_with_version_check_policy(
+        mut self,
+        overrides: &Option<CliOverrides>,
+    ) -> Result<Self, ConfigError> {
+        if let Some(ovr) = overrides {
+            if ovr.disable_version_check {
+                self.disable_version_check = true;
+            }
+        }
+
+        if self.disable_version_check || no_version_check_from_env() {
+            self.disable_version_check = true;
+        }
+
+        Ok(self)
+    }
+}
+
+fn no_version_check_from_env() -> bool {
+    match std::env::var_os(XET_DISABLE_VERSION_CHECK) {
+        Some(v) => v != "0",
+        None => false,
+    }
 }
 
 /// Returns true if XET_NO_SMUDGE=1 is set in the environment
@@ -447,7 +480,7 @@ fn cfg_to_xetconfig_with_repoinfo(
     // via the repo info.
     XetConfig::try_from_cfg(working_cfg, &repo_info)?
         .with_origin_cfg(original_cfg)
-        .try_with_repo_info(&repo_info, overrides)
+        .try_with_repo_info(&repo_info, &overrides)
 }
 
 /// Converts a Cfg to a XetConfig, applying any profile and overrides to the config.
@@ -840,6 +873,7 @@ mod config_create_tests {
             user_name: None,
             user_token: None,
             user_email: None,
+            disable_version_check: true,
             user_login_id: None,
         };
         let config = cfg_to_xetconfig(

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -428,7 +428,7 @@ fn no_version_check_from_env() -> bool {
         Some(v) => v != "0",
         None => false,
     }
-}    
+}
 
 /// Returns true if XET_NO_SMUDGE=1 is set in the environment
 fn no_smudge_from_env() -> bool {

--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -105,7 +105,7 @@ pub enum GitXetRepoError {
 
     #[error("Repo Salt Unavailable: {0}")]
     RepoSaltUnavailable(String),
-    
+
     #[error("Lazy Config Error : {0}")]
     LazyConfigError(#[from] LazyError),
 }

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -677,6 +677,7 @@ impl GitRepo {
                 info!(".gitattributes file contains locking tag, refusing to alter.");
 
                 if force_write_gitattributes {
+                    eprintln!("ERROR: Cannot change .gitattributes; file content is locked.  To update the file, remove the line containing \"XET LOCK\" and rerun the operation.");
                     error!("Cannot change .gitattributes; file content is locked.  To update the file, remove the line containing \"XET LOCK\" and rerun the operation.");
                 }
 
@@ -692,7 +693,8 @@ impl GitRepo {
                         .take(GITATTRIBUTES_CONTENT.matches('\n').count())
                         .all(|line| GITATTRIBUTES_TEST_REGEX.is_match(line.trim()))
                     {
-                        warn!(".gitattributes file written, but contains non-xet content.  To update this file, run `git xet init` to force writing out the file.  To silence this warning, add the comment \"# XET LOCK\" at the top of the .gitattributes file.");
+                        warn!(".gitattributes file written, but contains non-xet content.");
+                        eprintln!("WARNING: .gitattributes file written, but contains non-xet content.  To update this file, run `git xet init` to force writing out the file.  To silence this warning, add the comment \"# XET LOCK\" at the top of the .gitattributes file.");
                     }
                     return Ok(false);
                 }

--- a/rust/gitxetcore/src/lib.rs
+++ b/rust/gitxetcore/src/lib.rs
@@ -26,6 +26,7 @@ pub mod standalone_pointer;
 pub mod stream;
 pub mod summaries;
 pub mod summaries_plumb;
+pub mod upgrade_checks;
 pub mod user;
 mod utils;
 pub mod xetmnt;

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -44,7 +44,7 @@ fn get_critical_text() -> String {
 }
 
 fn get_version_info_filename() -> PathBuf {
-    let version_check_filename = match std::env::var("XET_VERSION_CHECK_FILENAME") {
+    let version_check_filename = match std::env::var("XET_UPGRADE_CHECK_FILENAME") {
         Ok(v) => v,
         Err(_) => VERSION_CHECK_FILENAME_HOME.to_owned(),
     };

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -287,7 +287,7 @@ impl VersionCheckInfo {
                     continue;
                 };
 
-                if !version_is_newer(&version, &self.local_version) {
+                if !version_is_newer(version, &self.local_version) {
                     // Skip any versions this one or later as they are in descending order;
                     // no need to worry about them.
                     break;

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -1,0 +1,394 @@
+use std::path::{Path, PathBuf};
+
+use crate::constants::CURRENT_VERSION;
+use chrono::{DateTime, Utc};
+use reqwest::{self, Client};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info, warn};
+use version_compare::{self, Cmp};
+
+const GITHUB_REPO_OWNER: &'static str = "xetdata";
+const GITHUB_REPO_NAME: &'static str = "xet-tools";
+const VERSION_CHECK_FILENAME_HOME: &'static str = ".xet/version_check_info";
+
+/// The notification time for an update in seconds
+const NEW_VERSION_NOTIFICATION_INTERVAL: u64 = 24 * 60 * 60;
+
+/// The notification time for a critical update in seconds
+const NEW_CRITICAL_VERSION_NOTIFICATION_INTERVAL: u64 = 2 * 60 * 60;
+
+// The interval in which to compare
+const VERSION_CHECK_INTERVAL: u64 = 24 * 60 * 60;
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+    body: String,
+}
+
+fn version_is_newer(other_version: &str, current_version: &str) -> bool {
+    version_compare::compare(other_version, current_version)
+        .map_err(|e| {
+            error!("Error comparing version strings {other_version} with {current_version}");
+            e
+        })
+        .unwrap_or(Cmp::Lt)
+        == Cmp::Gt
+}
+
+fn get_version_info_filename() -> PathBuf {
+    let version_check_filename = match std::env::var("XET_VERSION_CHECK_FILENAME") {
+        Ok(v) => v,
+        Err(_) => VERSION_CHECK_FILENAME_HOME.to_owned(),
+    };
+
+    if let Some(mut path) = dirs::home_dir() {
+        path.push(version_check_filename);
+        return path;
+    }
+
+    if let Some(mut path) = dirs::cache_dir() {
+        path.push(version_check_filename);
+        return path;
+    }
+
+    // Guess it's just the local directory?
+    PathBuf::from(version_check_filename)
+}
+
+/// Queries the github releases API to get the latest release of the xet client.
+pub async fn get_newer_client_release_versions(
+    local_version: &str,
+    remote_repo_name: &str,
+) -> Option<Vec<(String, String)>> {
+    // Build the URL
+    let url =
+        format!("https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases");
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        "XetData: xet-tools".parse().unwrap(),
+    );
+    headers.insert(
+        reqwest::header::ACCEPT,
+        "application/vnd.github.v3+json".parse().unwrap(),
+    );
+
+    let client = Client::new();
+    // Send the GET request
+    let Ok(response) = client.get(&url).headers(headers).send().await.map_err(|e|
+        {
+            info!("get_latest_client_release_version: Version check query returned error: {e:?}");
+            e
+        }) else { return None; };
+
+    // Ensure the request was successful
+    if let Ok(response) = response.error_for_status().map_err(|e| {
+        info!("get_latest_client_release_version: Server returned error: {e:?}");
+        e
+    }) {
+        let Ok(releases) = response.json::<Vec<Release>>().await.map_err(|e| {
+
+            info!("Error parsing info for response query as json: {e:?}");
+            e
+        }) else {return None; } ;
+
+        let mut newer_releases = Vec::new();
+
+        // Check for all the releases that compare newer to this version string.
+        for release in releases {
+            let version_tag = release.tag_name.clone();
+
+            if version_is_newer(&version_tag, local_version) {
+                newer_releases.push((version_tag, release.body));
+            } else {
+                break;
+            }
+        }
+
+        Some(newer_releases)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionCheckInfo {
+    latest_version: String,
+    contains_critical_fix: bool,
+    query_time: DateTime<Utc>,
+    inform_time: Option<DateTime<Utc>>,
+
+    #[serde(skip)]
+    version_check_filename: PathBuf,
+
+    #[serde(skip)]
+    local_version: String,
+
+    #[serde(skip)]
+    remote_repo_name: String,
+}
+
+impl Default for VersionCheckInfo {
+    fn default() -> Self {
+        Self {
+            latest_version: Default::default(),
+            contains_critical_fix: false,
+            query_time: Default::default(),
+            inform_time: None,
+            version_check_filename: get_version_info_filename(),
+            local_version: CURRENT_VERSION.to_owned(),
+            remote_repo_name: GITHUB_REPO_NAME.to_owned(),
+        }
+    }
+}
+
+impl VersionCheckInfo {
+    fn known_new_release(&self) -> bool {
+        version_is_newer(&self.latest_version, &self.local_version)
+    }
+
+    pub fn notify_user_if_appropriate(&mut self) {
+        if self.known_new_release() {
+            let mut notification_happened = false;
+
+            if self.contains_critical_fix {
+                if self.inform_age_in_seconds().unwrap_or(u64::MAX)
+                    >= NEW_CRITICAL_VERSION_NOTIFICATION_INTERVAL
+                {
+                    eprintln!("\n\n**CRITICAL:**\nA new version of the Xet client tools, {}, is available at https://github.com/xetdata/xet-tools/releases and contains a critical bug fix from your current version.  Upgrading to this release immediately is strongly recommended.\n\n", self.latest_version);
+                    notification_happened = true;
+                }
+            } else {
+                if self.inform_age_in_seconds().unwrap_or(u64::MAX)
+                    >= NEW_VERSION_NOTIFICATION_INTERVAL
+                {
+                    eprintln!("\nA new version of the Xet client tools, {}, is available at https://github.com/xetdata/xet-tools/releases.\n",
+                      self.latest_version);
+                    notification_happened = true;
+                }
+            }
+
+            if notification_happened {
+                self.inform_time = Some(Utc::now());
+                self.save();
+            }
+        }
+    }
+
+    pub fn query_age_in_seconds(&self) -> u64 {
+        self.query_time
+            .signed_duration_since(Utc::now())
+            .num_seconds()
+            .max(0) as u64
+    }
+
+    pub fn inform_age_in_seconds(&self) -> Option<u64> {
+        if let Some(t) = self.inform_time {
+            Some(t.signed_duration_since(Utc::now()).num_seconds().max(0) as u64)
+        } else {
+            None
+        }
+    }
+
+    fn load_from_file(version_check_filename: &Path) -> Option<Self> {
+        let Ok(file_contents) = std::fs::read_to_string(&version_check_filename).map_err(|e| {
+                warn!("Error reading version file {version_check_filename:?}: {e:?})");
+                e
+            }) else {
+                return None;
+            };
+
+        if let Ok(mut vci) = serde_json::from_str::<VersionCheckInfo>(&file_contents).map_err(|e| {
+            warn!("Error decoding version file contents from {version_check_filename:?}: {e:?})");
+            e
+        }) {
+            vci.version_check_filename = version_check_filename.to_path_buf();
+            Some(vci)
+        } else {
+            None
+        }
+    }
+
+    fn save(&self) {
+        if let Some(p) = self.version_check_filename.parent() {
+            if !p.exists() {
+                let _ = std::fs::create_dir_all(p);
+            }
+        }
+
+        // Now, save out the information here.
+        if let Ok(json_string) = serde_json::to_string_pretty(&self).map_err(|e| {
+            warn!("Error serializing version info to JSON: {:?}", e);
+            e
+        }) {
+            let _ = std::fs::write(&self.version_check_filename, json_string).map_err(|e| {
+                warn!(
+                    "Error writing current version info to file to {:?}: {e:?}",
+                    self.version_check_filename
+                );
+                e
+            });
+        }
+    }
+
+    async fn refresh(&mut self) -> bool {
+        // OK, go and retrieve the information; the current file is either out of date or so
+        let Some(new_versions) = get_newer_client_release_versions(&self.local_version, &self.remote_repo_name).await else {
+        // Return now without updating the known version file.
+        info!("Error retrieving new release informaition; ignoring version check."); 
+        return false;
+    };
+
+        let has_new_version = !new_versions.is_empty();
+
+        // Does a newer version exist with a critical bugfix in it?
+        self.latest_version = if has_new_version {
+            new_versions[0].0.clone()
+        } else {
+            self.local_version.to_owned()
+        };
+
+        self.
+               contains_critical_fix = // False if new_version is empty 
+        if has_new_version { new_versions
+            .iter()
+            .any(|(_tag, notes)| notes.contains("CRITICAL")) } else { false };
+
+        self.query_time = Utc::now();
+
+        info!("Successfully perfermed new version check: {self:?}");
+
+        true
+    }
+
+    /// For testing
+    pub fn construct_with_options(
+        local_version: &str,
+        remote_repo_name: &str,
+        version_check_filename: &Path,
+    ) -> Self {
+        Self {
+            local_version: local_version.to_owned(),
+            remote_repo_name: remote_repo_name.to_owned(),
+            version_check_filename: version_check_filename.to_path_buf(),
+            ..Default::default()
+        }
+    }
+
+    pub async fn load_or_query_impl(mut self) -> Option<Self> {
+        loop {
+            // Go through all the conditions that allow us to skip querying the endpoint.
+            // Yes, it means a nested loop, but I argue it's okay here.
+
+            // Does the file exist?
+            if !self.version_check_filename.exists() {
+                break; // query and refresh
+            }
+
+            // Is the file old?
+            let Ok(metadata) = std::fs::metadata(&self.version_check_filename).map_err(|e| {
+            warn!("Warning: Error loading metadata on {:?}: {e:?}", &self.version_check_filename);
+            e
+        } ) else {
+            break; // query and refresh
+            };
+
+            let Ok(modified_time) = metadata.modified() else {
+            break; // query and refresh
+            };
+
+            if modified_time.elapsed().unwrap_or_default().as_secs() >= VERSION_CHECK_INTERVAL {
+                break; // query and refresh
+            }
+
+            let Some(vci) = Self::load_from_file(&self.version_check_filename) else {
+            break; // query and refresh
+            };
+
+            // Now see if the elapsed time since vci.query_time is greater than VERSION_CHECK_INTERVAL
+            if vci.query_age_in_seconds() < VERSION_CHECK_INTERVAL {
+                return Some(vci);
+            } else {
+                break; // query and refresh
+            }
+        }
+
+        if self.refresh().await {
+            self.save();
+            Some(self)
+        } else {
+            None
+        }
+    }
+
+    pub async fn load_or_query() -> Option<Self> {
+        Self::default().load_or_query_impl().await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::constants::CURRENT_VERSION;
+    use more_asserts::*;
+
+    #[tokio::test]
+    async fn test_retrieve_new_version_with_upgrade() {
+        // Create a temp directory
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let version_check_filename = tmp_dir.path().join("version_check_filename");
+
+        let Some(mut version_info) = VersionCheckInfo::construct_with_options("v0.0.0", "xet-tools", &version_check_filename).load_or_query_impl().await else {
+            panic!("version check returned None when it should have returned version info; internet may not be available.");
+        };
+
+        assert!(version_info.known_new_release());
+
+        assert!(version_info.inform_age_in_seconds().is_none());
+        version_info.notify_user_if_appropriate();
+        assert_lt!(version_info.inform_age_in_seconds().unwrap(), 10);
+
+        // Now, pretend we've upgraded a single version, and see what has happened.  Now it should load it from the file.
+        let Some(version_info_2)
+            = VersionCheckInfo::construct_with_options(
+                "v0.0.0", "xet-tools", &version_check_filename).load_or_query_impl().await else {
+
+            panic!("version check 2 returned None when it should have returned version info.");
+        };
+
+        assert_eq!(version_info.latest_version, version_info_2.latest_version);
+        assert_eq!(version_info.query_time, version_info_2.query_time);
+        assert_eq!(
+            version_info.contains_critical_fix,
+            version_info_2.contains_critical_fix
+        );
+        assert_eq!(version_info.inform_time, version_info_2.inform_time);
+
+        // Now, pretend the user has upgraded.
+        let Some(version_info)
+             = VersionCheckInfo::construct_with_options(
+                    CURRENT_VERSION, "xet-tools", &version_check_filename).load_or_query_impl().await else {
+
+            panic!("Last version check returned None when it should have returned version info.");
+        };
+
+        assert!(!version_info.known_new_release());
+        assert_lt!(version_info.query_age_in_seconds(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_new_version_no_upgrade() {
+        // Create a temp directory
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let version_check_filename = tmp_dir.path().join("version_check_filename");
+
+        // Now, query when there's no results
+        let Some(version_info) = VersionCheckInfo::construct_with_options(CURRENT_VERSION, "xet-tools", &version_check_filename).load_or_query_impl().await else {
+            panic!("Last version check returned None when it should have returned version info.");
+        };
+
+        assert!(!version_info.known_new_release());
+    }
+}

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -157,14 +157,15 @@ impl VersionCheckInfo {
                 if self.inform_age_in_seconds().unwrap_or(u64::MAX)
                     >= NEW_CRITICAL_VERSION_NOTIFICATION_INTERVAL
                 {
-                    eprintln!("\n\n**CRITICAL:**\nA new version of the Xet client tools, {}, is available at https://github.com/xetdata/xet-tools/releases and contains a critical bug fix from your current version.  Upgrading to this release immediately is strongly recommended.\n\n", self.latest_version);
+                    eprintln!("\n\n**CRITICAL:**\nA new version of the Xet client tools, {}, is available at https://github.com/xetdata/xet-tools/releases and contains a critical bug fix from your current version.  It is strongly recommended to upgrade to this release immediately.\n\n",
+                              self.latest_version);
                     notification_happened = true;
                 }
             } else if self.inform_age_in_seconds().unwrap_or(u64::MAX)
                 >= NEW_VERSION_NOTIFICATION_INTERVAL
             {
                 eprintln!("\nA new version of the Xet client tools, {}, is available at https://github.com/xetdata/xet-tools/releases.\n",
-                      self.latest_version);
+                          self.latest_version);
                 notification_happened = true;
             }
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -36,6 +36,13 @@ fn version_is_newer(other_version: &str, current_version: &str) -> bool {
         == Cmp::Gt
 }
 
+fn get_critical_text() -> String {
+    match std::env::var("_XET_TEST_VERSION_CHECK_CRITICAL_PATTERN") {
+        Ok(v) => v,
+        Err(_) => "CRITICAL".to_owned(),
+    }
+}
+
 fn get_version_info_filename() -> PathBuf {
     let version_check_filename = match std::env::var("XET_VERSION_CHECK_FILENAME") {
         Ok(v) => v,
@@ -248,9 +255,12 @@ impl VersionCheckInfo {
 
         self.
                contains_critical_fix = // False if new_version is empty 
-        if has_new_version { new_versions
+        if has_new_version { 
+            let critical_text = get_critical_text();  
+            
+            new_versions
             .iter()
-            .any(|(_tag, notes)| notes.contains("CRITICAL")) } else { false };
+            .any(|(_tag, notes)| notes.contains(&critical_text)) } else { false };
 
         self.query_time = Utc::now();
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -147,7 +147,7 @@ impl Default for VersionCheckInfo {
             query_time: Default::default(),
             inform_time: DateTime::<Utc>::MIN_UTC,
             version_check_filename: get_version_info_filename(),
-            local_version: get_current_version().to_owned(),
+            local_version: get_current_version(),
             remote_repo_name: GITHUB_REPO_NAME.to_owned(),
         }
     }


### PR DESCRIPTION
This PR adds a version check around many different git xet operations.  
- If the release notes on any version between the latest released version and the current version contain the letters CRITICAL, the user will be asked to upgrade every 2 hours, with a urgent warning:

```
**CRITICAL:**
A new version of the Xet client tools, {version}, is available at https://github.com/xetdata/xet-tools/releases and contains a critical bug fix from your current version.  Upgrading to this release immediately is strongly recommended.
```

- Otherwise every 24 hours the user will see:

```
A new version of the Xet client tools, {version}, is available at https://github.com/xetdata/xet-tools/releases.
```

Checking is done by polling github.com/xetdata/xet-tools/releases.


