### PR TITLE
Push repo salt in case the remote is not xet-enabled

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo.rs
@@ -1741,6 +1741,7 @@ impl GitRepo {
                     GIT_NOTES_MERKLEDB_V2_REF_NAME,
                     GIT_NOTES_MERKLEDB_V1_REF_NAME,
                     GIT_NOTES_SUMMARIES_REF_NAME,
+                    GIT_NOTES_REPO_SALT_REF_NAME,
                 ],
             )?,
         };


### PR DESCRIPTION
In our tests the remote is not xet-enabled and a local clone set up the salt.