### PR TITLE
On implicit init, sync merkledb stuff too.

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_file_tools.rs
+++ b/rust/gitxetcore/src/git_integration/git_file_tools.rs
@@ -305,8 +305,8 @@ mod git_file_tools_tests {
 
     use crate::git_integration::git_repo::test_tools::TestRepo;
 
-    #[test]
-    fn test_listing() -> Result<()> {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_listing() -> Result<()> {
         let tr = TestRepo::new()?;
 
         tr.test_consistent()?;
@@ -397,8 +397,8 @@ mod git_file_tools_tests {
         Ok(())
     }
 
-    #[test]
-    fn test_listing_odd_names() -> Result<()> {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_listing_odd_names() -> Result<()> {
         let tr = TestRepo::new()?;
 
         tr.test_consistent()?;

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1353,7 +1353,10 @@ impl GitRepo {
         })
         .map_err(convert_parallel_error)?;
 
-        debug!("XET sync_notes_to_dbs_implicit: merging summaries");
+        // Annoyingly, merging summaries is not going to work here.  The reason is
+        // that libgit2 cannot be used inside the block_on_async_function call.  Rather annoying.
+        // This just means that summaries will end up being computed locally if they are needed
+        // rather than pulled from the remote, which isn't that bad.
 
         Ok(())
     }


### PR DESCRIPTION
Likely needed for some pull workflows.