### PR TITLE
Logging File improvements.

### DIFF
--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -12,7 +12,7 @@ export HOME=$PWD
 # Set up logging
 export XET_LOG_LEVEL=debug
 export XET_LOG_FORMAT=compact
-export XET_LOG_PATH=$HOME/run_log.txt
+export XET_LOG_PATH="$HOME/logs/log_{timestamp}_{pid}.txt"
 
 # support both Mac OS and Linux for these scripts
 if hash md5 2>/dev/null; then 

--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -66,12 +66,10 @@ impl TryFrom<Option<&Log>> for LogSettings {
                 } else if !config::util::can_write(path) {
                     return Err(LogPathReadOnly(path.to_path_buf()));
                 }
-            } else {
-                if let Some(p) = path.parent() {
-                    if !p.exists() {
-                        std::fs::create_dir_all(&p)
-                            .map_err(|_| ConfigError::LogPathReadOnly(path.to_path_buf()))?;
-                    }
+            } else if let Some(p) = path.parent() {
+                if !p.exists() {
+                    std::fs::create_dir_all(p)
+                        .map_err(|_| ConfigError::LogPathReadOnly(path.to_path_buf()))?;
                 }
             }
             Ok(())
@@ -84,12 +82,12 @@ impl TryFrom<Option<&Log>> for LogSettings {
                     None => Level::WARN,
                 };
                 let path = match log.path.as_ref() {
-                    Some(path) if !config::util::is_empty(&path) => {
+                    Some(path) if !config::util::is_empty(path) => {
                         let mut path_s = path.to_str().unwrap_or_default().to_owned();
 
                         if path_s.contains("{timestamp}") {
                             path_s = path_s
-                                .replace("{timestamp}", &Utc::now().to_rfc3339().replace(":", "-"));
+                                .replace("{timestamp}", &Utc::now().to_rfc3339().replace(':', "-"));
                         }
 
                         if path_s.contains("{pid}") {


### PR DESCRIPTION
Currently, the log files are written to a fixed path.  However, with this configuration, it means that the operation logs saved in the integration tests overwrite previous operations, making debugging things with multiple invocations of git difficult.   This PR adds "{timestamp}" and "{pid}" fields to the log path, which allows XET_LOG_PATH to be generate unique file paths for each process log. 

For example,

```
export XET_LOG_PATH="$HOME/logs/log_{timestamp}_{pid}.txt"
```

could result in the log file 

```
logs/log_2023-10-19T15-28-14.580960+00-00_71376.txt
```

In addition, logging now ensures that the directory the log would be written to exists, and that relative paths work correctly.  
