### PR TITLE
Disable version check in recursive calls.

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_wrap.rs
+++ b/rust/gitxetcore/src/git_integration/git_wrap.rs
@@ -53,6 +53,9 @@ fn spawn_git_command(
         }
     }
 
+    // Disable version check on recursive calls
+    cmd.env("XET_DISABLE_VERSION_CHECK", "1");
+
     if let Some(dir) = base_directory {
         debug_assert!(dir.exists());
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -187,7 +187,9 @@ impl VersionCheckInfo {
 
     pub fn notify_user_if_appropriate(&mut self) {
         debug!("VersionCheckInfo:notify_user_if_appropriate: version check info = {self:?}");
-        if self.known_new_release() {
+        if self.known_new_release()
+            && std::env::var_os("XET_DISABLE_VERSION_CHECK").unwrap_or("0".into()) == "0"
+        {
             let mut notification_happened = false;
 
             if self.contains_critical_fix {


### PR DESCRIPTION
Disables the version check in all calls spawned downstream from another git-xet process.   Addresses https://github.com/xetdata/xethub/issues/4600 and other cases where the version check message may be swallowed silently due to this.