### PR TITLE
Pad out spaces on progress monitoring. 

### DIFF
--- a/rust/progress_reporting/src/data_progress.rs
+++ b/rust/progress_reporting/src/data_progress.rs
@@ -143,6 +143,11 @@ impl DataProgressReporter {
 
     /// Does the actual printing
     fn print(&self, is_final: bool) -> std::result::Result<(), std::io::Error> {
+        // Put a minimum width for the line we print.  This is based on git's messages,
+        // which can be longer than ours, causing weird inteleaving when the user does
+        // stuff to the input (hits a new line, etc.)  So, print a minimum buffer of spaces.
+        const PRINT_LINE_MIN_WIDTH: usize = 74;
+
         if self.disable || !self.is_active.load(Ordering::Relaxed) {
             return Ok(());
         }
@@ -161,7 +166,9 @@ impl DataProgressReporter {
         }
 
         // Acquire the print lock
-        let Ok(mut lg_print_info) = self.print_info.lock() else {return Ok(()) };
+        let Ok(mut lg_print_info) = self.print_info.lock() else {
+            return Ok(());
+        };
 
         // get the last print time
         let last_print_time = self.last_print_time.load(Ordering::Relaxed);
@@ -297,8 +304,10 @@ impl DataProgressReporter {
             }
         };
 
-        if write_str.len() < lg_print_info.last_write_length {
-            let mut len_to_write = lg_print_info.last_write_length - write_str.len();
+        let write_str_pad_len = lg_print_info.last_write_length.min(PRINT_LINE_MIN_WIDTH);
+
+        if write_str.len() < write_str_pad_len {
+            let mut len_to_write = write_str_pad_len - write_str.len();
 
             loop {
                 write_str.push_str(&WHITESPACE[..usize::min(len_to_write, WHITESPACE.len())]);

--- a/rust/progress_reporting/src/data_progress.rs
+++ b/rust/progress_reporting/src/data_progress.rs
@@ -304,7 +304,7 @@ impl DataProgressReporter {
             }
         };
 
-        let write_str_pad_len = lg_print_info.last_write_length.min(PRINT_LINE_MIN_WIDTH);
+        let write_str_pad_len = lg_print_info.last_write_length.max(PRINT_LINE_MIN_WIDTH);
 
         if write_str.len() < write_str_pad_len {
             let mut len_to_write = write_str_pad_len - write_str.len();


### PR DESCRIPTION
Puts a minimum width for the line we print in our progress bar, with the difference made up with spaces.  This is based on git's messages, which can be longer than ours, causing weird interleaving when the user does stuff to the input (hits a new line, etc.)  .