### PR TITLE
Downgrade summary load error to info

### DIFF
--- a/rust/gitxetcore/src/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries_plumb.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, info};
 
 use crate::config::XetConfig;
 use crate::{
@@ -180,7 +180,7 @@ async fn merge_db_from_git(
             .map(|(_, blob)| async move {
                 if !blob.is_empty() {
                     bincode::deserialize::<WholeRepoSummary>(&blob).map_err(|e| {
-                        error!("Error unpacking file content summary information; discarding (Error = {:?})", &e);
+                        info!("Error unpacking file content summary information; discarding (Error = {:?})", &e);
                         e
                     }).unwrap_or_default()
                 } else {


### PR DESCRIPTION
After https://github.com/xetdata/xet-core/pull/154, the summary in git notes is no longer compatible with the struct layout for Serde serialization, which is by design (summaries will be regenerated). Since this is by design, this fix downgrades the error to an info message.