### PR TITLE
Ensure git will not block on waiting for user input.

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -66,6 +66,8 @@ fn spawn_git_command(
         &env
     );
 
+    // Using idea from https://stackoverflow.com/questions/30776520/closing-stdout-or-stdin
+
     // Disable stdin so it doesn't hang silently in the background.
     cmd.stdin(std::process::Stdio::piped());
 

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::path::PathBuf;
+use std::process::Child;
 use std::process::Command;
 use std::str::FromStr;
 use tracing::error;
@@ -29,12 +30,13 @@ pub fn get_git_executable() -> &'static str {
 }
 
 /// Sets up the git command to run how the caller chooses.
-fn setup_git_command(
+fn spawn_git_command(
     base_directory: Option<&PathBuf>,
     command: &str,
     args: &[&str],
     env: Option<&[(&str, &str)]>,
-) -> Result<Command> {
+    capture_output: bool,
+) -> Result<Child> {
     let git_executable = get_git_executable();
 
     let mut cmd = Command::new(git_executable);
@@ -62,7 +64,25 @@ fn setup_git_command(
         &env
     );
 
-    Ok(cmd)
+    // Disable stdin so it doesn't hang silently in the background.
+    cmd.stdin(std::process::Stdio::piped());
+
+    // Set up the command to capture or pass through stdout and stderr
+    if capture_output {
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+    } else {
+        cmd.stdout(std::process::Stdio::inherit());
+        cmd.stderr(std::process::Stdio::inherit());
+    }
+
+    // Spawn the child
+    let mut child = cmd.spawn()?;
+
+    // Immediately drop the writing end of the stdin pipe; if git attempts to wait on stdin, it will cause an error.
+    drop(child.stdin.take());
+
+    Ok(child)
 }
 
 /// Calls git directly, piping both stdout and stderr through.  
@@ -87,9 +107,9 @@ pub fn run_git_captured(
         None => vec![("GCM_INTERACTIVE", "never")],
     };
 
-    let mut cmd = setup_git_command(base_directory, command, args, Some(&env))?;
+    let child = spawn_git_command(base_directory, command, args, Some(&env), true)?;
 
-    let out = cmd.output()?;
+    let out = child.wait_with_output()?;
 
     let res_stdout = std::str::from_utf8(&out.stdout[..]).unwrap_or("<Binary Data>");
     let res_stderr = std::str::from_utf8(&out.stderr[..]).unwrap_or("<Binary Data>");
@@ -142,9 +162,9 @@ pub fn run_git_passthrough(
     check_result: bool,
     env: Option<&[(&str, &str)]>,
 ) -> Result<i32> {
-    let mut cmd = setup_git_command(base_directory, command, args, env)?;
+    let mut child = spawn_git_command(base_directory, command, args, env, false)?;
 
-    let status = cmd.status()?;
+    let status = child.wait()?;
 
     let ret = status.code();
 


### PR DESCRIPTION
With integrating git with different endpoints, git will sometimes block on waiting for user input when the authentication configurations are not correct.  Since the integration methods probe several connection methods (https, ssh), this causes an issue.   This PR prevents this, and the git process will error out in such a case.  