### PR TITLE
Allow server only smudge on Xetea

### DIFF
--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -339,7 +339,15 @@ impl XetConfig {
                     .try_with_lazy_config(lazy_config)?
                     .try_with_repo_config_file(&git_path)?
             }
-            None => self,
+            None => {
+                // smudge query policy should be applied regardless of an existing repo
+                let smudge_query_policy = overrides
+                    .as_ref()
+                    .map(|x| x.smudge_query_policy)
+                    .unwrap_or_default();
+
+                self.try_with_smudge_query_policy(smudge_query_policy)?
+            }
         })
     }
 

--- a/rust/mdb_shard/src/error.rs
+++ b/rust/mdb_shard/src/error.rs
@@ -36,6 +36,9 @@ pub enum MDBShardError {
     #[error("MerkleDB Error: {0}")]
     MerkleDBError(#[from] MerkleDBError),
 
+    #[error("Smudge query policy Error: {0}")]
+    SmudgeQueryPolicyError(String),
+
     #[error("Error: {0}")]
     Other(String),
 }


### PR DESCRIPTION
1. update smudge query interface to really allow server only query
2. update smudge command to self retry on mdbv1 smudge, this helps to eliminates `merkledb query` and `merkledb extract-git` on V2 repos on xetea. 

Xetea side PR: https://github.com/xetdata/xethub/pull/4770

Fix https://github.com/xetdata/xethub/issues/3838