### PR TITLE
Speedup of pre-push hook

### DIFF
--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -106,6 +106,9 @@ pub enum GitXetRepoError {
     #[error("Repo Salt Unavailable: {0}")]
     RepoSaltUnavailable(String),
 
+    #[error("Subtask scheduling error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
+
     #[error("Lazy Config Error : {0}")]
     LazyConfigError(#[from] LazyError),
 }
@@ -162,6 +165,7 @@ impl From<GitXetRepoError> for ExitCode {
             GitXetRepoError::RepoUninitialized(_) => 30,
             GitXetRepoError::RepoSaltUnavailable(_) => 31,
             GitXetRepoError::LazyConfigError(_) => 30,
+            GitXetRepoError::JoinError(_) => 32,
         })
     }
 }

--- a/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
+++ b/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
@@ -47,6 +47,7 @@ fn spawn_git_command(
 
     // Disable version check on recursive calls
     cmd.env("XET_DISABLE_VERSION_CHECK", "1");
+    cmd.env("XET_DISABLE_HOOKS", "1");
 
     if let Some(dir) = base_directory {
         debug_assert!(dir.exists());

--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -2,10 +2,10 @@ use is_executable::IsExecutable;
 use mdb_shard::error::MDBShardError;
 use mdb_shard::shard_version::ShardVersion;
 use std::collections::{HashMap, HashSet};
-use std::fs::create_dir_all;
 #[cfg(unix)]
 use std::fs::Permissions;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
+use std::fs::{create_dir_all, OpenOptions};
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 
@@ -71,8 +71,11 @@ lazy_static! {
 
 const PREPUSH_HOOK_CONTENT: &str =
     "git-xet hooks pre-push-hook --remote \"$1\" --remote-loc \"$2\"\n";
-const REFERENCE_TRANSACTION_HOOK_CONTENT: &str =
+
+const REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V1: &str =
     "git-xet hooks reference-transaction-hook --action \"$1\"\n";
+const REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V2: &str =
+    "[[ ! -z \"$XET_DISABLE_HOOKS\" ]] || git-xet hooks reference-transaction-hook --action \"$1\"\n";
 
 // Provides a mechanism to lock files that can often be modifiied, such as hooks,
 // .gitattributes, etc.  Normally our mechanisms should handle all these files
@@ -896,10 +899,20 @@ impl GitXetRepo {
             }
 
             if !content.contains(script) {
-                let mut file = OpenOptions::new().append(true).open(&path)?;
+                let mut file = OpenOptions::new().write(true).open(&path)?;
+
+                for line in content.lines() {
+                    if !line.contains("git-xet hooks") {
+                        writeln!(file, "{line}")?;
+                    }
+                }
                 writeln!(file, "{script}")?;
+
                 changed = true;
-                info!("Adding hooks to file {:?}, appending to end.", subpath);
+                info!(
+                    "Adding hooks to file {:?}, filtering and appending to end.",
+                    subpath
+                );
             }
         }
 
@@ -938,7 +951,12 @@ impl GitXetRepo {
     pub fn write_reference_transaction_hook(&self) -> Result<bool> {
         self.write_hook(
             "hooks/reference-transaction",
-            REFERENCE_TRANSACTION_HOOK_CONTENT,
+            match self.mdb_version {
+                ShardVersion::V1 => REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V1,
+                ShardVersion::V2 | ShardVersion::Uninitialized => {
+                    REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V2
+                }
+            },
         )
     }
 
@@ -949,7 +967,11 @@ impl GitXetRepo {
 
         let mut hook_erase_content: HashSet<&str> = HashSet::new();
 
-        for hook_line in &[PREPUSH_HOOK_CONTENT, REFERENCE_TRANSACTION_HOOK_CONTENT] {
+        for hook_line in &[
+            PREPUSH_HOOK_CONTENT,
+            REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V1,
+            REFERENCE_TRANSACTION_HOOK_CONTENT_MDB_V2,
+        ] {
             for s in hook_line
                 .lines()
                 .map(|s| s.trim())

--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -1,5 +1,8 @@
+use cas_client::Staging;
 use is_executable::IsExecutable;
 use mdb_shard::error::MDBShardError;
+use mdb_shard::session_directory::consolidate_shards_in_directory;
+use mdb_shard::shard_format::MDB_SHARD_MIN_TARGET_SIZE;
 use mdb_shard::shard_version::ShardVersion;
 use std::collections::{HashMap, HashSet};
 #[cfg(unix)]
@@ -8,6 +11,7 @@ use std::fs::{self, File};
 use std::fs::{create_dir_all, OpenOptions};
 #[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
+use tokio::sync::Mutex;
 
 use std::io::Write;
 use std::path::Path;
@@ -19,6 +23,7 @@ use crate::command::init::InitArgs;
 use crate::config::XetConfig;
 use crate::config::{ConfigGitPathOption, UpstreamXetRepo};
 
+use crate::data_processing_v2::create_cas_client;
 use crate::git_integration::git_process_wrapping;
 use crate::git_integration::git_repo_plumbing::*;
 use crate::git_integration::git_repo_salt::*;
@@ -29,13 +34,15 @@ use regex::Regex;
 use tracing::{debug, error, info, warn};
 
 use crate::constants::*;
-use crate::data_processing::PointerFileTranslator;
 use crate::errors::GitXetRepoError::{self};
-use crate::errors::Result;
+use crate::errors::{convert_cas_error, Result};
 use crate::merkledb_plumb::{
     self, check_merklememdb_is_empty, merge_merkledb_from_git, update_merkledb_to_git,
 };
-use crate::merkledb_shard_plumb::{self, get_mdb_version};
+use crate::merkledb_shard_plumb::{
+    self, get_mdb_version, move_session_shards_to_local_cache, sync_session_shards_to_remote,
+    update_mdb_shards_to_git_notes,
+};
 use crate::summaries_plumb::{merge_summaries_from_git, update_summaries_to_git};
 
 use super::git_merkledb::get_merkledb_notes_name;
@@ -106,6 +113,9 @@ pub struct GitXetRepo {
     pub merkledb_v2_session_dir: PathBuf,
     pub summaries_file: PathBuf,
     pub cas_staging_path: PathBuf,
+
+    // Some caching things that we may need to use multiple times.
+    cached_staging_cas: Mutex<Option<Arc<dyn Staging + Send + Sync>>>,
 }
 
 impl GitXetRepo {
@@ -196,6 +206,7 @@ impl GitXetRepo {
             merkledb_v2_session_dir,
             summaries_file,
             cas_staging_path,
+            cached_staging_cas: Mutex::new(None),
         })
     }
 
@@ -1384,6 +1395,7 @@ impl GitXetRepo {
             ShardVersion::V2 => {
                 merkledb_shard_plumb::sync_mdb_shards_to_git(
                     &self.xet_config,
+                    &self.get_staging_cas().await?,
                     &self.merkledb_v2_session_dir,
                     &self.merkledb_v2_cache_dir,
                     GIT_NOTES_MERKLEDB_V2_REF_NAME,
@@ -1575,26 +1587,32 @@ impl GitXetRepo {
         self.sync_remote_to_notes(remote)?;
 
         match self.mdb_version {
-            ShardVersion::V1 => self.run_git_checked_in_repo(
-                "push",
-                &[
-                    "--no-verify",
-                    remote,
-                    GIT_NOTES_MERKLEDB_V1_REF_NAME,
-                    GIT_NOTES_SUMMARIES_REF_NAME,
-                ],
-            )?,
-            ShardVersion::V2 | ShardVersion::Uninitialized => self.run_git_checked_in_repo(
-                "push",
-                &[
-                    "--no-verify",
-                    remote,
-                    GIT_NOTES_MERKLEDB_V2_REF_NAME,
-                    GIT_NOTES_MERKLEDB_V1_REF_NAME,
-                    GIT_NOTES_SUMMARIES_REF_NAME,
-                    GIT_NOTES_REPO_SALT_REF_NAME,
-                ],
-            )?,
+            ShardVersion::V1 => {
+                self.run_git_checked_in_repo(
+                    "push",
+                    &[
+                        "--no-verify",
+                        remote,
+                        GIT_NOTES_MERKLEDB_V1_REF_NAME,
+                        GIT_NOTES_SUMMARIES_REF_NAME,
+                    ],
+                )?;
+            }
+
+            ShardVersion::V2 | ShardVersion::Uninitialized => {
+                self.run_git_checked_in_repo(
+                    "push",
+                    &[
+                        "--no-verify",
+                        "--porcelain",
+                        remote,
+                        GIT_NOTES_MERKLEDB_V2_REF_NAME,
+                        GIT_NOTES_MERKLEDB_V1_REF_NAME,
+                        GIT_NOTES_SUMMARIES_REF_NAME,
+                        GIT_NOTES_REPO_SALT_REF_NAME,
+                    ],
+                )?;
+            }
         };
 
         Ok(())
@@ -1602,29 +1620,104 @@ impl GitXetRepo {
 
     /// Pushes all the staged data in the local CAS
     pub async fn upload_all_staged(&self) -> Result<()> {
-        let repo = PointerFileTranslator::from_config(&self.xet_config).await?;
-        repo.upload_cas_staged(false).await?;
-        Ok(())
+        let cas = self.get_staging_cas().await?;
+
+        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, true)
+            .await
+            .or_else(convert_cas_error)
     }
 
     /// The pre-push hook
     pub async fn pre_push_hook(&self, remote: &str) -> Result<()> {
         info!("Running prepush hook with remote = {}", remote);
 
-        // upload all staged should start first
-        // in case the other db has issues, we are guaranteed to at least
-        // get the bytes off the machine before anything else gets actually
-        // pushed
+        match self.mdb_version {
+            ShardVersion::V1 => {
+                // upload all staged should start first
+                // in case the other db has issues, we are guaranteed to at least
+                // get the bytes off the machine before anything else gets actually
+                // pushed
 
-        // the first upload staged is to ensure all xorbs are synced
-        // so shard registration (in MDBv2) in sync_dbs_to_notes will find them.
-        self.upload_all_staged().await?;
-        self.sync_dbs_to_notes().await?;
-        // the second upload staged is to ensure xorbs associated with large MDBv1
-        // diff as standalone pointer file as synced.
-        self.upload_all_staged().await?;
-        self.sync_notes_to_remote(remote)?;
+                self.upload_all_staged().await?;
 
+                self.sync_dbs_to_notes().await?;
+
+                // the second upload staged is to ensure xorbs associated with large MDBv1
+                // diff as standalone pointer file as synced.
+                self.upload_all_staged().await?;
+                self.sync_notes_to_remote(remote)?;
+            }
+            ShardVersion::V2 | ShardVersion::Uninitialized => {
+                // The shards themselves, with the shard server, are uploaded as part of
+                // the sync_dbs_to_notes.  So the upload_all_staged part can run independently
+                // from the sync_dbs_to_notes stage.
+
+                // First, get all the shards prepared and load them.
+                let session_dir = self.merkledb_v2_session_dir.clone();
+                let merged_shards_jh = tokio::spawn(async move {
+                    consolidate_shards_in_directory(&session_dir, MDB_SHARD_MIN_TARGET_SIZE)
+                });
+
+                // Now, start the CAS (needed for all the steps below.
+                let cas = self.get_staging_cas().await?;
+
+                // Begin uploading all the CAS blocks to the remote.
+                let upload_all_jh = {
+                    let cas = cas.clone();
+
+                    tokio::spawn(async move {
+                        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, false)
+                            .await
+                            .or_else(convert_cas_error)
+                    })
+                };
+
+                // Get a list of all the merged shards in order to upload them.
+                let merged_shards = merged_shards_jh.await??;
+
+                // Now, these need to be sent to the remote.  The rest of this task can happen
+                // independently of all of the notes stuff.
+                let upload_shard_jh = {
+                    let config = self.xet_config.clone();
+                    let cas = cas.clone();
+                    tokio::spawn(async move {
+                        sync_session_shards_to_remote(&config, &cas, merged_shards).await
+                    })
+                };
+
+                // Now while the shards are being uploaded, we can process the summaries.
+                update_summaries_to_git(
+                    &self.xet_config,
+                    &self.summaries_file,
+                    GIT_NOTES_SUMMARIES_REF_NAME,
+                )
+                .await?;
+
+                // Now, make sure we finish up all the remaining tasks that are running in the background.
+                upload_shard_jh.await??;
+
+                // Write v2 ref notes.  Make sure we do this after the shards have all
+                // finished uploading, or we could get
+                // notes pushed without a corresponding object in CAS.
+                update_mdb_shards_to_git_notes(
+                    &self.xet_config,
+                    &self.merkledb_v2_session_dir,
+                    GIT_NOTES_MERKLEDB_V2_REF_NAME,
+                )?;
+
+                self.sync_notes_to_remote(remote)?;
+
+                // Finally, we can move all the mdb shards from the session directory, which is used
+                // by the upload_shard task, to the cache.
+                move_session_shards_to_local_cache(
+                    &self.merkledb_v2_session_dir,
+                    &self.merkledb_v2_cache_dir,
+                )
+                .await?;
+
+                upload_all_jh.await??;
+            }
+        };
         Ok(())
     }
 
@@ -1824,6 +1917,20 @@ impl GitXetRepo {
         })?;
 
         Ok(true)
+    }
+
+    pub async fn get_staging_cas(&self) -> Result<Arc<dyn Staging + Send + Sync>> {
+        let mut staging_cas_lg = self.cached_staging_cas.lock().await;
+
+        if let Some(ret) = staging_cas_lg.as_ref() {
+            Ok(ret.clone())
+        } else {
+            let cas_client = create_cas_client(&self.xet_config).await?;
+
+            *staging_cas_lg = Some(cas_client.clone());
+
+            Ok(cas_client)
+        }
     }
 }
 

--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -1622,7 +1622,7 @@ impl GitXetRepo {
     pub async fn upload_all_staged(&self) -> Result<()> {
         let cas = self.get_staging_cas().await?;
 
-        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, true)
+        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, false)
             .await
             .or_else(convert_cas_error)
     }

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -620,8 +620,7 @@ pub async fn sync_session_shards_to_remote(
         };
 
         let shard_file_client = shard_client::from_config(shard_connection_config)
-            .await
-            .expect("1");
+            .await?;
         let shard_file_client_ref = &shard_file_client;
         let shard_prefix = config.cas.shard_prefix();
         let shard_prefix_ref = &shard_prefix;
@@ -635,7 +634,7 @@ pub async fn sync_session_shards_to_remote(
                 "Uploading shard {shard_prefix_ref}/{:?} from staging area to CAS.",
                 &si.shard_hash
             );
-            let data = fs::read(&si.path).expect("2");
+            let data = fs::read(&si.path);
             let data_len = data.len();
             // Upload the shard.
             cas.put_bypass_stage(

--- a/rust/gitxetcore/src/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries_plumb.rs
@@ -10,7 +10,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
-use crate::config::XetConfig;
+use crate::{config::XetConfig, errors::GitXetRepoError};
 use crate::{
     constants::GIT_NOTES_SUMMARIES_REF_NAME, errors, git_integration::GitNotesWrapper,
     summaries::analysis::FileSummary,
@@ -216,7 +216,7 @@ pub async fn update_summaries_to_git(
     config: &XetConfig,
     input: &Path,
     notesref: &str,
-) -> anyhow::Result<()> {
+) -> Result<(), GitXetRepoError> {
     // open the input db
     let inputdb = WholeRepoSummary::load_or_recreate_from_git(config, input, notesref).await?;
 

--- a/rust/xetblob/src/xet_repo.rs
+++ b/rust/xetblob/src/xet_repo.rs
@@ -708,7 +708,12 @@ impl XetRepoWriteTransaction {
                     return Ok(());
                 }
 
-                sync_session_shards_to_remote(&self.config, merged_shards).await?;
+                sync_session_shards_to_remote(
+                    &self.config,
+                    &create_cas_client(&self.config).await?,
+                    merged_shards,
+                )
+                .await?;
 
                 let Some(newmdbnote) = create_new_mdb_shard_note(session_dir)? else {
                     return Ok(());


### PR DESCRIPTION
This PR speeds up the pre-push hook significantly, cutting down the pre-push hook execution time on the Flickr30k dataset, with one change committed, from 9.5 seconds to 5 seconds.   There are two main parts:

1. Initializing the CAS once, and using it for all operations.   The previous version create a CAS staging client three independent times.  Each time takes well over a second due to the time required to scan the cache folder (another issue, the next one to look at).

2. Running the operations in parallel while respecting the dependencies.  The uploading to the CAS is done in the background for all of it.  Uploading the shards is done in the background until the notes are needed.