### PR TITLE
Fixed for mdb guard note setting logic.

### DIFF
--- a/rust/gitxet/tests/integration_tests/test_get_xet_init.sh
+++ b/rust/gitxet/tests/integration_tests/test_get_xet_init.sh
@@ -31,6 +31,8 @@ fi
 # running init on the same version should succeed
 git xet init -m 2 --force
 [[ ! -z $(git xet merkledb version | grep "2") ]] || die "merkledb version is not 2"
+[[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 guard notes not set"
+[[ -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes not set"
 
 create_data_file data.dat 10000
 git add data.dat
@@ -39,6 +41,8 @@ git commit -a -m "Adding data."
 # init on the same version with repo not empty should succeed
 git xet init -m 2 --force
 [[ ! -z $(git xet merkledb version | grep "2") ]] || die "merkledb version is not 2"
+[[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 guard notes not set"
+[[ -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes not set"
 
 popd
 
@@ -54,6 +58,7 @@ git commit -a -m "Adding data."
 # check version is 1
 [[ ! -z $(git xet merkledb version | grep "1") ]] || die "merkledb version is not 1"
 [[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 ref notes not set"
+[[ ! -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes set"
 
 # upgrade with repo not empty should fail (check lobal db)
 if [[ -z $(git xet init -m 2 --force 2>&1 | grep "Merkle DB is not empty") ]]; then
@@ -71,6 +76,8 @@ rm .git/xet/merkledb.db
 
 # check version is 1
 [[ ! -z $(git xet merkledb version | grep "1") ]] || die "merkledb version is not 1"
+[[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 ref notes not set"
+[[ ! -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes set"
 
 # upgrade when repo not empty should fail (check db in notes)
 if [[ -z $(git xet init -m 2 --force 2>&1 | grep "Merkle DB is not empty") ]]; then

--- a/rust/gitxet/tests/integration_tests/test_get_xet_init.sh
+++ b/rust/gitxet/tests/integration_tests/test_get_xet_init.sh
@@ -8,6 +8,7 @@ git xet install
 
 remote=$(create_bare_repo)
 
+# test uninitialized -> V1 -> V2 -> V1 -> V2 -> add data -> V2
 git clone $remote repo_1
 
 pushd repo_1
@@ -17,6 +18,7 @@ git xet init -m 1 --force
 # check version is 1
 [[ ! -z $(git xet merkledb version | grep "1") ]] || die "merkledb version is not 1"
 [[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 ref notes not set"
+[[ ! -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes set"
 
 # upgrade to v2 is Ok when v1 is empty
 git xet init -m 2 --force
@@ -46,6 +48,7 @@ git xet init -m 2 --force
 
 popd
 
+# test uninitialized -> V1 -> add data -> V2
 git clone $remote repo_2
 pushd repo_2
 
@@ -69,6 +72,7 @@ git push origin main
 
 popd
 
+# test V1 with data -> V2
 git clone $remote repo_3
 pushd repo_3
 
@@ -83,5 +87,31 @@ rm .git/xet/merkledb.db
 if [[ -z $(git xet init -m 2 --force 2>&1 | grep "Merkle DB is not empty") ]]; then
     die "git-xet didn't block illegal action"
 fi
+
+popd
+
+# test uninitialized -> V2
+mkdir repo_4
+pushd repo_4
+
+git init
+git xet init -m 2 --force
+# check version is 2
+[[ ! -z $(git xet merkledb version | grep "2") ]] || die "merkledb version is not 2"
+[[ -e ./.git/refs/notes/xet/merkledb ]] || die "merkledb v1 guard notes not set"
+[[ -e ./.git/refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes not set"
+
+popd
+
+# test bare repo uninitialized -> V2
+mkdir repo_5
+pushd repo_5
+
+git init --bare
+git xet init -m 2 --force --bare
+# check version is 2
+[[ ! -z $(git xet merkledb version | grep "2") ]] || die "merkledb version is not 2"
+[[ -e ./refs/notes/xet/merkledb ]] || die "merkledb v1 guard notes not set"
+[[ -e ./refs/notes/xet/merkledbv2 ]] || die "merkledb v2 notes not set"
 
 popd

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1706,9 +1706,8 @@ impl GitRepo {
             .map_err(GitXetRepoError::from);
         }
 
-        // Only need to install guard notes when this is an upgrade.
-        if self.mdb_version < *version && self.mdb_version != ShardVersion::Uninitialized {
-            // Make sure Merkle DB is empty before set verison.
+        if self.mdb_version < *version {
+            // Make sure Merkle DB is empty before set version.
             let mut v = *version;
             while let Some(lower_version) = v.get_lower() {
                 if !self.check_merkledb_is_empty(&lower_version).await? {


### PR DESCRIPTION
There is an error in which the MerkleDB version of a repo created by the new client is improperly detected by an old client.  This fixes that issue. 