### PR TITLE
Swtich to embedded TLS roots instead of Native TLS

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -96,7 +96,7 @@ mockall_double = "0.3"
 
 # axe
 sysinfo = "0.26.6"
-reqwest = {version = "0.11.4", features = ["json"]}
+reqwest = {version = "0.11.4", features = ["json", "webpki-roots"]}
 serde_with = "1.6.1"
 chrono = {version = "0.4.19", features = ["serde"] }
 

--- a/rust/xetblob/Cargo.toml
+++ b/rust/xetblob/Cargo.toml
@@ -16,7 +16,7 @@ pointer_file = { path = "../pointer_file" }
 mdb_shard = { path = "../mdb_shard"}
 anyhow = "1"
 url = "2.3"
-reqwest = {version = "0.11.4"}
+reqwest = {version = "0.11.4", features=["json","webpki-roots"]}
 tracing = "0.1.*"
 tokio = { version = "1", features = ["full"] }
 serde = {version = "1.0.142", features = ["derive"] }


### PR DESCRIPTION
Mac Native TLS takes a long time to load.
https://github.com/rustls/rustls-native-certs/issues/30

This is an issue as some git operations spawn (sequentially) a large number of git-xet subprocesses. This switches reqwest to using an embedded Mozilla certificate roots.  (webpki-roots crate). This reduces push time by about 33%.