### PR TITLE
Disable recursive reference transaction hooks

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
+++ b/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
@@ -47,6 +47,7 @@ fn spawn_git_command(
 
     // Disable version check on recursive calls
     cmd.env("XET_DISABLE_VERSION_CHECK", "1");
+    cmd.env("XET_DISABLE_HOOKS", "1");
 
     if let Some(dir) = base_directory {
         debug_assert!(dir.exists());

--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -75,7 +75,7 @@ const PREPUSH_HOOK_CONTENT: &str =
 const REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V1: &str =
     "git-xet hooks reference-transaction-hook --action \"$1\"\n";
 const REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V2: &str =
-    "[[ \"${XET_DISABLE_HOOKS:-0}\" != 1 || \"$1\" != \"committed\" ]] || git-xet hooks reference-transaction-hook --action \"$1\"\n";
+    "[[ ! -z \"$XET_DISABLE_HOOKS\" ]] || git-xet hooks reference-transaction-hook --action \"$1\"\n";
 
 // Provides a mechanism to lock files that can often be modifiied, such as hooks,
 // .gitattributes, etc.  Normally our mechanisms should handle all these files


### PR DESCRIPTION
This PR disables recursive reference transaction hooks in the MerkleDB v2 case.  It is unclear why they are needed in the MDB v1 case; this warrants further investigation.

On the pre-push hook, this seems to save roughly 1.5 - 2 seconds of time depending on the scenario.  