### PR TITLE
disable command path not implemented

### DIFF
--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -250,7 +250,7 @@ pub async fn handle_merkledb_plumb_command(
             ShardVersion::Uninitialized => {
                 error!("Repo is not initialized for Xet.");
                 Err(GitXetRepoError::RepoUninitialized(format!(
-                    "Diff: Shard version config not detected in repo={:?}.",
+                    "Print: Shard version config not detected in repo={:?}.",
                     cfg.repo_path()
                 )))
             }


### PR DESCRIPTION
No actual functionality change. Just disable command paths in `git xet merkledb` that are not implemented.