### PR TITLE
Updated logic and error message printing in probing github remote.

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_integration_plumb.rs
+++ b/rust/gitxetcore/src/git_integration/git_integration_plumb.rs
@@ -143,7 +143,9 @@ pub async fn handle_hook_plumb_command(
         HookCommand::PostCommitLFSHook => repo()?.post_commit_lfs_hook().await?,
 
         // Download direction
-        HookCommand::SyncRemoteToNotes(remote) => repo()?.sync_remote_to_notes(&remote.remote)?,
+        HookCommand::SyncRemoteToNotes(remote) => {
+            let _ = repo()?.sync_remote_to_notes(&remote.remote)?;
+        }
         HookCommand::SyncNotesToMerkleDB => repo()?.sync_notes_to_dbs().await?,
         HookCommand::SyncRemoteToMerkleDB(remote) => {
             repo()?.sync_remote_to_notes(&remote.remote)?;

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -378,10 +378,14 @@ impl GitRepo {
             for r in remotes.iter() {
                 s.sync_remote_to_notes(r)?;
 
-                if let Some(Some(remote_url)) = s.repo.find_remote(r).ok().map(|r| r.url().map(<_>::to_owned)) {
-                queried_urls.insert(remote_url);
+                if let Some(Some(remote_url)) = s
+                    .repo
+                    .find_remote(r)
+                    .ok()
+                    .map(|r| r.url().map(<_>::to_owned))
+                {
+                    queried_urls.insert(remote_url);
                 };
-
             }
 
             if let Some(upstream_repo) = &s.xet_config.upstream_xet_repo {
@@ -398,14 +402,14 @@ impl GitRepo {
                     let fetch_succeeded = s.sync_remote_to_notes_with_custom_destination(&remote_url, Some("_upstream_xet_repo_"),
                         ).map_err(|e| {
                             info!("GitRepo::open: Error while attempting to query upstream xet repo {remote_url} on initialization: {e:?}.  Attempting other urls.");
-                            e 
+                            e
                         } ).unwrap_or(false);
 
                     if fetch_succeeded {
                         info!("Succeeded in fetching remotes from destination {remote_url}, breaking.");
                         break;
                     }
-                } 
+                }
             }
 
             // Sync in the notes and mdb stuff as needed from all the remotes.


### PR DESCRIPTION
Updated how we probe github remotes: 
- If the remote URL formed from the .xet/config.toml file is one of the remotes, then just probe the remote, not both. 
- If one version of https or ssh succeeds, then don't probe the other one. 
- If there is an error, don't log an error -- just swallow it. 