### PR TITLE
Fix summary deserialization compat

### DIFF
--- a/rust/libmagic/src/file_types.rs
+++ b/rust/libmagic/src/file_types.rs
@@ -12,12 +12,14 @@ pub fn get_summary_from_extension(extension: &str) -> LibmagicSummary {
         Some(type_info) => LibmagicSummary {
             file_type: extension.to_string(),
             file_type_simple: type_info.friendly_type.to_string(),
+            file_type_simple_category: "".to_string(), // this field intentionally left blank; unused
             file_type_mime: type_info.mime_type.to_string(),
             buffer: None,
         },
         None => LibmagicSummary {
             file_type: extension.to_string(),
             file_type_simple: "Unknown".to_string(),
+            file_type_simple_category: "".to_string(), // this field intentionally left blank; unused
             file_type_mime: "application/octet-stream".to_string(),
             buffer: None,
         },

--- a/rust/libmagic/src/libmagic.rs
+++ b/rust/libmagic/src/libmagic.rs
@@ -9,6 +9,7 @@ use crate::file_types::get_summary_from_extension;
 pub struct LibmagicSummary {
     pub file_type: String,
     pub file_type_simple: String,
+    pub file_type_simple_category: String, // unused, but do not remove!
     pub file_type_mime: String,
 
     // A buffer to allow us to add more to the serialized options
@@ -20,6 +21,7 @@ impl Default for LibmagicSummary {
         Self {
             file_type: Default::default(),
             file_type_simple: "Unknown".to_string(),
+            file_type_simple_category: "".to_string(), // this field intentionally left blank; unused
             file_type_mime: "application/octet-stream".to_string(),
             buffer: None,
         }


### PR DESCRIPTION
The PR #154 broke summary deserialization by removing a field from the LibmagicSummary type. This was intentional for libmagic summaries, but I didn't realize this would also affect deserialization of CSV summaries since we combine them together in a WholeRepoSummary struct that we then try to deserialize. We still want to be able to read CSV summaries through that struct, so we need to keep this field forever for Serde compat.