### PR TITLE
Don't try to write the .gitattributes in a bare repo

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -767,6 +767,11 @@ impl GitXetRepo {
     ) -> Result<bool> {
         // Make sure that * filter=xet is in .gitattributes.
 
+        // No need to do this in a bare repo.
+        if self.repo.is_bare() {
+            return Ok(false);
+        }
+
         let text = GITATTRIBUTES_CONTENT;
 
         let path = self.repo_dir.join(".gitattributes");


### PR DESCRIPTION
This can happen if GIT_WORK_TREE is set (e.g.)