### PR TITLE
Robust .xet permission handling

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -81,6 +81,7 @@ winapi = { version = "0.3", features = ["winerror", "winnt", "handleapi", "proce
 normalize-path = "0.1.0"
 git-version = "0.3"
 const_format="0.2"
+whoami = "1.4.1"
 
 # tracing
 tracing-futures = "0.2"

--- a/rust/gitxetcore/src/command.rs
+++ b/rust/gitxetcore/src/command.rs
@@ -401,7 +401,9 @@ impl XetApp {
         let mut version_check_handle = None;
 
         if !self.config.disable_version_check {
-            version_check_handle = Some(tokio::spawn(VersionCheckInfo::load_or_query()));
+            version_check_handle = Some(tokio::spawn(VersionCheckInfo::load_or_query(
+                self.config.clone(),
+            )));
         }
 
         let span = get_trace_span(&self.command);

--- a/rust/gitxetcore/src/config/errors.rs
+++ b/rust/gitxetcore/src/config/errors.rs
@@ -109,6 +109,6 @@ pub enum ConfigError {
     #[error("Error parsing local repo config file: {0}")]
     RepoConfigFileParseError(String),
 
-    #[error("Lack of read-write permission for path: {0}")]
-    LackofPermission(PathBuf),
+    #[error("Cound not find parent for path: {0}")]
+    InvalidPathParent(PathBuf),
 }

--- a/rust/gitxetcore/src/config/errors.rs
+++ b/rust/gitxetcore/src/config/errors.rs
@@ -108,4 +108,7 @@ pub enum ConfigError {
 
     #[error("Error parsing local repo config file: {0}")]
     RepoConfigFileParseError(String),
+
+    #[error("Lack of read-write permission for path: {0}")]
+    LackofPermission(PathBuf),
 }

--- a/rust/gitxetcore/src/config/mod.rs
+++ b/rust/gitxetcore/src/config/mod.rs
@@ -18,7 +18,7 @@ mod env;
 mod errors;
 mod git_path;
 mod log;
-mod permission;
+pub mod permission;
 mod upstream_config;
 mod user;
 mod util;

--- a/rust/gitxetcore/src/config/permission.rs
+++ b/rust/gitxetcore/src/config/permission.rs
@@ -1,10 +1,8 @@
+use anyhow::anyhow;
 use colored::Colorize;
-#[cfg(unix)]
-use libc;
-use std::path::Path;
-#[cfg(windows)]
-use std::ptr;
-use tracing::warn;
+use rand::{thread_rng, Rng};
+use std::path::{Path, PathBuf};
+use tracing::info;
 #[cfg(windows)]
 use winapi::{
     shared::winerror::ERROR_SUCCESS,
@@ -16,10 +14,29 @@ use winapi::{
     },
 };
 
-#[derive(Debug, Clone)]
+// Facts:
+// Assume there's a standard user A that is not a root user.
+// 1. On Unix systems, suppose there is a path 'dir/f' where 'dir' is created by A but 'f'
+//    created by 'sudo A', A can read, rename or remove 'dir/f'. This implies that it's enough
+//    to check the permission of 'dir' if we don't directly write into 'dir/f'. This is exactly
+//    how we interact with the xorb cache: if an eviction is deemed necessary, the replacement
+//    data is written to a tempfile first and then renamed to the to-be-evicted entry. So even
+//    if a certain cache file was created by 'sudo A', the eviction by 'A' will succeed.
+// 2. On Windows, 'Run as administrator' by logged in user A actually sets %HOMEPATH% to administrator's
+//    HOME, so by default the xet metadata folders are isolated. If 'run as admin A' explicility configures
+//    cache or repo path to another location owned by A, ACLs for the created path inherit from the parent
+//    folder, so A still has full control.
+
+#[derive(Debug, Clone, Copy)]
 pub enum Permission {
     Regular,
     Elevated,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FileType {
+    File,
+    Dir,
 }
 
 impl Permission {
@@ -37,30 +54,125 @@ impl Permission {
         }
     }
 
-    pub fn check_path(&self, path: &Path) {
-        if self.is_elevated() && !path.exists() {
-            let message = format!("Warning: A xet command is running with elevated privileges. A xet metadata directory will be 
-created at {path:?} with elevated privileges. Future xet commands running with standard 
-privileges may not be able to access this folder, causing them to fail. If this is not desired, 
-please change the directory permissions accordingly.");
+    /// Check if the current process has R+W permission writing to 'path', if not can suggest an alternate
+    /// if 'suggest' is true by searching varies options in the below order:
+    ///
+    /// 1. paths in 'priority_suggest_list' from first to last.
+    /// 2. path_[$USER]
+    /// 3. $HOME/[suggest_prefix]_[random_number]
+    /// 4. $TMPDIR/[suggest_prefix]_[random_number]
+    /// 5. $PWD/[suggest_prefix]_[random_number]
+    /// The random numbers are generated from a CSPRNG and are unlikely to collide.
+    ///
+    /// If the current process is running with elevated privileges, warn if the checked path doesn't exist and will be created.
+    ///
+    /// Return Ok(path) if the provided path is good to write into or an alternate path is suggested;
+    /// Return Err(_) if lacking permision for the provided path and unable to suggest an alternate.
+    pub fn check_or_suggest_path(
+        &self,
+        path: &Path,
+        expect_type: FileType,
+        suggest: bool,
+        priority_suggest_list: Option<&[&Path]>,
+        suggest_prefix: Option<&str>,
+    ) -> anyhow::Result<PathBuf> {
+        if self.is_elevated() {
+            if !path.exists() {
+                let message = format!("Warning: A xet command is running with elevated privileges. A xet metadata directory will be 
+    created at {path:?} with elevated privileges. Future xet commands running with standard 
+    privileges may not be able to access this folder, causing them to fail. If this is not desired, 
+    please change the directory permissions accordingly.");
 
-            eprintln!("{}", message.bright_blue());
-            warn!("Xet directory {path:?} created with elevated privileges");
+                eprintln!("{}", message.bright_blue());
+                info!("Xet directory {path:?} created with elevated privileges");
+            }
+
+            // root user / administrator can create or access any path
+            return Ok(path.to_owned());
         }
+
+        // Now the process is running with standard privileges
+        if may_have_write_permission_into(path, expect_type) {
+            return Ok(path.to_owned());
+        }
+
+        info!("Lack permission for R+W into {path:?}");
+
+        if suggest {
+            if let Some(suggest_list) = priority_suggest_list {
+                for &path in suggest_list {
+                    if may_have_write_permission_into(path, expect_type) {
+                        return Ok(path.to_owned());
+                    }
+                    info!("Lack permission for R+W into {path:?}");
+                }
+            }
+
+            // Cannot write into path, try append the path by "_[username]"
+            let mut path = path.to_owned();
+            let pathstr = path.as_mut_os_string();
+            pathstr.push(format!("_{}", whoami::username()));
+
+            if may_have_write_permission_into(&path, expect_type) {
+                return Ok(path);
+            }
+
+            info!("Lack permission for R+W into {path:?}");
+
+            let last_component = format!(
+                "{}_{}",
+                suggest_prefix.unwrap_or_default(),
+                thread_rng().gen::<u32>() // thread_rng is CSPRNG, very unlikely to collide
+            );
+
+            // Cannot write into "path_[username]", try a random path "[prefix]_[xxx]" under HOME
+            if let Some(home) = dirs::home_dir() {
+                let path = home.join(&last_component);
+
+                if may_have_write_permission_into(&path, expect_type) {
+                    return Ok(path);
+                }
+
+                info!("Lack permission for R+W into {path:?}");
+            }
+
+            // Cannot write into home directory, try a random path "[prefix]_[xxx]" under /tmp
+            let path = std::env::temp_dir().join(&last_component);
+
+            if may_have_write_permission_into(&path, expect_type) {
+                return Ok(path);
+            }
+
+            info!("Lack permission for R+W into {path:?}");
+
+            // Cannot write into tmp directory, try a random path "[prefix]_[xxx]" under the cwd
+            let path = std::env::current_dir()
+                .unwrap_or_default()
+                .join(&last_component);
+
+            if may_have_write_permission_into(&path, expect_type) {
+                return Ok(path);
+            }
+
+            info!("Lack permission for R+W into {path:?}");
+        }
+
+        Err(anyhow!("Fail to find a path with correct permission"))
     }
 }
 
-/// Checks if the program is run under elevated privilege
-
+/// Checks if the program is running under elevated privilege
 fn is_elevated() -> bool {
     // In a Unix-like environment, when a program is run with sudo,
     // the effective user ID (euid) of the process is set to 0.
     #[cfg(unix)]
-    return unsafe { libc::geteuid() == 0 };
+    {
+        unsafe { libc::getegid() == 0 }
+    }
 
     #[cfg(windows)]
     {
-        let mut token: HANDLE = ptr::null_mut();
+        let mut token: HANDLE = std::ptr::null_mut();
         if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
             return false;
         }
@@ -85,11 +197,282 @@ fn is_elevated() -> bool {
     }
 }
 
-#[test]
-fn main() {
-    if is_elevated() {
-        println!("The program is running with elevated privileges.");
-    } else {
-        println!("The program is not running with elevated privileges.");
+/// Check if the current process may have R+W permission to a path.
+fn may_have_write_permission_into(path: impl AsRef<Path>, expect_type: FileType) -> bool {
+    let path = path.as_ref();
+    match expect_type {
+        FileType::File => {
+            if let Some(pparent) = path.parent() {
+                if std::fs::create_dir_all(pparent).is_err() {
+                    return false;
+                }
+            }
+            let exist = path.exists();
+            let f = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .read(true)
+                .open(path);
+            if f.is_err() {
+                return false;
+            }
+            drop(f);
+
+            // exist is only trustable if opening file for R+W succeeded
+            if !exist {
+                // removal can fail and it's ok
+                let _ = std::fs::remove_file(path);
+            }
+
+            true
+        }
+        FileType::Dir => {
+            if std::fs::create_dir_all(path).is_err() {
+                return false;
+            }
+            tempfile::tempfile_in(path).is_ok()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+
+    use super::{may_have_write_permission_into, FileType, Permission};
+    use crate::config::permission::is_elevated;
+
+    #[test]
+    #[ignore = "run manually due to sudo"]
+    fn test_read_write_permission() -> anyhow::Result<()> {
+        // Run this test manually, steps:
+
+        // For Unix
+        // 1. Run the below shell script in an empty dir with standard privileges.
+        // 2. Set env var 'XET_TEST_PATH' to this path.
+        // 3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
+        // 4. Locate the path to the executable as TEST_EXE
+        // 5. Run with test with a non-root user: 'TEST_EXE config::permission::test::test_read_write_permission --exact --nocapture --include-ignored'
+        // 6. Run with root user: 'sudo -E TEST_EXE config::permission::test::test_read_write_permission --exact --nocapture --include-ignored'
+        r#"
+# a regular dir with a regular file, a root file and a root dir
+mkdir regdir
+touch regdir/regf
+sudo touch regdir/rootf
+sudo mkdir regdir/rootdir
+
+# a root dir with a regular file, a root file and a regular dir
+sudo mkdir rootdir
+sudo touch rootdir/regf
+sudo chown $USER rootdir/regf
+sudo touch rootdir/rootf
+sudo mkdir rootdir/regdir
+sudo chown $USER rootdir/regdir
+"#;
+        let test_path = std::env::var("XET_TEST_PATH")?;
+        std::env::set_current_dir(test_path)?;
+
+        if is_elevated() {
+            // test path that exists
+            assert!(may_have_write_permission_into("regdir", FileType::Dir));
+            assert!(may_have_write_permission_into(
+                "regdir/regf",
+                FileType::File
+            ));
+            assert!(may_have_write_permission_into(
+                "regdir/rootf",
+                FileType::File
+            ));
+            assert!(may_have_write_permission_into(
+                "regdir/rootdir",
+                FileType::Dir
+            ));
+
+            assert!(may_have_write_permission_into("rootdir", FileType::Dir));
+            assert!(may_have_write_permission_into(
+                "rootdir/regf",
+                FileType::File
+            ));
+            assert!(may_have_write_permission_into(
+                "rootdir/rootf",
+                FileType::File
+            ));
+            assert!(may_have_write_permission_into(
+                "rootdir/regdir",
+                FileType::Dir
+            ));
+
+            // test path that doesn't exist
+            assert!(may_have_write_permission_into("regdir/adir", FileType::Dir));
+            assert!(may_have_write_permission_into("regdir/af", FileType::File));
+            assert!(may_have_write_permission_into(
+                "rootdir/adir",
+                FileType::Dir
+            ));
+            assert!(may_have_write_permission_into("rootdir/af", FileType::File));
+
+            assert!(may_have_write_permission_into("adir/adir", FileType::Dir));
+
+            assert!(may_have_write_permission_into("bdir/bf", FileType::File));
+
+            assert!(may_have_write_permission_into("cdir", FileType::Dir));
+
+            assert!(may_have_write_permission_into("cf", FileType::Dir));
+        } else {
+            // test path that exists
+            assert!(may_have_write_permission_into("regdir", FileType::Dir));
+            assert!(may_have_write_permission_into(
+                "regdir/regf",
+                FileType::File
+            ));
+            assert!(!may_have_write_permission_into(
+                "regdir/rootf",
+                FileType::File
+            ));
+            assert!(!may_have_write_permission_into(
+                "regdir/rootdir",
+                FileType::Dir
+            ));
+
+            assert!(!may_have_write_permission_into("rootdir", FileType::Dir));
+            assert!(may_have_write_permission_into(
+                "rootdir/regf",
+                FileType::File
+            ));
+            assert!(!may_have_write_permission_into(
+                "rootdir/rootf",
+                FileType::File
+            ));
+            assert!(may_have_write_permission_into(
+                "rootdir/regdir",
+                FileType::Dir
+            ));
+
+            // test path that doesn't exist
+            assert!(may_have_write_permission_into("regdir/adir", FileType::Dir));
+            assert!(may_have_write_permission_into("regdir/af", FileType::File));
+            assert!(!may_have_write_permission_into(
+                "rootdir/adir",
+                FileType::Dir
+            ));
+            assert!(!may_have_write_permission_into(
+                "rootdir/af",
+                FileType::File
+            ));
+
+            assert!(may_have_write_permission_into("adir/adir", FileType::Dir));
+
+            assert!(may_have_write_permission_into("bdir/bf", FileType::File));
+
+            assert!(may_have_write_permission_into("cdir", FileType::Dir));
+
+            assert!(may_have_write_permission_into("cf", FileType::Dir));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "run manually due to sudo"]
+    fn test_path_check_or_suggest_dir() -> anyhow::Result<()> {
+        // Run this test manually, steps:
+
+        // For Unix
+        // 1. Run the below shell script in an empty dir with standard privileges.
+        // 2. Set env var 'XET_TEST_PATH' to this path.
+        // 3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
+        // 4. Locate the path to the executable as TEST_EXE
+        // 5. Run with test with a non-root user: 'TEST_EXE config::permission::test::test_path_check_or_suggest_dir --exact --nocapture --include-ignored'
+        r#"
+sudo mkdir .xet
+"#;
+        let test_path = std::env::var("XET_TEST_PATH")?;
+        std::env::set_current_dir(test_path)?;
+
+        let permission = Permission::current();
+
+        let xet_home = Path::new(".xet");
+        let xet_home =
+            permission.check_or_suggest_path(xet_home, FileType::Dir, true, None, Some(".xet"))?;
+        assert_eq!(
+            &xet_home,
+            Path::new(&format!(".xet_{}", whoami::username()))
+        );
+
+        let cache_path = Path::new(".xet/cache");
+        let cache_path = permission.check_or_suggest_path(
+            cache_path,
+            FileType::File,
+            true,
+            Some(&[&xet_home.join("cache")]),
+            Some("cache"),
+        )?;
+
+        assert_eq!(
+            &cache_path,
+            Path::new(&format!(".xet_{}/cache", whoami::username()))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "run manually due to sudo"]
+    fn test_path_check_or_suggest_dir_prefix() -> anyhow::Result<()> {
+        // Run this test manually, steps:
+
+        // For Unix
+        // 1. Run the below shell script in an empty dir with standard privileges.
+        // 2. Set env var 'XET_TEST_PATH' to this path.
+        // 3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
+        // 4. Locate the path to the executable as TEST_EXE
+        // 5. Run with test with a non-root user: 'TEST_EXE config::permission::test::test_path_check_or_suggest_dir_prefix --exact --nocapture --include-ignored'
+        r#"
+sudo mkdir .xet
+sudo mkdir .xet_$USER
+"#;
+        let test_path = std::env::var("XET_TEST_PATH")?;
+        std::env::set_current_dir(test_path)?;
+
+        let permission = Permission::current();
+
+        let xet_home = Path::new(".xet");
+        let xet_home =
+            permission.check_or_suggest_path(xet_home, FileType::Dir, true, None, Some(".xet"))?;
+
+        assert!(xet_home.to_str().unwrap_or_default().contains(".xet"));
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "run manually due to sudo"]
+    fn test_path_check_or_suggest_file() -> anyhow::Result<()> {
+        // Run this test manually, steps:
+
+        // For Unix
+        // 1. Run the below shell script in an empty dir with standard privileges.
+        // 2. Set env var 'XET_TEST_PATH' to this path.
+        // 3. Build the test executable by running 'cargo test -p gitxetcore --lib --no-run'.
+        // 4. Locate the path to the executable as TEST_EXE
+        // 5. Run with test with a non-root user: 'TEST_EXE config::permission::test::test_path_check_or_suggest_file --exact --nocapture --include-ignored'
+        r#"
+mkdir .xet
+sudo touch .xet/upgrade_check
+"#;
+        let test_path = std::env::var("XET_TEST_PATH")?;
+        std::env::set_current_dir(test_path)?;
+
+        let permission = Permission::current();
+
+        let ucfile = Path::new(".xet/upgrade_check");
+        let ucfile = permission.check_or_suggest_path(ucfile, FileType::Dir, true, None, None)?;
+
+        assert_eq!(
+            &ucfile,
+            Path::new(&format!(".xet/upgrade_check_{}", whoami::username()))
+        );
+
+        Ok(())
     }
 }

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -261,10 +261,10 @@ impl XetConfig {
 
         let xet_home = dirs::home_dir().unwrap_or_default().join(DEFAULT_XET_HOME);
 
-        // check xet home permission, if lack of permission find an alternate
+        // create xet home with correct permission
         permission.create_dir_all(&xet_home)?;
 
-        // check cache path permission, if lack of permission find an alternate
+        // create cache directory with correct permission
         if let Some(cache) = active_cfg.cache.as_ref() {
             if let Some(cache_path) = cache.path.as_ref() {
                 permission.create_dir_all(cache_path)?;

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -5,7 +5,7 @@ use crate::config::cas::CasSettings;
 use crate::config::env::XetEnv;
 use crate::config::git_path::{ConfigGitPathOption, RepoInfo};
 use crate::config::log::LogSettings;
-use crate::config::permission::Permission;
+use crate::config::permission::{self, Permission};
 use crate::config::user::UserSettings;
 use crate::config::util;
 use crate::config::util::OptionHelpers;
@@ -25,7 +25,7 @@ use crate::smudge_query_interface::SmudgeQueryPolicy;
 use std::fs;
 use std::path::{Path, PathBuf};
 use url::Url;
-use xet_config::{Cfg, Level, XetConfigLoader};
+use xet_config::{Cfg, Level, XetConfigLoader, DEFAULT_CACHE_PATH_UNDER_HOME, DEFAULT_XET_HOME};
 
 use super::upstream_config::{LocalXetRepoConfig, UpstreamXetRepo};
 use toml;
@@ -79,6 +79,7 @@ pub struct XetConfig {
     pub origin_cfg: Cfg,
     pub upstream_xet_repo: Option<UpstreamXetRepo>,
     pub permission: Permission,
+    pub xet_home: PathBuf,
 }
 
 // pub methods
@@ -106,6 +107,7 @@ impl XetConfig {
             origin_cfg: Cfg::with_default_values(),
             upstream_xet_repo: Default::default(),
             permission: Permission::current(),
+            xet_home: Default::default(),
         }
     }
 
@@ -257,21 +259,45 @@ impl XetConfig {
         // Creation of the .xet folder happens below, check permission before it is created.
         let permission = Permission::current();
 
-        let xet_home = dirs::home_dir()
-            .ok_or_else(|| ConfigError::HomePathUnknown)?
-            .join(".xet");
+        let xet_home = dirs::home_dir().unwrap_or_default().join(DEFAULT_XET_HOME);
 
-        let path = if let Some(cache) = &active_cfg.cache {
-            cache.path.clone().unwrap_or(xet_home)
-        } else {
-            xet_home
-        };
+        // check xet home permission, if lack of permission find an alternate
+        let xet_home = permission
+            .check_or_suggest_path(
+                &xet_home,
+                permission::FileType::Dir,
+                true,
+                None,
+                Some(DEFAULT_XET_HOME),
+            )
+            .map_err(|_| {
+                eprintln!("Failed to find a Xet Home path, please check if any of environment variable '$HOME' or '%HOMEPATH%' and '$HOME/.xet' points at a directory with read and write permission");
+                ConfigError::LackofPermission(xet_home)
+            }
+            )?;
 
-        permission.check_path(&path);
+        // check cache path permission, if lack of permission find an alternate
+        let mut cache = active_cfg.cache.clone();
+        if let Some(ref mut cache) = cache {
+            if let Some(ref mut cache_path) = cache.path {
+                permission
+                    .check_or_suggest_path(
+                        cache_path,
+                        permission::FileType::Dir,
+                        true,
+                        Some(&[&xet_home.join(DEFAULT_CACHE_PATH_UNDER_HOME)]),
+                        Some(DEFAULT_CACHE_PATH_UNDER_HOME),
+                    )
+                    .map_err(|_| {
+                        eprintln!("Failed to find a Xet Cache Path, please check if any of environment variable 'XET_CACHE_PATH', config 'xet.cache.path' or '$HOME/.xet/cache' points at a directory with read and write permission");
+                        ConfigError::LackofPermission(cache_path.to_owned())
+                    })?;
+            }
+        }
 
         Ok(Self {
             cas: active_cfg.cas.as_ref().try_into()?,
-            cache: active_cfg.cache.as_ref().try_into()?,
+            cache: cache.as_ref().try_into()?,
             log: active_cfg.log.as_ref().try_into()?,
             user: (active_cfg.user.as_ref(), &repo_info.remote_urls).try_into()?,
             axe: active_cfg.axe.as_ref().try_into()?,
@@ -288,6 +314,7 @@ impl XetConfig {
             upstream_xet_repo: Default::default(),
             origin_cfg: active_cfg,
             permission,
+            xet_home,
         })
     }
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info};
 use version_compare::{self, Cmp};
 
-use crate::config::{permission::FileType, XetConfig};
+use crate::config::XetConfig;
 use crate::constants::CURRENT_VERSION;
 
 const GITHUB_REPO_OWNER: &str = "xetdata";
@@ -52,14 +52,8 @@ fn get_version_info_filename(config: &XetConfig) -> Option<PathBuf> {
 
     config
         .permission
-        .check_or_suggest_path(
-            &version_check_filename,
-            FileType::File,
-            true,
-            None,
-            Some(VERSION_CHECK_FILENAME_HOME),
-        )
-        .ok()
+        .create_file(&version_check_filename)
+        .map_or(None, |_| Some(version_check_filename))
 }
 
 fn get_current_version() -> String {

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -50,6 +50,7 @@ fn get_version_info_filename(config: &XetConfig) -> Option<PathBuf> {
         Err(_) => config.xet_home.join(VERSION_CHECK_FILENAME_HOME),
     };
 
+    // create version info file with correct permission
     config
         .permission
         .create_file(&version_check_filename)

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -14,7 +14,8 @@ pub const DEFAULT_CAS_PREFIX: &str = "default";
 pub const PROD_AXE_CODE: &str = "phc_aE643CSQ5F9MrqF8VT1gr7smML8hDU8gzH9lZ4WhdUY";
 pub const PROD_CAS_ENDPOINT: &str = "cas-lb.xethub.com:443";
 
-pub const DEFAULT_CACHE_PATH_HOME: &str = ".xet/cache";
+pub const DEFAULT_XET_HOME: &str = ".xet";
+pub const DEFAULT_CACHE_PATH_UNDER_HOME: &str = "cache";
 pub const DEFAULT_CACHE_SIZE: u64 = 10_737_418_240; // 10GiB
 
 pub const DEFAULT_LOG_LEVEL: &str = "warn";
@@ -117,8 +118,8 @@ impl Cfg {
     /// See the struct docs for an explanation of why we are not
     /// spreading this throughout the `Default` trait.
     pub fn with_default_values() -> Self {
-        let mut default_cache_path = dirs::home_dir().unwrap();
-        default_cache_path.push(DEFAULT_CACHE_PATH_HOME);
+        let default_xet_home = dirs::home_dir().unwrap_or_default().join(DEFAULT_XET_HOME);
+        let default_cache_path = default_xet_home.join(DEFAULT_CACHE_PATH_UNDER_HOME);
 
         Self {
             version: CURRENT_VERSION,

--- a/rust/xet_config/src/lib.rs
+++ b/rust/xet_config/src/lib.rs
@@ -7,7 +7,10 @@ mod level;
 mod loader;
 
 pub use cfg::{Axe, Cache, Cas, Cfg, Log, User};
-pub use cfg::{DEFAULT_CAS_PREFIX, PROD_AXE_CODE, PROD_CAS_ENDPOINT};
+pub use cfg::{
+    DEFAULT_CACHE_PATH_UNDER_HOME, DEFAULT_CAS_PREFIX, DEFAULT_XET_HOME, PROD_AXE_CODE,
+    PROD_CAS_ENDPOINT,
+};
 pub use error::CfgError;
 pub use level::Level;
 pub use loader::XetConfigLoader;

--- a/rust/xetblob/src/xet_repo_manager.rs
+++ b/rust/xetblob/src/xet_repo_manager.rs
@@ -51,6 +51,7 @@ impl XetRepoManager {
             config.xet_home.join(GLOBAL_REPO_ROOT_PATH)
         };
 
+        // create repo cache directory with correct permission
         config.permission.create_dir_all(&root_path)?;
 
         if root_path.exists() && !root_path.is_dir() {

--- a/rust/xetblob/src/xet_repo_manager.rs
+++ b/rust/xetblob/src/xet_repo_manager.rs
@@ -1,7 +1,7 @@
 use super::bbq_queries::*;
 use super::*;
 use gitxetcore::command::CliOverrides;
-use gitxetcore::config::{permission, remote_to_repo_info, ConfigGitPathOption, XetConfig};
+use gitxetcore::config::{remote_to_repo_info, ConfigGitPathOption, XetConfig};
 use gitxetcore::user::XeteaAuth;
 use std::collections::HashMap;
 use std::fs;
@@ -51,16 +51,7 @@ impl XetRepoManager {
             config.xet_home.join(GLOBAL_REPO_ROOT_PATH)
         };
 
-        let root_path = config.permission.check_or_suggest_path(
-            &root_path,
-            permission::FileType::Dir,
-            true,
-            None,
-            Some(GLOBAL_REPO_ROOT_PATH),
-        ).map_err(|e| {
-            eprintln!("Failed to find a Xet Repo Path, please check if any of environment variable 'XET_REPO_CACHE' or '$XET_HOME/repos' points at a directory with read and write permission");
-            e
-        })?;
+        config.permission.create_dir_all(&root_path)?;
 
         if root_path.exists() && !root_path.is_dir() {
             return Err(anyhow!(


### PR DESCRIPTION
Adds a `xet_home` in XetConfig. Each xet metadata folder/file to access (cache, repos, version_check_info), if not explicitly configured to a different path, will be created or read/written under a checked `xet_home`. Such directories and files will also be checked or created for R+W permissions with `Permission::create_dir_all` or `Permission::create_file`. If the running git-xet process lacks such permission, an error message is printed asking the user to reset the permissions.

Fix https://github.com/xetdata/xethub/issues/4592