### PR TITLE
fix write lazyconfig on clone

### DIFF
--- a/rust/gitxet/tests/integration_tests.rs
+++ b/rust/gitxet/tests/integration_tests.rs
@@ -261,6 +261,11 @@ mod git_integration_tests {
     fn test_merkledb_upgrade() -> anyhow::Result<()> {
         IntegrationTest::new(include_str!("integration_tests/test_merkledb_upgrade.sh")).run()
     }
+
+    #[test]
+    fn test_xet_lazy() -> anyhow::Result<()> {
+        IntegrationTest::new(include_str!("integration_tests/test_xet_lazy.sh")).run()
+    }
 }
 
 #[cfg(test)]

--- a/rust/gitxet/tests/integration_tests/test_xet_lazy.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_lazy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
+. "$SCRIPT_DIR/initialize.sh"
+git xet install
+
+remote=$(create_bare_repo)
+
+# create a repository with the below structure
+# ROOT  - d.dat
+#       - sub1
+#           - d1.dat
+#           - sub2
+#               - d2.dat
+git clone $remote repo_1
+
+pushd repo_1
+
+[[ $(git branch) == *"main"* ]] || git checkout -b main
+git xet init --force
+
+create_data_file d.dat 10000
+mkdir sub1
+create_data_file sub1/d1.dat 10000
+mkdir sub1/sub2
+create_data_file sub1/sub2/d2.dat 10000
+
+git add .
+git commit -a -m "Adding data."
+git push
+
+popd
+
+git xet clone --lazy $remote repo_2
+
+pushd repo_2
+
+[[ -e ./.git/xet/lazyconfig ]] || die "lazyconfig not set"
+assert_is_pointer_file d.dat
+assert_is_pointer_file sub1/d1.dat
+assert_is_pointer_file sub1/sub2/d2.dat
+
+echo "POINTER sub1/sub2" >>./.git/xet/lazyconfig
+echo "SMUDGE sub1" >>./.git/xet/lazyconfig
+
+cat ./.git/xet/lazyconfig >&2
+
+git xet lazy apply
+
+assert_is_pointer_file d.dat
+assert_files_equal sub1/d1.dat ../repo_1/sub1/d1.dat
+assert_is_pointer_file sub1/sub2/d2.dat
+
+popd

--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -32,15 +32,6 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
     verify_user_config(None)?;
     eprintln!("Preparing to clone Xet repository.");
 
-    GitRepo::clone(
-        Some(&config),
-        &arg_v[..],
-        args.no_smudge || args.lazy,
-        None,
-        true,
-        false,
-    )?;
-
     if args.lazy {
         // We cannot reliably detect the directory cloned into,
         // because of how git picks the "humanish" part of the source
@@ -57,6 +48,15 @@ If this is an empty repo, please create this file manually at the aforementioned
 
         std::env::set_var(XET_LAZY_CLONE_ENV, "1");
     }
+
+    GitRepo::clone(
+        Some(&config),
+        &arg_v[..],
+        args.no_smudge || args.lazy,
+        None,
+        true,
+        false,
+    )?;
 
     Ok(())
 }

--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -43,7 +43,7 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
 
         eprintln!(
             "Setting up lazyconfig under your repo at REPO_ROOT/{GIT_LAZY_CHECKOUT_CONFIG}. 
-If this is an empty repo, please create this file manually at the aforementioned path."
+If cloning an empty branch, please create this file manually at the aforementioned path."
         );
 
         std::env::set_var(XET_LAZY_CLONE_ENV, "1");

--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -2,6 +2,7 @@ use crate::constants::GIT_LAZY_CHECKOUT_CONFIG;
 use crate::git_integration::git_repo::{verify_user_config, GitRepo};
 use clap::Args;
 use lazy::lazy_config::XET_LAZY_CLONE_ENV;
+use tracing::info;
 
 use crate::config::XetConfig;
 use crate::errors::Result;
@@ -44,6 +45,9 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
         eprintln!(
             "Setting up lazyconfig under your repo at REPO_ROOT/{GIT_LAZY_CHECKOUT_CONFIG}. 
 If cloning an empty branch, please create this file manually at the aforementioned path."
+        );
+        info!(
+            "Setting up lazyconfig under the cloned repo at REPO_ROOT/{GIT_LAZY_CHECKOUT_CONFIG}"
         );
 
         std::env::set_var(XET_LAZY_CLONE_ENV, "1");

--- a/rust/gitxetcore/src/command/filter.rs
+++ b/rust/gitxetcore/src/command/filter.rs
@@ -37,6 +37,7 @@ pub async fn filter_command(config: XetConfig) -> errors::Result<()> {
     {
         let config_file = repo.git_dir.join(GIT_LAZY_CHECKOUT_CONFIG);
         check_or_write_default_lazy_config(&config_file).await?;
+
         Some(config_file)
     } else {
         None

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use cas::output_bytes;
 use cas_client::Staging;
 use futures::prelude::stream::*;
-use lazy::lazy_config::LazyConfig;
-use lazy::lazy_rule::LazyStrategy;
+use lazy::lazy_config::{LazyConfig, LazyStrategy, DEFAULT_LAZY_RULE};
 use lru::LruCache;
 use merkledb::constants::TARGET_CAS_BLOCK_SIZE;
 use merkledb::prelude_v2::*;
@@ -654,10 +653,10 @@ impl PointerFileTranslatorV1 {
                     let rule = lazy
                         .match_rule(path)
                         .map_err(|e| {
-                            eprintln!("LazyConfig error matching rule: {e:?}");
+                            error!("LazyConfig error matching rule: {e:?}");
                             e
                         })
-                        .unwrap();
+                        .unwrap_or_else(|_| DEFAULT_LAZY_RULE.clone());
                     if rule.strategy == LazyStrategy::POINTER {
                         // we dump the pointer file
                         if let Some(ready_signal) = ready {

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use cas::output_bytes;
 use cas_client::Staging;
 use futures::prelude::stream::*;
+use lazy::lazy_config::LazyConfig;
+use lazy::lazy_rule::LazyStrategy;
 use lru::LruCache;
 use merkledb::constants::TARGET_CAS_BLOCK_SIZE;
 use merkledb::prelude_v2::*;
@@ -101,6 +103,7 @@ pub struct PointerFileTranslatorV1 {
     prefetched: Arc<Mutex<LruCache<(MerkleHash, u64), ()>>>,
     derive_blocks_cache: Mutex<LruCache<MerkleHash, Vec<ObjectRange>>>,
     cfg: XetConfig,
+    lazyconfig: Option<LazyConfig>,
 }
 
 impl PointerFileTranslatorV1 {
@@ -122,6 +125,12 @@ impl PointerFileTranslatorV1 {
             .await?,
         ));
 
+        let lazyconfig = if let Some(f) = config.lazy_config.as_ref() {
+            Some(LazyConfig::load_from_file(f).await?)
+        } else {
+            None
+        };
+
         // let axe = Axe::new("DataPipeline", &config.clone(), None).await.ok();
         Ok(Self {
             initial_mdb_sequence_number: mdb.get_sequence_number(),
@@ -135,6 +144,7 @@ impl PointerFileTranslatorV1 {
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),
             derive_blocks_cache: Mutex::new(LruCache::new(DERIVE_BLOCKS_CACHE_COUNT)),
             cfg: config.clone(),
+            lazyconfig,
         })
     }
     /// Creates a PointerFileTranslator that has ephemeral DBs
@@ -156,6 +166,7 @@ impl PointerFileTranslatorV1 {
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),
             derive_blocks_cache: Mutex::new(LruCache::new(DERIVE_BLOCKS_CACHE_COUNT)),
             cfg: config.clone(),
+            lazyconfig: None,
         })
     }
 
@@ -639,6 +650,23 @@ impl PointerFileTranslatorV1 {
 
         match fi {
             Some(ptr) => {
+                if let Some(lazy) = &self.lazyconfig {
+                    let rule = lazy
+                        .match_rule(path)
+                        .map_err(|e| {
+                            eprintln!("LazyConfig error matching rule: {e:?}");
+                            e
+                        })
+                        .unwrap();
+                    if rule.strategy == LazyStrategy::POINTER {
+                        // we dump the pointer file
+                        if let Some(ready_signal) = ready {
+                            let _ = ready_signal.send(true);
+                        }
+                        let _ = writer.send(Ok(data)).await.map_err(print_err);
+                        return 0;
+                    }
+                }
                 self.smudge_file_from_pointer_to_mpsc(path, &ptr, writer, ready, progress_indicator)
                     .await
             }
@@ -851,6 +879,7 @@ impl PointerFileTranslatorV1 {
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),
             derive_blocks_cache: Mutex::new(LruCache::new(DERIVE_BLOCKS_CACHE_COUNT)),
             cfg: XetConfig::default(),
+            lazyconfig: None,
         }
     }
 }

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -956,7 +956,13 @@ impl PointerFileTranslatorV2 {
         match fi {
             Some(ptr) => {
                 if let Some(lazy) = &self.lazyconfig {
-                    let rule = lazy.match_rule(path).unwrap();
+                    let rule = lazy
+                        .match_rule(path)
+                        .map_err(|e| {
+                            eprintln!("LazyConfig error matching rule: {e:?}");
+                            e
+                        })
+                        .unwrap();
                     if rule.strategy == LazyStrategy::POINTER {
                         // we dump the pointer file
                         if let Some(ready_signal) = ready {

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use cas::output_bytes;
 use cas_client::*;
 use futures::prelude::stream::*;
-use lazy::lazy_config::{LazyConfig, LazyStrategy};
+use lazy::lazy_config::{LazyConfig, LazyStrategy, DEFAULT_LAZY_RULE};
 use mdb_shard::cas_structs::{CASChunkSequenceEntry, CASChunkSequenceHeader, MDBCASInfo};
 use mdb_shard::file_structs::{FileDataSequenceEntry, FileDataSequenceHeader, MDBFileInfo};
 use mdb_shard::intershard_reference_structs::IntershardReferenceSequence;
@@ -959,10 +959,10 @@ impl PointerFileTranslatorV2 {
                     let rule = lazy
                         .match_rule(path)
                         .map_err(|e| {
-                            eprintln!("LazyConfig error matching rule: {e:?}");
+                            error!("LazyConfig error matching rule: {e:?}");
                             e
                         })
-                        .unwrap();
+                        .unwrap_or_else(|_| DEFAULT_LAZY_RULE.clone());
                     if rule.strategy == LazyStrategy::POINTER {
                         // we dump the pointer file
                         if let Some(ready_signal) = ready {

--- a/rust/lazy/Cargo.toml
+++ b/rust/lazy/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 thiserror = "1.0.49"
 tracing = "0.1.*"
 tokio = { version = "1", features = ["full"] }
+lazy_static = "1.4.0"

--- a/rust/lazy/src/lazy_config.rs
+++ b/rust/lazy/src/lazy_config.rs
@@ -97,7 +97,7 @@ impl LazyConfig {
     }
 }
 
-const DEFAULT_LAZY_RULE: &str = "pointer *";
+const DEFAULT_LAZY_RULE: &str = "pointer *\n";
 
 /// Check if the config file exists and if parsing succeeds.
 /// Otherwise write the default config.

--- a/rust/lazy/src/lazy_config.rs
+++ b/rust/lazy/src/lazy_config.rs
@@ -7,6 +7,8 @@ use std::{
     vec,
 };
 
+use tracing::debug;
+
 use crate::error::{LazyError, Result};
 pub use crate::lazy_rule::*;
 
@@ -105,6 +107,7 @@ pub async fn check_or_write_default_lazy_config(config_file: &Path) -> Result<()
         return Ok(());
     }
 
+    debug!("Writing \"{DEFAULT_LAZY_RULE}\" to {config_file:?}");
     let mut file = File::create(config_file)?;
     file.write_all(DEFAULT_LAZY_RULE.as_bytes())?;
     Ok(())

--- a/rust/lazy/src/lazy_config.rs
+++ b/rust/lazy/src/lazy_config.rs
@@ -10,6 +10,8 @@ use std::{
 use crate::error::{LazyError, Result};
 pub use crate::lazy_rule::*;
 
+pub const XET_LAZY_CLONE_ENV: &str = "XET_LAZY_CLONE";
+
 #[derive(Debug)]
 pub struct LazyConfig {
     rules: Vec<LazyRule>,
@@ -95,7 +97,14 @@ impl LazyConfig {
 
 const DEFAULT_LAZY_RULE: &str = "pointer *";
 
-pub fn write_default_lazy_config(config_file: &Path) -> Result<()> {
+/// Check if the config file exists and if parsing succeeds.
+/// Otherwise write the default config.
+pub async fn check_or_write_default_lazy_config(config_file: &Path) -> Result<()> {
+    if config_file.is_file() {
+        LazyConfig::load_from_file(config_file).await?;
+        return Ok(());
+    }
+
     let mut file = File::create(config_file)?;
     file.write_all(DEFAULT_LAZY_RULE.as_bytes())?;
     Ok(())

--- a/rust/lazy/src/lazy_config.rs
+++ b/rust/lazy/src/lazy_config.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use std::{
     cmp::Ordering,
     collections::HashMap,
@@ -6,8 +7,7 @@ use std::{
     path::Path,
     vec,
 };
-
-use tracing::debug;
+use tracing::info;
 
 use crate::error::{LazyError, Result};
 pub use crate::lazy_rule::*;
@@ -97,7 +97,13 @@ impl LazyConfig {
     }
 }
 
-const DEFAULT_LAZY_RULE: &str = "pointer *\n";
+const DEFAULT_LAZY_RULE_STR: &str = "pointer *\n";
+lazy_static! {
+    pub static ref DEFAULT_LAZY_RULE: LazyRule = LazyRule {
+        path: "*".to_owned(),
+        strategy: LazyStrategy::POINTER
+    };
+}
 
 /// Check if the config file exists and if parsing succeeds.
 /// Otherwise write the default config.
@@ -107,9 +113,9 @@ pub async fn check_or_write_default_lazy_config(config_file: &Path) -> Result<()
         return Ok(());
     }
 
-    debug!("Writing \"{DEFAULT_LAZY_RULE}\" to {config_file:?}");
+    info!("Writing \"{DEFAULT_LAZY_RULE_STR}\" to {config_file:?}");
     let mut file = File::create(config_file)?;
-    file.write_all(DEFAULT_LAZY_RULE.as_bytes())?;
+    file.write_all(DEFAULT_LAZY_RULE_STR.as_bytes())?;
     Ok(())
 }
 


### PR DESCRIPTION
Moving writing the lazyconfig from clone command to filter command because we cannot reliably detect the cloned directory.
Also adds the lazy logic into v1 repo path.
Fix https://github.com/xetdata/xethub/issues/4427