### PR TITLE
Adding printing path and logging the invocation command.

### DIFF
--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -13,6 +13,7 @@ export HOME=$PWD
 export XET_LOG_LEVEL=debug
 export XET_LOG_FORMAT=compact
 export XET_LOG_PATH="$HOME/logs/log_{timestamp}_{pid}.txt"
+export XET_PRINT_LOG_FILE_PATH=1
 
 # support both Mac OS and Linux for these scripts
 if hash md5 2>/dev/null; then 

--- a/rust/gitxetcore/src/command.rs
+++ b/rust/gitxetcore/src/command.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand};
 use const_format::concatcp;
 use git_version::git_version;
+use itertools::Itertools;
 use opentelemetry::global::force_flush_tracer_provider;
 use tracing::{debug, info, Instrument};
 
@@ -360,6 +361,12 @@ impl XetApp {
             )?,
         };
         initialize_tracing_subscriber(&cfg)?;
+
+        // Log the command used to invoke this process.
+        info!(
+            "Xet invoked with {}",
+            std::env::args().map(|a| format!("\"{a}\"")).join(" ")
+        );
 
         Ok(XetApp {
             command: cli.command,

--- a/rust/gitxetcore/src/command.rs
+++ b/rust/gitxetcore/src/command.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand};
 use const_format::concatcp;
 use git_version::git_version;
-use itertools::Itertools;
 use opentelemetry::global::force_flush_tracer_provider;
 use tracing::{debug, info, Instrument};
 
@@ -32,8 +31,8 @@ use crate::command::visualization_dependencies::{
 use crate::constants::CURRENT_VERSION;
 
 use crate::axe::Axe;
-use crate::config::ConfigGitPathOption;
 use crate::config::XetConfig;
+use crate::config::{get_sanitized_invocation_command, ConfigGitPathOption};
 use crate::config_cmd::{handle_config_command, ConfigArgs};
 use crate::diff::{diff_command, DiffArgs};
 use crate::errors;
@@ -365,7 +364,7 @@ impl XetApp {
         // Log the command used to invoke this process.
         info!(
             "Xet invoked with {}",
-            std::env::args().map(|a| format!("\"{a}\"")).join(" ")
+            get_sanitized_invocation_command(false)
         );
 
         Ok(XetApp {
@@ -378,6 +377,10 @@ impl XetApp {
     pub async fn run(&self) -> errors::Result<()> {
         info!("Is Debug build: {:?}", is_debug_build());
         debug!("Config: {:?}", self.config);
+        info!(
+            "Running in directory {:?}",
+            std::env::current_dir().unwrap_or_default()
+        );
 
         let mut version_check_handle = None;
 

--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::config::util::get_sanitized_invocation_command;
 use crate::config::ConfigError;
 use crate::config::ConfigError::{LogPathNotFile, LogPathReadOnly};
 use atty::Stream;
@@ -102,7 +103,8 @@ impl TryFrom<Option<&Log>> for LogSettings {
                         validate_path(&path)?;
                         if std::env::var("XET_PRINT_LOG_FILE_PATH").unwrap_or("0".to_owned()) != "0"
                         {
-                            eprintln!("Xet: Writing logs to file {path:?}");
+                            let prog = get_sanitized_invocation_command(true);
+                            eprintln!("Xet: ({prog}) Writing logs to file {path:?}",);
                         }
                         Some(path)
                     }

--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -100,6 +100,10 @@ impl TryFrom<Option<&Log>> for LogSettings {
                         let path = path.canonicalize().unwrap_or(path);
 
                         validate_path(&path)?;
+                        if std::env::var("XET_PRINT_LOG_FILE_PATH").unwrap_or("0".to_owned()) != "0"
+                        {
+                            eprintln!("Xet: Writing logs to file {path:?}");
+                        }
                         Some(path)
                     }
                     _ => None,

--- a/rust/gitxetcore/src/config/mod.rs
+++ b/rust/gitxetcore/src/config/mod.rs
@@ -7,6 +7,7 @@ pub use git_path::{remote_to_repo_info, ConfigGitPathOption, RepoInfo};
 pub use log::{LogFormat, LogSettings};
 pub use upstream_config::*;
 pub use user::{UserIdType, UserSettings};
+pub use util::get_sanitized_invocation_command;
 pub use util::{get_global_config, get_local_config};
 pub use xet::{create_config_loader, XetConfig};
 

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -147,15 +147,16 @@ pub fn get_sanitized_invocation_command(strip_program_path: bool) -> String {
         })
         .unwrap_or_default();
 
-    let cwd = std::env::current_dir()
-        .unwrap_or_default()
-        .to_str()
-        .unwrap_or_default()
-        .to_owned();
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let cwd_str = cwd.to_str().unwrap_or_default();
 
     let subcommand: String = args
-        .map(|ee| {
-            let e = ee.strip_prefix(&cwd).unwrap_or(&ee);
+        .map(|mut e| {
+            if e.starts_with(cwd_str) {
+                if let Ok(e_rel) = PathBuf::from(&e).strip_prefix(&cwd) {
+                    e = e_rel.to_str().unwrap_or(&e).to_owned();
+                }
+            }
             if e.contains(' ') {
                 format!("\"{e}\"")
             } else {

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -160,7 +160,7 @@ pub fn get_sanitized_invocation_command(strip_program_path: bool) -> String {
             if e.contains(' ') {
                 format!("\"{e}\"")
             } else {
-                e.to_owned()
+                e
             }
         })
         .join(" ");


### PR DESCRIPTION
A simple update that: 
- If XET_PRINT_LOG_FILE_PATH, then the log path is dumped to stderr.
- After the log is set up, the invocation command of the program is logged as the first command. 