### PR TITLE
Fix for git xet init issue on bare repos

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_commits.rs
+++ b/rust/gitxetcore/src/git_integration/git_commits.rs
@@ -1,0 +1,510 @@
+use std::{path::PathBuf, collections::HashMap, sync::Arc};
+use crate::errors::{Result, GitXetRepoError};
+use chrono::{DateTime, Utc, TimeZone};
+use git2;
+use serde::Serialize;
+use tracing::{error, info, Level, span, Span};
+
+// Describes a set of actions to perform on a git repo
+#[derive(Debug, Clone)]
+pub enum ManifestEntry {
+    Create {
+        file: PathBuf,
+        modeexec: bool,
+        content: Vec<u8>,
+        githash_content: Option<git2::Oid>,
+    },
+    Update {
+        file: PathBuf,
+        content: Vec<u8>,
+        githash_content: Option<git2::Oid>,
+    },
+    Upsert {
+        file: PathBuf,
+        modeexec: bool,
+        content: Vec<u8>,
+        githash_content: Option<git2::Oid>,
+    },
+    Move {
+        file: PathBuf,
+        prev_path: PathBuf,
+        content: Option<Vec<u8>>,
+    },
+    Delete {
+        file: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AtomicCommitOutput {
+    pub id: String,
+    pub short_id: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub author_name: Option<String>,
+    #[serde(default)]
+    pub author_email: Option<String>,
+    #[serde(default)]
+    pub committer_name: Option<String>,
+    #[serde(default)]
+    pub committer_email: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    pub parent_ids: Vec<String>,
+    pub committed_date: DateTime<Utc>,
+}
+
+fn _get_file_mode(tree_entry: &git2::TreeEntry) -> Result<git2::FileMode> {
+    let raw_mode = tree_entry.filemode();
+    if raw_mode == i32::from(git2::FileMode::BlobExecutable) {
+        Ok(git2::FileMode::BlobExecutable)
+    } else if raw_mode == i32::from(git2::FileMode::Blob) {
+        Ok(git2::FileMode::Blob)
+    } else if raw_mode == i32::from(git2::FileMode::Tree) {
+        Ok(git2::FileMode::Tree)
+    } else if raw_mode == i32::from(git2::FileMode::Link) {
+        Ok(git2::FileMode::Link)
+    } else {
+        Err(GitXetRepoError::InvalidOperation(format!("File has unsupported mode {raw_mode}")))
+    }
+}
+
+// only return Ok(Tree) or Ok(Blob) or Err
+fn _validate_oid_is_tree_or_blob(
+    repo: &Arc<git2::Repository>,
+    file: &std::path::Path,
+    oid: git2::Oid,
+) -> Result<git2::ObjectType> {
+    match repo.find_object(oid, None) {
+        Ok(obj) => {
+            // must be a tree or a blob
+            if matches!(obj.kind(), Some(git2::ObjectType::Tree)) {
+                Ok(git2::ObjectType::Tree)
+            } else if matches!(obj.kind(), Some(git2::ObjectType::Blob)) {
+                Ok(git2::ObjectType::Blob)
+            } else {
+                Err(GitXetRepoError::InvalidOperation("Can only copy files or directories".to_owned()))
+            }
+        }
+        Err(_) => 
+                Err(GitXetRepoError::InvalidOperation(format!(
+            "Trying to create {file:?} from non-existant Oid {oid:?}"
+        ))),
+    }
+}
+// We wait for at most 10s to acquire the lock
+const MAX_RETRY_TIME_MS: u64 = 1000;
+
+/// Performs an atomic commit of a manifest into a git repository.
+/// refname can be a branch name, or can be any other ref.
+///
+/// If create_ref is set, the ref will be created if it does not already exist.
+/// refname must start with "refs/"
+#[tracing::instrument(skip_all, name = "atomic_commit", 
+    fields(manifest.counts, repo_path, 
+           author = author, refname = refname, author_email = author_email))]
+pub fn atomic_commit_impl<'a> (
+    repo: &'a Arc<git2::Repository>,
+    manifest_entries: Vec<ManifestEntry>,
+    refname: &str,
+    commit_message: &str,
+    author: &str,
+    author_email: &str,
+    create_ref: bool,
+) -> Result<(String, git2::Commit<'a> )> {
+    
+    Span::current().record("repo_path", format!("{:?}", repo.path()));
+
+    let init_span = span!(Level::INFO, "Initialization");
+    let init_span_lg = init_span.enter();
+
+    let mut manifest_modes: HashMap<usize, git2::FileMode> = HashMap::new();
+    let mut manifest_oids: HashMap<usize, git2::Oid> = HashMap::new();
+
+    // if we find refs/heads/{refname} and it is a branch we use it.
+    // Otherwise, we stick with the original refname.
+    let refname = {
+        if refname.starts_with("refs/") { 
+            refname.to_owned()
+        } else {
+            format!("refs/heads/{refname}")
+        }
+    };
+
+    drop(init_span_lg);
+
+    let mut m_create_count = 0usize;
+    let mut m_upsert_count = 0usize;
+    let mut m_move_count = 0usize;
+    let mut m_update_count = 0usize;
+    let mut m_delete_count = 0usize;
+
+    {
+        let verification_span = span!(Level::INFO, "Verification");
+        let _lg = verification_span.enter();
+
+        // early terminate sanity check on the ref name
+        let reference = repo.find_reference(&refname).ok().or_else(||
+            if create_ref { 
+                repo.head().ok()
+            } else {
+                None
+            });
+        let commit = reference.and_then(|x| x.peel_to_commit().ok());
+        let tree = commit.and_then(|x| x.tree().ok());
+        // early terminate in case of validation errors
+        for (i, manifest_entry) in manifest_entries.iter().enumerate() {
+            match manifest_entry {
+                ManifestEntry::Create {
+                    file,
+                    modeexec,
+                    content: _,
+                    githash_content,
+                } => {
+                    if tree.as_ref().and_then(|x| x.get_path(file).ok()).is_some() {
+                        error!("Trying to create {file:?} which already exists.");
+                        return Err(GitXetRepoError::InvalidOperation(format!("Trying to create {file:?} which already exists")));
+                    }
+                    if let Some(ref oid) = githash_content {
+                        if _validate_oid_is_tree_or_blob(repo, file, *oid)? == git2::ObjectType::Tree
+                        {
+                            // if this is a tree, the mode must be tree
+                            // if the blob case we fall through
+                            manifest_modes.insert(i, git2::FileMode::Tree);
+                            continue;
+                        }
+                    }
+                    if *modeexec {
+                        manifest_modes.insert(i, git2::FileMode::BlobExecutable)
+                    } else {
+                        manifest_modes.insert(i, git2::FileMode::Blob)
+                    };
+                    m_create_count += 1;
+                }
+                ManifestEntry::Upsert {
+                    file,
+                    modeexec,
+                    content: _,
+                    githash_content,
+                } => {
+                    if let Some(ref oid) = githash_content {
+                        if _validate_oid_is_tree_or_blob(repo, file, *oid)? == git2::ObjectType::Tree
+                        {
+                            // if this is a tree, the mode must be tree
+                            // if the blob case we fall through
+                            manifest_modes.insert(i, git2::FileMode::Tree);
+                            continue;
+                        }
+                    }
+                    if *modeexec {
+                        manifest_modes.insert(i, git2::FileMode::BlobExecutable)
+                    } else {
+                        manifest_modes.insert(i, git2::FileMode::Blob)
+                    };
+                    m_upsert_count += 1;
+                }
+                ManifestEntry::Delete { file } => {
+                    if tree.as_ref().and_then(|x| x.get_path(file).ok()).is_none() {
+                        error!("Trying to delete {file:?} which does not exist.");
+                        return Err(GitXetRepoError::InvalidOperation(format!("Trying to delete {file:?} which does not exist")));
+                    }
+                    m_delete_count += 1;
+                }
+                ManifestEntry::Move {
+                    file: _,
+                    prev_path,
+                    content: _,
+                } => {
+                    if let Some(ref tree) = tree {
+                        match tree.get_path(prev_path) {
+                            Ok(tree_entry) => {
+                                manifest_modes.insert(i, _get_file_mode(&tree_entry)?);
+                                let object = tree_entry.to_object(repo);
+                                match object {
+                                    Ok(object) => {
+                                        manifest_oids.insert(i, object.id());
+                                    }
+                                    Err(_) => {
+                                        error!("Trying to move {prev_path:?} which does not have a valid object id.");
+                                        return Err(GitXetRepoError::InvalidOperation(format!(
+                                    "Trying to move {prev_path:?} which does not have a valid object id",
+                                )));
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                error!("Trying to move {prev_path:?} which does not exist.");
+                                return Err(GitXetRepoError::InvalidOperation(format!(
+                                    "Trying to move {prev_path:?} which does not exist",
+                                )));
+                            }
+                        }
+                    } else {
+                        return Err(GitXetRepoError::InvalidOperation(format!("Trying to move {prev_path:?} which does not exist",)));
+                    }
+                    m_move_count += 1;
+                }
+                ManifestEntry::Update {
+                    file,
+                    content: _,
+                    githash_content,
+                } => {
+                    if let Some(ref oid) = githash_content {
+                        if _validate_oid_is_tree_or_blob(repo, file, *oid)? == git2::ObjectType::Tree
+                        {
+                            // if this is a tree, the mode must be tree
+                            // if the blob case we fall through
+                            manifest_modes.insert(i, git2::FileMode::Tree);
+                            continue;
+                        }
+                    }
+                    if let Some(ref tree) = tree {
+                        match tree.get_path(file) {
+                            Ok(tree_entry) => {
+                                manifest_modes.insert(i, _get_file_mode(&tree_entry)?);
+                            }
+                            Err(_) => {
+                                error!("Trying to update {file:?} which does not exist");
+                                return Err(GitXetRepoError::InvalidOperation(format!(
+                                    "Trying to update {file:?} which does not exist",
+                                )));
+                            }
+                        }
+                    } else {
+                        error!("Trying to update {file:?} which does not exist");
+                        return Err(GitXetRepoError::InvalidOperation(format!("Trying to update {file:?} which does not exist")));
+                    }
+                    m_update_count += 1;
+                }
+            }
+            // do not put code here. The match above has "continue" cases
+        }
+    }
+
+    Span::current().record("manifest_counts", 
+        format!("Total: {} (Create: {m_create_count}, Upserts: {m_upsert_count}, Deletes: {m_delete_count}, Moves: {m_move_count}, Updates: {m_update_count})", manifest_entries.len()));
+
+    info!("manifest_counts: Sanity check completed.");
+
+    let preparation_span = span!(Level::INFO, "Preparation");
+    let preparation_span_lg = preparation_span.enter();
+
+    // build the commit signature first to early check for correctness
+    let signature = git2::Signature::now(author, author_email)?;
+
+    // convert objects in the manifest to an oid
+    for (i, manifest_entry) in manifest_entries.iter().enumerate() {
+        match manifest_entry {
+            ManifestEntry::Create {
+                file: _,
+                modeexec: _,
+                content,
+                githash_content,
+            }
+            | ManifestEntry::Upsert {
+                file: _,
+                modeexec: _,
+                content,
+                githash_content,
+            }
+            | ManifestEntry::Update {
+                file: _,
+                content,
+                githash_content,
+            } => {
+                if let Some(ref oid) = githash_content {
+                    manifest_oids.insert(i, *oid);
+                } else {
+                    let oid = repo.blob(content)?;
+                    manifest_oids.insert(i, oid);
+                }
+            }
+            ManifestEntry::Move {
+                file: _,
+                prev_path: _,
+                content: Some(content),
+            } => {
+                // Move actions that do not specify content preserve the existing file content,
+                // and any other value of content overwrites the file content.
+                let oid = repo.blob(content)?;
+                manifest_oids.insert(i, oid);
+            }
+            _ => {}
+        }
+    }
+
+    // to build up all the intermediate trees can actually be a little bit
+    // tricky... except libgit2 provides this very nice TreeUpdateBuilder!
+    let mut builder = git2::build::TreeUpdateBuilder::new();
+    for (i, manifest_entry) in manifest_entries.into_iter().enumerate() {
+        match manifest_entry {
+            ManifestEntry::Create {
+                file,
+                modeexec: _,
+                content: _,
+                githash_content: _,
+            }
+            | ManifestEntry::Upsert {
+                file,
+                modeexec: _,
+                content: _,
+                githash_content: _,
+            }
+            | ManifestEntry::Update {
+                file,
+                content: _,
+                githash_content: _,
+            } => {
+                let oid = manifest_oids[&i];
+                let mode = manifest_modes[&i];
+                builder.upsert(&file, oid, mode);
+            }
+            ManifestEntry::Delete { file } => {
+                builder.remove(&file);
+            }
+            ManifestEntry::Move {
+                file,
+                prev_path,
+                content: _,
+            } => {
+                let oid = manifest_oids[&i];
+                let mode = manifest_modes[&i];
+                builder.remove(&prev_path);
+                builder.upsert(&file, oid, mode);
+            }
+        }
+    }
+
+    drop(preparation_span_lg);
+
+    let lock_acquisition_span = span!(Level::INFO, "Transaction Lock Acquisition");
+    let lock_acquisition_span_lg: span::Entered<'_> = lock_acquisition_span.enter();
+
+    // ok. Now we need to construct the commit
+    // lock the ref first
+    let mut reflock = repo.transaction()?;
+    let mut retry_time_ms = 100;
+    loop {
+        match reflock.lock_ref(&refname) {
+            Ok(_) => {
+                break;
+            }
+            Err(e) => {
+                if e.code() == git2::ErrorCode::Locked {
+                    info!("Locked. Sleeping for {retry_time_ms} ms and retry");
+                    let sleep_time = std::time::Duration::from_millis(retry_time_ms);
+                    std::thread::sleep(sleep_time);
+                    // multiplicative backoff. But no longer than MAX_RETRY_TIME_MS
+                    retry_time_ms = std::cmp::min(retry_time_ms * 2, MAX_RETRY_TIME_MS);
+                    continue;
+                } else {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+    drop(lock_acquisition_span_lg);
+
+    let commit_span = span!(Level::INFO, "Committing");
+    let commit_span_lg: span::Entered<'_> = commit_span.enter();
+        let prev_reference = repo.find_reference(&refname).ok().or_else(||
+            if create_ref { 
+                repo.head().ok()
+            } else {
+                None
+            });
+        
+    let commit = if let Some(reference) = prev_reference {
+        // find the tree at the current ref
+        let previous_commit = reference.peel_to_commit()?;
+        let tree = previous_commit.tree()?;
+        // create an updated tree
+        let result_tree_oid = builder.create_updated(repo, &tree)?;
+        let result_tree = repo.find_tree(result_tree_oid)?;
+        // commit the changes
+        let commit_oid = repo.commit(
+            None,
+            &signature,
+            &signature,
+            commit_message,
+            &result_tree,
+            &[&previous_commit],
+        )?;
+        let commit = repo.find_commit(commit_oid)?;
+        // update the ref
+        reflock.set_target(&refname, commit_oid, Some(&signature), commit_message)?;
+        reflock.commit()?;
+        commit
+    } else if create_ref {
+        // we creating the ref from scratch. so we need to work backwards a bit
+        // start by making an empty tree
+        let empty_treebuilder = repo.treebuilder(None)?;
+        let empty_tree_oid = empty_treebuilder.write()?;
+        let empty_tree = repo.find_tree(empty_tree_oid)?;
+        // create the result tree
+        let result_tree_oid = builder.create_updated(repo, &empty_tree)?;
+        let result_tree = repo.find_tree(result_tree_oid)?;
+        // create a commit with no parent
+        let commit_oid = repo.commit(
+None,
+            &signature,
+            &signature,
+            commit_message,
+            &result_tree,
+            &[],
+        )?;
+        let commit = repo.find_commit(commit_oid)?;
+        // then create the ref
+        reflock.set_target(&refname, commit_oid, Some(&signature), commit_message)?;
+        reflock.commit()?;
+        commit
+    } else {
+        return Err(GitXetRepoError::InvalidOperation(format!("Unable to find reference {refname:?}")));
+    };
+
+    drop(commit_span_lg);
+
+    Ok((refname, commit))
+}
+
+pub fn atomic_commit(
+    repo: &Arc<git2::Repository>,
+    manifest_entries: Vec<ManifestEntry>,
+    refname: &str,
+    commit_message: &str,
+    author: &str,
+    author_email: &str,
+    create_ref: bool,
+) -> Result<AtomicCommitOutput> {
+
+    let (_, commit) = atomic_commit_impl(repo, manifest_entries, refname, commit_message, author, author_email, create_ref)?;
+
+    let id = commit.id().to_string();
+    let mut short_id = id.clone();
+    short_id.truncate(8);
+    let author = commit.author();
+    let committer = commit.committer();
+    let committed_date: DateTime<Utc> = Utc
+        .timestamp_millis_opt(commit.time().seconds() * 1000)
+        .single().ok_or(GitXetRepoError::Other("Unable to create DateTime".to_string()))?;
+    let parent_ids = commit
+        .parent_ids()
+        .map(|parent_id| parent_id.to_string())
+        .collect::<Vec<String>>();
+
+    let ret = AtomicCommitOutput {
+        id,
+        short_id,
+        title: commit.summary().map(str::to_string),
+        author_name: author.name().map(str::to_string),
+        author_email: author.email().map(str::to_string),
+        committer_name: committer.name().map(str::to_string),
+        committer_email: committer.email().map(str::to_string),
+        message: commit.message().map(str::to_string),
+        committed_date,
+        parent_ids,
+    };
+
+    Ok(ret)
+}

--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -676,7 +676,7 @@ impl GitRepo {
                 info!("GitRepo::open: Successfully read repo salt.");
             } else {
                 let msg = format!("{}\n{}\n{}", 
-                        "Implicit initialization failed, no Xet configuration info found in remoteself.", 
+                        "Implicit initialization failed, no Xet configuration info found in remotes.", 
                         "Please add the upstream Xet initialized repository as a remote using", 
                         "`git remote add upstream_xet_repo <url>` and then run `git restore --source=HEAD :/`.");
                 error!("{msg}");

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -439,7 +439,7 @@ pub fn create_commit(
                     .as_ref()
                     .and_then(|r| r.name())
                     .unwrap_or(default_branch),
-                true,
+                false,
             )
         }
     };

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -426,7 +426,7 @@ pub fn create_commit(
     let mut _head = None;
 
     // Create the commit
-    let (refname, set_head) = {
+    let (refname, mut set_head) = {
         if branch_name != "HEAD" {
             (branch_name, false)
         } else if !repo.branches(None)?.any(|_| true) {
@@ -448,9 +448,11 @@ pub fn create_commit(
     if !refname.starts_with("refs/") {
         // See if it's a branch
         if let Err(_) = repo.find_branch(refname, git2::BranchType::Local) {
-            // The branch does not exist, create it from HEAD.
+            // The branch does not exist, create it from HEAD if it exists.  Otherwise, set head later
             if let Ok(commit) = repo.head().and_then(|r| r.peel_to_commit()) {
                 repo.branch(refname, &commit, false)?;
+            } else {
+                set_head = true;
             }
         }
     }

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -447,7 +447,7 @@ pub fn create_commit(
     // If the reference doesn't exist, create a new branch with that.
     if !refname.starts_with("refs/") {
         // See if it's a branch
-        if let Err(_) = repo.find_branch(refname, git2::BranchType::Local) {
+        if repo.find_branch(refname, git2::BranchType::Local).is_err() {
             // The branch does not exist, create it from HEAD if it exists.  Otherwise, set head later
             if let Ok(commit) = repo.head().and_then(|r| r.peel_to_commit()) {
                 repo.branch(refname, &commit, false)?;
@@ -468,7 +468,7 @@ pub fn create_commit(
     let (refname, _) = atomic_commit_impl(
         repo,
         files
-            .into_iter()
+            .iter()
             .map(|(name, data)| ManifestEntry::Upsert {
                 file: name.into(),
                 modeexec: false,
@@ -476,7 +476,7 @@ pub fn create_commit(
                 githash_content: None,
             })
             .collect(),
-        &refname,
+        refname,
         commit_message,
         &user_name,
         &user_email,

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -426,18 +426,21 @@ pub fn create_commit(
     let mut _head = None;
 
     // Create the commit
-    let refname = {
+    let (refname, set_head) = {
         if branch_name != "HEAD" {
-            branch_name
+            (branch_name, false)
         } else if !repo.branches(None)?.any(|_| true) {
             info!("git_wrap:create_commit: Setting HEAD to point to new branch {default_branch}.");
-            default_branch
+            (default_branch, true)
         } else {
             _head = repo.head().ok();
-            _head
-                .as_ref()
-                .and_then(|r| r.name())
-                .unwrap_or(default_branch)
+            (
+                _head
+                    .as_ref()
+                    .and_then(|r| r.name())
+                    .unwrap_or(default_branch),
+                true,
+            )
         }
     };
 
@@ -478,7 +481,9 @@ pub fn create_commit(
         true,
     )?;
 
-    repo.set_head(&refname)?;
+    if set_head {
+        repo.set_head(&refname)?;
+    }
 
     Ok(())
 }

--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -1,6 +1,8 @@
 use crate::constants::MINIMUM_GIT_VERSION;
 use crate::errors::GitXetRepoError;
 use crate::errors::Result;
+use crate::git_integration::git_commits::atomic_commit_impl;
+use crate::git_integration::git_commits::ManifestEntry;
 use git2::Repository;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -8,6 +10,7 @@ use regex::Regex;
 use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
+use std::process::Output;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::error;
@@ -94,13 +97,13 @@ fn spawn_git_command(
 /// The command is run in the directory base_directory.  On nonzero exit status, an error is
 /// returned.
 #[tracing::instrument(skip_all, err, fields(command = command, ?args))]
-pub fn run_git_captured(
+pub fn run_git_captured_raw(
     base_directory: Option<&PathBuf>,
     command: &str,
     args: &[&str],
     check_result: bool,
     env: Option<&[(&str, &str)]>,
-) -> Result<(Option<i32>, String, String)> {
+) -> Result<Output> {
     // Block use of credential manager for this bit.
     let env: Vec<(&str, &str)> = match env {
         Some(d) => {
@@ -113,10 +116,48 @@ pub fn run_git_captured(
 
     let child = spawn_git_command(base_directory, command, args, Some(&env), true)?;
 
-    let out = child.wait_with_output()?;
+    let ret = child.wait_with_output()?;
 
-    let res_stdout = std::str::from_utf8(&out.stdout[..]).unwrap_or("<Binary Data>");
-    let res_stderr = std::str::from_utf8(&out.stderr[..]).unwrap_or("<Binary Data>");
+    if check_result {
+        if let Some(0) = ret.status.code() {
+            Ok(ret)
+        } else {
+            let res_stdout = std::str::from_utf8(&ret.stdout[..])
+                .unwrap_or("<Binary Data>")
+                .trim();
+            let res_stderr = std::str::from_utf8(&ret.stderr[..])
+                .unwrap_or("<Binary Data>")
+                .trim();
+            Err(GitXetRepoError::Other(format!(
+                "Error running git command: git {:?} {:?} err_code={:?}, stdout=\"{:?}\", stderr=\"{:?}\"",
+                &command, args.iter().map(|s| format!("\"{s}\"")).join(" "), &ret.status, &res_stdout, &res_stderr
+            )))
+        }
+    } else {
+        Ok(ret)
+    }
+}
+
+/// Calls git directly, piping both stdout and stderr through.  
+///
+/// The command is run in the directory base_directory.  On nonzero exit status, an error is
+/// returned.
+#[tracing::instrument(skip_all, err, fields(command = command, ?args))]
+pub fn run_git_captured(
+    base_directory: Option<&PathBuf>,
+    command: &str,
+    args: &[&str],
+    check_result: bool,
+    env: Option<&[(&str, &str)]>,
+) -> Result<(Option<i32>, String, String)> {
+    let out = run_git_captured_raw(base_directory, command, args, check_result, env)?;
+
+    let res_stdout = std::str::from_utf8(&out.stdout[..])
+        .unwrap_or("<Binary Data>")
+        .trim();
+    let res_stderr = std::str::from_utf8(&out.stderr[..])
+        .unwrap_or("<Binary Data>")
+        .trim();
 
     debug!(
         "Git return: status = {:?}, stdout = {:?}, stderr = {:?}.",
@@ -133,24 +174,11 @@ pub fn run_git_captured(
         }
     );
 
-    let ret = (
+    Ok((
         out.status.code(),
-        res_stdout.trim().to_string(),
-        res_stderr.trim().to_string(),
-    );
-
-    if check_result {
-        if let Some(0) = ret.0 {
-            Ok(ret)
-        } else {
-            Err(GitXetRepoError::Other(format!(
-                "Error running git command: git {:?} {:?} err_code={:?}, stdout=\"{:?}\", stderr=\"{:?}\"",
-                &command, args.iter().map(|s| format!("\"{s}\"")).join(" "), &ret.0, &ret.1, &ret.2
-            )))
-        }
-    } else {
-        Ok(ret)
-    }
+        res_stdout.to_owned(),
+        res_stderr.to_owned(),
+    ))
 }
 
 /// Calls git directly, letting stdout and stderr through to the console
@@ -391,108 +419,66 @@ pub fn create_commit(
     files: &[(&str, &[u8])],
     main_branch_name_if_empty_repo: Option<&str>, // If given, make sure the repo has at least one branch
 ) -> Result<()> {
-    // Create blobs for the files
-    let file_oids: Vec<_> = files
-        .iter()
-        .map(|(file_name, data)| {
-            let blob_oid = repo.blob(data)?;
-            Ok((
-                file_name.to_owned().trim_end_matches('/'),
-                blob_oid,
-                data.len(),
-            ))
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let default_branch = main_branch_name_if_empty_repo.unwrap_or("main");
 
-    info!(
-        "git_wrap:create_commit: Creating new commit with {} new files.",
-        file_oids.len()
-    );
+    let branch_name = branch_name.unwrap_or("HEAD");
 
-    // Create a tree from the blobs; do this in memory, then do it one by one.
-    let mut index = git2::Index::new()?;
-
-    for (file_name, file_oid, data_len) in file_oids {
-        let entry = git2::IndexEntry {
-            path: file_name.as_bytes().into(),
-            id: file_oid,
-            file_size: data_len as u32,
-            mode: 0o100644, // represents a blob (file)
-            dev: 0,
-            ino: 0,
-            uid: 0,
-            gid: 0,
-            flags: 0,
-            flags_extended: 0,
-            mtime: git2::IndexTime::new(0, 0),
-            ctime: git2::IndexTime::new(0, 0),
-        };
-        index.add(&entry)?;
-    }
-
-    // Now, write the whole index to the repo
-    let tree_oid = index.write_tree_to(repo)?;
-    debug!("git_wrap:create_commit: tree = {tree_oid:?}.");
-    let tree = repo.find_tree(tree_oid)?;
+    let mut _head = None;
 
     // Create the commit
-    let (update_ref, parent_ref, set_head) = {
-        if let Some(bn) = branch_name {
-            if let Ok(branch) = repo.find_branch(bn, git2::BranchType::Local) {
-                (
-                    format!("refs/heads/{bn}"),
-                    Some(branch.into_reference()),
-                    false,
-                )
-            } else {
-                (format!("refs/heads/{bn}"), repo.head().ok(), false)
-            }
-        } else if let (Some(new_br), false) = (
-            main_branch_name_if_empty_repo,
-            repo.branches(None)?.any(|_| true),
-        ) {
-            info!("git_wrap:create_commit: Setting HEAD to point to new branch {new_br}.");
-            (format!("refs/heads/{new_br}"), repo.head().ok(), true)
+    let refname = {
+        if branch_name != "HEAD" {
+            branch_name
+        } else if !repo.branches(None)?.any(|_| true) {
+            info!("git_wrap:create_commit: Setting HEAD to point to new branch {default_branch}.");
+            default_branch
         } else {
-            ("HEAD".to_owned(), repo.head().ok(), false)
+            _head = repo.head().ok();
+            _head
+                .as_ref()
+                .and_then(|r| r.name())
+                .unwrap_or(default_branch)
         }
     };
-    debug!(
-        "git_wrap:create_commit: update_ref = {update_ref:?}, parent_ref = {:?}.",
-        parent_ref.as_ref().map(|p| p.name())
-    );
 
-    let parent_commit;
+    // If the reference doesn't exist, create a new branch with that.
+    if !refname.starts_with("refs/") {
+        // See if it's a branch
+        if let Err(_) = repo.find_branch(refname, git2::BranchType::Local) {
+            // The branch does not exist, create it from HEAD.
+            if let Ok(commit) = repo.head().and_then(|r| r.peel_to_commit()) {
+                repo.branch(refname, &commit, false)?;
+            }
+        }
+    }
 
-    let parents = if let Some(pr) = parent_ref {
-        parent_commit = repo.find_commit(pr.target().unwrap())?;
-        info!("git_wrap:create_commit: creating commit with parent commit {parent_commit:?}.");
-        vec![&parent_commit]
-    } else {
-        info!(
-            "git_wrap:create_commit: creating commit with no parents as repo appears to be empty."
-        );
-        Vec::new()
-    };
+    debug!("git_wrap:create_commit: update_ref = {refname:?}");
 
-    let signature = repo.signature()?;
+    let config = git2::Config::open_default()?;
 
-    let commit_oid = repo.commit(
-        Some(&update_ref),
-        &signature,
-        &signature,
+    // Retrieve the user's name and email
+    let user_name = config.get_string("user.name")?;
+    let user_email = config.get_string("user.email")?;
+
+    let (refname, _) = atomic_commit_impl(
+        repo,
+        files
+            .into_iter()
+            .map(|(name, data)| ManifestEntry::Upsert {
+                file: name.into(),
+                modeexec: false,
+                content: (*data).into(),
+                githash_content: None,
+            })
+            .collect(),
+        &refname,
         commit_message,
-        &tree,
-        &parents,
+        &user_name,
+        &user_email,
+        true,
     )?;
 
-    info!("git_wrap:create_commit: New commit created with oid {commit_oid}.");
-
-    if set_head {
-        let commit = repo.find_commit(commit_oid)?;
-        let branch = repo.branch(main_branch_name_if_empty_repo.unwrap(), &commit, true)?;
-        repo.set_head(branch.get().name().unwrap())?;
-    }
+    repo.set_head(&refname)?;
 
     Ok(())
 }
@@ -504,37 +490,73 @@ pub fn read_file_from_repo(
     branch: Option<&str>,
 ) -> Result<Option<Vec<u8>>> {
     // Resolve HEAD or the specified branch to the corresponding commit
-    let mut commit = match branch {
+    let (_reference_name, commit) = match branch {
         Some(branch_name) => {
-            let reference = repo.find_reference(&format!("refs/heads/{}", branch_name))?;
-            reference.peel_to_commit()?
+            let reference_name = format!("refs/heads/{}", branch_name);
+            let reference = repo.find_reference(&reference_name)?;
+            (reference_name, reference.peel_to_commit()?)
         }
         None => {
             let Ok(head) = repo.head() else {
                 return Ok(None);
             };
-            head.peel_to_commit()?
+            ("HEAD".to_owned(), head.peel_to_commit()?)
         }
     };
 
-    if let Some(blob) = loop {
+    if let Some(blob) = 'a: {
         if let Ok(tree) = commit.tree() {
             if let Ok(entry) = tree.get_path(std::path::Path::new(file_path)) {
                 if entry.kind() == Some(git2::ObjectType::Blob) {
                     if let Ok(blob) = repo.find_blob(entry.id()) {
-                        break Some(blob);
+                        break 'a Some(blob);
                     }
                 }
             }
         }
 
-        match commit.parent(0) {
-            Ok(parent) => commit = parent,
-            Err(_) => break None, // End of commit history
-        }
+        None
     } {
-        Ok(Some(blob.content().into()))
+        let ret: Vec<u8> = blob.content().into();
+
+        #[cfg(debug_assertions)]
+        {
+            let git_out = run_git_captured_raw(
+                Some(&repo.path().to_path_buf()),
+                "show",
+                &[&format!("{_reference_name}:{file_path}")],
+                false,
+                None,
+            )?;
+            debug_assert_eq!(git_out.status.code(), Some(0));
+
+            if git_out.stdout != ret {
+                let content = std::str::from_utf8(&ret[..]).unwrap_or("<Binary Data>");
+                let res_stdout =
+                    std::str::from_utf8(&git_out.stdout[..]).unwrap_or("<Binary Data>");
+                let res_stderr =
+                    std::str::from_utf8(&git_out.stderr[..]).unwrap_or("<Binary Data>");
+
+                panic!("Not equal: (retrieved) '{content:?}' != '{res_stdout:?}', error={res_stderr:?}");
+            }
+            debug_assert_eq!(git_out.status.code(), Some(0));
+        }
+
+        Ok(Some(ret))
     } else {
+        #[cfg(debug_assertions)]
+        {
+            let git_out = run_git_captured_raw(
+                Some(&repo.path().to_path_buf()),
+                "show",
+                &[&format!("{_reference_name}:{file_path}")],
+                false,
+                None,
+            )?;
+            debug_assert!(git_out.stdout.is_empty());
+            debug_assert_ne!(git_out.status.code(), Some(0));
+        }
+
         Ok(None)
     }
 }
@@ -547,7 +569,7 @@ mod git_repo_tests {
     use crate::git_integration::git_repo::open_libgit2_repo;
 
     #[test]
-    fn test_direct_repo_read_write_empty() -> anyhow::Result<()> {
+    fn test_direct_repo_read_write_branches() -> anyhow::Result<()> {
         // Create a temporary directory
         let tmp_repo = TempDir::new().unwrap();
         let tmp_repo_path = tmp_repo.path().to_path_buf();
@@ -558,8 +580,9 @@ mod git_repo_tests {
 
         let file_1 = "Random Content 1".as_bytes();
         let file_2 = "Random Content 2".as_bytes();
+        let file_2b = "Random Content 2b".as_bytes();
+        let file_2c = "Random Content 2c".as_bytes();
         let file_3 = "Random Content 3".as_bytes();
-        let file_4 = "Random Content 4".as_bytes();
 
         create_commit(
             &repo,
@@ -576,7 +599,21 @@ mod git_repo_tests {
         assert_eq!(file_1, file_1_read);
         assert_eq!(file_2, file_2_read);
 
-        // Now write to a specified branch
+        // Make sure we can overwrite things correctly.
+        create_commit(
+            &repo,
+            None,
+            "Test commit updated",
+            &[("file_2.txt", file_2b)],
+            None,
+        )?;
+        let file_1_read = read_file_from_repo(&repo, "file_1.txt", None)?.unwrap();
+        let file_2_read = read_file_from_repo(&repo, "file_2.txt", None)?.unwrap();
+
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2b, file_2_read);
+
+        // Now write to a specified branch.  This branch doesn't exist, so it should create a new branch off of main
         create_commit(
             &repo,
             Some("my_branch"),
@@ -584,21 +621,193 @@ mod git_repo_tests {
             &[("file_3.txt", file_3)],
             None,
         )?;
+
+        // Read this off of HEAD
+        let file_1_read = read_file_from_repo(&repo, "file_1.txt", None)?.unwrap();
+        let file_2_read = read_file_from_repo(&repo, "file_2.txt", None)?.unwrap();
         let file_3_read = read_file_from_repo(&repo, "file_3.txt", Some("my_branch"))?.unwrap();
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2b, file_2_read);
         assert_eq!(file_3, file_3_read);
 
-        // Repeat
+        // Read this off of the branch name
+        let file_1_read = read_file_from_repo(&repo, "file_1.txt", Some("my_branch"))?.unwrap();
+        let file_2_read = read_file_from_repo(&repo, "file_2.txt", Some("my_branch"))?.unwrap();
+        let file_3_read = read_file_from_repo(&repo, "file_3.txt", Some("my_branch"))?.unwrap();
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2b, file_2_read);
+        assert_eq!(file_3, file_3_read);
+
+        // Make sure main doesn't change
+        let file_1_read = read_file_from_repo(&repo, "file_1.txt", Some("main"))?.unwrap();
+        let file_2_read = read_file_from_repo(&repo, "file_2.txt", Some("main"))?.unwrap();
+        let file_3_query = read_file_from_repo(&repo, "file_3.txt", Some("main"))?;
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2b, file_2_read);
+        assert!(file_3_query.is_none());
+
+        // Write to main, overwrite
         create_commit(
             &repo,
-            Some("my_branch"),
+            Some("main"),
             "Test commit",
-            &[("file_4.txt", file_4)],
+            &[("file_2.txt", file_2c)],
             None,
         )?;
-        let file_3_read = read_file_from_repo(&repo, "file_3.txt", Some("my_branch"))?.unwrap();
-        let file_4_read = read_file_from_repo(&repo, "file_4.txt", Some("my_branch"))?.unwrap();
+        let file_1_read = read_file_from_repo(&repo, "file_1.txt", Some("main"))?.unwrap();
+        let file_2_read = read_file_from_repo(&repo, "file_2.txt", Some("main"))?.unwrap();
+        let file_3_query = read_file_from_repo(&repo, "file_3.txt", Some("main"))?;
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2c, file_2_read);
+        assert!(file_3_query.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repo_respect_delete() -> anyhow::Result<()> {
+        // Create a temporary directory
+        let tmp_repo = TempDir::new().unwrap();
+        let tmp_repo_path = tmp_repo.path().to_path_buf();
+        let tmp_repo_1_path = tmp_repo.path().join("repo_1");
+        std::fs::create_dir_all(&tmp_repo_1_path)?;
+
+        let _ = run_git_captured(Some(&tmp_repo_1_path), "init", &["--bare"], true, None)?;
+
+        let repo_1 = open_libgit2_repo(Some(&tmp_repo_1_path))?;
+
+        let file_1 = "Random Content 1".as_bytes();
+        let file_2 = "Random Content 2".as_bytes();
+        let file_2b = "Random Content 2b".as_bytes();
+        let file_3 = "Random Content 3".as_bytes();
+        let file_4 = "Random Content 4".as_bytes();
+
+        create_commit(
+            &repo_1,
+            None,
+            "Test commit",
+            &[
+                ("file_1.txt", file_1),
+                ("file_2.txt", file_2),
+                ("file_3.txt", file_3),
+            ],
+            None,
+        )?;
+        let file_1_read = read_file_from_repo(&repo_1, "file_1.txt", None)?.unwrap();
+        assert_eq!(file_1, file_1_read);
+
+        // Now clone and check the new version works on mirrored repos
+        let _ = run_git_captured(
+            Some(&tmp_repo_path),
+            "clone",
+            &["repo_1", "repo_2"],
+            true,
+            None,
+        )?;
+        let tmp_repo_2_path = tmp_repo.path().join("repo_2");
+
+        // Now, add a file, change a file, delete one of the files, commit, and push the change back.
+        let _ = run_git_captured(Some(&tmp_repo_2_path), "rm", &["file_1.txt"], true, None)?;
+        std::fs::write(tmp_repo_2_path.join("file_2.txt"), file_2b)?;
+        let _ = run_git_captured(Some(&tmp_repo_2_path), "add", &["file_2.txt"], true, None)?;
+        std::fs::write(tmp_repo_2_path.join("file_4.txt"), file_4)?;
+        let _ = run_git_captured(Some(&tmp_repo_2_path), "add", &["file_4.txt"], true, None)?;
+        let _ = run_git_captured(
+            Some(&tmp_repo_2_path),
+            "commit",
+            &["-m", "Update."],
+            true,
+            None,
+        )?;
+        let _ = run_git_captured(
+            Some(&tmp_repo_2_path),
+            "push",
+            &["origin", "main"],
+            true,
+            None,
+        )?;
+
+        // Now verify all the original things there.
+        assert!(read_file_from_repo(&repo_1, "file_1.txt", None)?.is_none());
+
+        let file_2_read = read_file_from_repo(&repo_1, "file_2.txt", None)?.unwrap();
+        assert_eq!(file_2b, file_2_read);
+
+        let file_3_read = read_file_from_repo(&repo_1, "file_3.txt", None)?.unwrap();
         assert_eq!(file_3, file_3_read);
+
+        let file_4_read = read_file_from_repo(&repo_1, "file_4.txt", None)?.unwrap();
         assert_eq!(file_4, file_4_read);
+        Ok(())
+    }
+
+    #[test]
+    fn test_repo_read_write_through_mirror_push() -> anyhow::Result<()> {
+        // Create a temporary directory
+        let tmp_repo = TempDir::new().unwrap();
+        let tmp_repo_path = tmp_repo.path().to_path_buf();
+        let tmp_repo_1_path = tmp_repo.path().join("repo_1");
+        std::fs::create_dir_all(&tmp_repo_1_path)?;
+
+        let _ = run_git_captured(Some(&tmp_repo_1_path), "init", &["--bare"], true, None)?;
+
+        let repo_1 = open_libgit2_repo(Some(&tmp_repo_1_path))?;
+
+        let file_1 = "Random Content 1".as_bytes();
+        let file_2 = "Random Content 2".as_bytes();
+
+        create_commit(
+            &repo_1,
+            None,
+            "Test commit",
+            &[("file_1.txt", file_1)],
+            None,
+        )?;
+        let file_1_read = read_file_from_repo(&repo_1, "file_1.txt", None)?.unwrap();
+        assert_eq!(file_1, file_1_read);
+
+        // Now clone and check the new version works on bare clones
+        let _ = run_git_captured(
+            Some(&tmp_repo_path),
+            "clone",
+            &["--bare", "repo_1", "repo_2"],
+            true,
+            None,
+        )?;
+        let tmp_repo_2_path = tmp_repo.path().join("repo_2");
+
+        let repo_2 = open_libgit2_repo(Some(&tmp_repo_2_path))?;
+
+        create_commit(
+            &repo_2,
+            None,
+            "Test commit 2",
+            &[("file_2.txt", file_2)],
+            None,
+        )?;
+
+        // Make sure that we can get those back (doesn't have to be bare here)
+        let file_1_read = read_file_from_repo(&repo_2, "file_1.txt", None)?.unwrap();
+        let file_2_read = read_file_from_repo(&repo_2, "file_2.txt", None)?.unwrap();
+
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2, file_2_read);
+
+        // Now, can we push back?
+        let _ = run_git_captured(
+            Some(&tmp_repo_2_path),
+            "push",
+            &["--force", "origin", "main"],
+            true,
+            None,
+        )?;
+
+        // Make sure that all the files are still there after the push.
+        let file_1_read = read_file_from_repo(&repo_1, "file_1.txt", None)?.unwrap();
+        let file_2_read = read_file_from_repo(&repo_1, "file_2.txt", None)?.unwrap();
+
+        assert_eq!(file_1, file_1_read);
+        assert_eq!(file_2, file_2_read);
 
         Ok(())
     }

--- a/rust/gitxetcore/src/git_integration/mod.rs
+++ b/rust/gitxetcore/src/git_integration/mod.rs
@@ -1,3 +1,4 @@
+pub mod git_commits;
 pub mod git_file_tools;
 pub mod git_integration_plumb;
 pub mod git_notes_wrapper;


### PR DESCRIPTION
The recently added git xet init functionality is actually broken; this PR fixes it.  

The create_commit function actually discards all previous commits.  This is due to creating a blank index instead of a tree as an intermediate step, then writing this as the commit; however, this sets the current state of the repo, not an update. 

The solution is to use a new, more general atomic commit function to make this happen.   A number of tests are added to cover this scenario. 