### PR TITLE
.xet folder permission

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -77,7 +77,7 @@ snailquote = "0.3.1"
 ring = "0.16.20"
 humantime = "2.1.0"
 toml = "0.5"
-
+winapi = { version = "0.3", features = ["winerror", "winnt", "handleapi", "processthreadsapi", "securitybaseapi"] }
 normalize-path = "0.1.0"
 git-version = "0.3"
 const_format="0.2"

--- a/rust/gitxetcore/src/config/mod.rs
+++ b/rust/gitxetcore/src/config/mod.rs
@@ -17,6 +17,7 @@ mod env;
 mod errors;
 mod git_path;
 mod log;
+mod permission;
 mod upstream_config;
 mod user;
 mod util;

--- a/rust/gitxetcore/src/config/permission.rs
+++ b/rust/gitxetcore/src/config/permission.rs
@@ -4,6 +4,7 @@ use libc;
 use std::path::Path;
 #[cfg(windows)]
 use std::ptr;
+use tracing::warn;
 #[cfg(windows)]
 use winapi::{
     shared::winerror::ERROR_SUCCESS,
@@ -44,6 +45,7 @@ privileges may not be able to access this folder, causing them to fail. If this 
 please change the directory permissions accordingly.");
 
             eprintln!("{}", message.bright_blue());
+            warn!("Xet directory {path:?} created with elevated privileges");
         }
     }
 }

--- a/rust/gitxetcore/src/config/permission.rs
+++ b/rust/gitxetcore/src/config/permission.rs
@@ -1,0 +1,80 @@
+#[cfg(unix)]
+use libc;
+#[cfg(windows)]
+use std::ptr;
+#[cfg(windows)]
+use winapi::{
+    shared::winerror::ERROR_SUCCESS,
+    um::{
+        processthreadsapi::GetCurrentProcess,
+        processthreadsapi::OpenProcessToken,
+        securitybaseapi::GetTokenInformation,
+        winnt::{TokenElevation, HANDLE, TOKEN_ELEVATION, TOKEN_QUERY},
+    },
+};
+
+#[derive(Debug, Clone)]
+pub enum Permission {
+    Regular,
+    Elevated,
+}
+
+impl Permission {
+    pub fn current() -> Permission {
+        match is_elevated() {
+            false => Permission::Regular,
+            true => Permission::Elevated,
+        }
+    }
+
+    pub fn is_elevated(&self) -> bool {
+        match self {
+            Permission::Regular => false,
+            Permission::Elevated => true,
+        }
+    }
+}
+
+/// Checks if the program is run under elevated privilege
+
+fn is_elevated() -> bool {
+    // In a Unix-like environment, when a program is run with sudo,
+    // the effective user ID (euid) of the process is set to 0.
+    #[cfg(unix)]
+    return unsafe { libc::geteuid() == 0 };
+
+    #[cfg(windows)]
+    {
+        let mut token: HANDLE = ptr::null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+            return false;
+        }
+
+        let mut elevation: TOKEN_ELEVATION = unsafe { std::mem::zeroed() };
+        let mut return_length = 0;
+        let success = unsafe {
+            GetTokenInformation(
+                token,
+                TokenElevation,
+                &mut elevation as *mut _ as *mut _,
+                std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+                &mut return_length,
+            )
+        };
+
+        if success == 0 {
+            false
+        } else {
+            elevation.TokenIsElevated != 0
+        }
+    }
+}
+
+#[test]
+fn main() {
+    if is_elevated() {
+        println!("The program is running with elevated privileges.");
+    } else {
+        println!("The program is not running with elevated privileges.");
+    }
+}

--- a/rust/gitxetcore/src/config/permission.rs
+++ b/rust/gitxetcore/src/config/permission.rs
@@ -1,5 +1,7 @@
+use colored::Colorize;
 #[cfg(unix)]
 use libc;
+use std::path::Path;
 #[cfg(windows)]
 use std::ptr;
 #[cfg(windows)]
@@ -31,6 +33,17 @@ impl Permission {
         match self {
             Permission::Regular => false,
             Permission::Elevated => true,
+        }
+    }
+
+    pub fn check_path(&self, path: &Path) {
+        if self.is_elevated() && !path.exists() {
+            let message = format!("Warning: A xet command is running with elevated privileges. A xet metadata directory will be 
+created at {path:?} with elevated privileges. Future xet commands running with standard 
+privileges may not be able to access this folder, causing them to fail. If this is not desired, 
+please change the directory permissions accordingly.");
+
+            eprintln!("{}", message.bright_blue());
         }
     }
 }

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -5,6 +5,7 @@ use crate::config::cas::CasSettings;
 use crate::config::env::XetEnv;
 use crate::config::git_path::{ConfigGitPathOption, RepoInfo};
 use crate::config::log::LogSettings;
+use crate::config::permission::Permission;
 use crate::config::user::UserSettings;
 use crate::config::util;
 use crate::config::util::OptionHelpers;
@@ -78,6 +79,7 @@ pub struct XetConfig {
     pub lazy_config: Option<PathBuf>,
     pub origin_cfg: Cfg,
     pub upstream_xet_repo: Option<UpstreamXetRepo>,
+    pub permission: Permission,
 }
 
 // pub methods
@@ -104,6 +106,7 @@ impl XetConfig {
             lazy_config: None,
             origin_cfg: Cfg::with_default_values(),
             upstream_xet_repo: Default::default(),
+            permission: Permission::current(),
         }
     }
 
@@ -270,6 +273,7 @@ impl XetConfig {
             lazy_config: None,
             upstream_xet_repo: Default::default(),
             origin_cfg: active_cfg,
+            permission: Permission::current(),
         })
     }
 

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -255,6 +255,21 @@ pub fn create_config_loader() -> Result<XetConfigLoader, GitXetRepoError> {
 // very internal methods
 impl XetConfig {
     fn try_from_cfg(active_cfg: Cfg, repo_info: &RepoInfo) -> Result<Self, ConfigError> {
+        // Creation of the .xet folder happens below, check permission before it is created.
+        let permission = Permission::current();
+
+        let xet_home = dirs::home_dir()
+            .ok_or_else(|| ConfigError::HomePathUnknown)?
+            .join(".xet");
+
+        let path = if let Some(cache) = &active_cfg.cache {
+            cache.path.clone().unwrap_or(xet_home)
+        } else {
+            xet_home
+        };
+
+        permission.check_path(&path);
+
         Ok(Self {
             cas: active_cfg.cas.as_ref().try_into()?,
             cache: active_cfg.cache.as_ref().try_into()?,
@@ -273,7 +288,7 @@ impl XetConfig {
             lazy_config: None,
             upstream_xet_repo: Default::default(),
             origin_cfg: active_cfg,
-            permission: Permission::current(),
+            permission,
         })
     }
 

--- a/rust/xetblob/src/xet_repo_manager.rs
+++ b/rust/xetblob/src/xet_repo_manager.rs
@@ -51,6 +51,7 @@ impl XetRepoManager {
             path.push(GLOBAL_REPO_ROOT_PATH);
             path
         };
+        config.permission.check_path(&root_path);
         if root_path.exists() && !root_path.is_dir() {
             return Err(anyhow!(
                 "Path {root_path:?} exists but it shoud be a directory"


### PR DESCRIPTION
Warn on creation of xet folders with elevated privileges. Fix https://github.com/xetdata/xethub/issues/4119. Make the permission issue on xet folder more robust in a future PR.

Examples:
`sudo git xet clone`:
<img width="1041" alt="Screenshot 2023-10-25 at 10 52 17 AM" src="https://github.com/xetdata/xet-core/assets/4929549/d406bbf8-75fe-44e6-b9dc-375744646a3b">
`sudo xet cp`:
<img width="871" alt="Screenshot 2023-10-25 at 10 52 38 AM" src="https://github.com/xetdata/xet-core/assets/4929549/38548bf1-85e9-4d8b-8c57-6d43a9a0bfa8">

