### PR TITLE
Updated test_xet_version_check.sh to be robust to API rate limits.

### DIFF
--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -7,7 +7,7 @@ global_tmp_dir=/tmp
 if [[ ! -z ${TEMP} ]] ; then
   global_tmp_dir="$TEMP"
 elif [[ ! -z ${TEMP_DIR} ]] ; then 
-  global_tmp_dir="$TMP"
+  global_tmp_dir="$TEMP_DIR"
 elif [[ ! -z ${TMPDIR} ]] ; then
   global_tmp_dir="$TMPDIR"
 fi

--- a/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
+++ b/rust/gitxet/tests/integration_tests/test_xet_version_check.sh
@@ -2,19 +2,72 @@
 set -e
 set -x
 
+global_tmp_dir=/tmp
+
+if [[ ! -z ${TEMP} ]] ; then
+  global_tmp_dir="$TEMP"
+elif [[ ! -z ${TEMP_DIR} ]] ; then 
+  global_tmp_dir="$TMP"
+elif [[ ! -z ${TMPDIR} ]] ; then
+  global_tmp_dir="$TMPDIR"
+fi
+
+# Set this here, before HOME gets reset to isolate git.
+xet_version_info_file_full="${global_tmp_dir}/git_xet_version_check_api_cache_full"
+xet_version_info_file_latest="${global_tmp_dir}/git_xet_version_check_api_cache_latest"
+
+github_api_url_full="https://api.github.com/repos/xetdata/xet-tools/releases"
+github_api_url_latest="https://api.github.com/repos/xetdata/xet-tools/releases/latest"
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 . "$SCRIPT_DIR/initialize.sh"
 setup_basic_run_environment
 
-if [[ ! -z $(ping -c 1 github.com 2>&1 | grep -i "unknown host") ]] ; then 
-  echo "github.com unreachable, skipping test."
-  exit 0
+download_new_version_file () { 
+  local version_url="$1"
+  local version_file="$2"
+  curl -L "$version_url" > "$version_file.temp"
+
+  if [[ ! -z $(grep "API rate limit exceeded" "$version_file.temp") ]] ; then
+    >&2 echo "Skipping update of cache of local information; API rate limit exceded."
+    rm -f "$version_file.temp"
+  elif [[ -z $(grep -l "github.com/xetdata/xet-tools/releases" "$version_file.temp") ]] ; then 
+    >&2 echo "Skipping update of cache of local information; downloaded file does not contain the correct info." 
+    rm -f "$version_file.temp"
+  else 
+    mv "$version_file.temp" "$version_file" 
+  fi
+}
+
+refresh_version_file() {
+  local version_url="$1"
+  local version_file="$2"
+
+# To avoid unneeded pings of the github API, without causing tests to fail, attempt 
+if [[ -e "$file" ]] ; then 
+  # If it has been written in the last 24 hours, just use that.  Otherwise, download a new version.
+  if [[ ! -z $(find "$file" -mtime +1d -print) ]] ; then
+    download_new_version_file "$version_url" "$version_file"
+  fi
+else 
+    download_new_version_file "$version_url" "$version_file"
 fi
 
+}
+
+refresh_version_file $github_api_url_full $xet_version_info_file_full
+refresh_version_file $github_api_url_latest $xet_version_info_file_latest
+
+if [[ ! -e "$xet_version_info_file_full" ]] ||  [[ ! -e "$xet_version_info_file_latest" ]]; then
+  2<&1 echo "Error downloading version info information; skipping test."
+  exit 0
+fi
 
 unset XET_DISABLE_VERSION_CHECK
 export _XET_TEST_VERSION_OVERRIDE="v0.0.0"
 export XET_UPGRADE_CHECK_FILENAME=`pwd`/.xet/xet_version_info
+export _XET_VERSION_QUERY_URL_OVERRIDE_FULL="file://$xet_version_info_file_full"
+export _XET_VERSION_QUERY_URL_OVERRIDE_LATEST="file://$xet_version_info_file_latest"
 
 env
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -158,6 +158,13 @@ pub async fn retrieve_client_release_information(
         release_text = q_release_text;
     }
 
+    if release_text.contains("API rate limit exceeded") {
+        info!(
+            "API rate limit exceeded in querying github for new releases; ignoring version check."
+        );
+        return None;
+    }
+
     // Slightly different parse depending on whether we're looking at all version or just the latest.
     if only_latest {
         let Ok(release) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&release_text).map_err(|e|

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -91,15 +91,11 @@ pub async fn retrieve_client_release_information(
                 format!(
             "https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases/latest")
             }
+        } else if let Ok(url) = std::env::var("_XET_VERSION_QUERY_URL_OVERRIDE_FULL") {
+            // This will be the full URL; we'll skip the "latest" route here.
+            url
         } else {
-            if let Ok(url) = std::env::var("_XET_VERSION_QUERY_URL_OVERRIDE_FULL") {
-                // This will be the full URL; we'll skip the "latest" route here.
-                url
-            } else {
-                format!(
-                    "https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases"
-                )
-            }
+            format!("https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases")
         }
     };
 

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -82,12 +82,25 @@ pub async fn retrieve_client_release_information(
     remote_repo_name: &str,
     only_latest: bool,
 ) -> Option<Vec<serde_json::Map<String, serde_json::Value>>> {
-    let url = if only_latest {
-        format!(
-            "https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases/latest"
-        )
-    } else {
-        format!("https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases")
+    let url = {
+        if only_latest {
+            if let Ok(url) = std::env::var("_XET_VERSION_QUERY_URL_OVERRIDE_LATEST") {
+                // This will be the full URL; we'll skip the "latest" route here.
+                url
+            } else {
+                format!(
+            "https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases/latest")
+            }
+        } else {
+            if let Ok(url) = std::env::var("_XET_VERSION_QUERY_URL_OVERRIDE_FULL") {
+                // This will be the full URL; we'll skip the "latest" route here.
+                url
+            } else {
+                format!(
+                    "https://api.github.com/repos/{GITHUB_REPO_OWNER}/{remote_repo_name}/releases"
+                )
+            }
+        }
     };
 
     let mut query_table = GIT_QUERY_CACHE.lock().await;
@@ -96,6 +109,17 @@ pub async fn retrieve_client_release_information(
 
     if let Some(r_text) = query_table.get(&url) {
         release_text = r_text.clone();
+    } else if let Some(file_url) = url.strip_prefix("file://") {
+        let Ok(text) = std::fs::read(file_url).map_err(|e| {
+            error!(
+                "Error reading file {url} specified with _XET_VERSION_QUERY_URL_OVERRIDE_???: {e:?}"
+            );
+            e
+        }) else {
+            return None;
+        };
+
+        release_text = String::from_utf8(text).unwrap_or_default();
     } else {
         // Actually perform the query
 


### PR DESCRIPTION
test_xet_version_check pings the github server a lot, resulting in denials due to API rate limits.  This new version uses a local file cache to reduce this query to once ever 24 hours or so, and then passes still if the query hits such API rate limits.