### PR TITLE
ConfigGitPathOption::NoPath doesn't invoke git

### DIFF
--- a/rust/gitxetcore/src/config/git_path.rs
+++ b/rust/gitxetcore/src/config/git_path.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use tracing::info;
 
 /// Used in XetConfig::new
+#[derive(Clone)]
 pub enum ConfigGitPathOption {
     /// Provided directory may be part of a git repo. attempts to discover the root
     /// if available. If not in a git repo, behaves as if NoPath is provided

--- a/rust/gitxetcore/src/config/user.rs
+++ b/rust/gitxetcore/src/config/user.rs
@@ -131,7 +131,7 @@ impl TryFrom<(Option<&User>, &Vec<String>)> for UserSettings {
                     if !xetea_users_ssh.is_empty() {
                         user.ssh = Some(xetea_users_ssh.clone());
                         user_cfg_clone.ssh = Some(xetea_users_ssh.clone());
-                        if let Ok(loader) = config::xet::create_config_loader() {
+                        if let Ok(loader) = config::xet::create_config_loader(None) {
                             let _ =
                                 loader.override_value(Level::GLOBAL, "user.ssh", xetea_users_ssh);
                         }
@@ -155,7 +155,7 @@ impl TryFrom<(Option<&User>, &Vec<String>)> for UserSettings {
                     if !xetea_users_https.is_empty() {
                         user.https = Some(xetea_users_https.clone());
                         user_cfg_clone.https = Some(xetea_users_https.clone());
-                        if let Ok(loader) = config::xet::create_config_loader() {
+                        if let Ok(loader) = config::xet::create_config_loader(None) {
                             let _ = loader.override_value(
                                 Level::GLOBAL,
                                 "user.https",

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -39,8 +39,8 @@ pub fn get_global_config() -> Result<PathBuf, ConfigError> {
 
 /// Gets the path to the local config file for a particular xet.
 /// This will not check that the file exists or is read/writable.
-pub fn get_local_config() -> Result<PathBuf, GitXetRepoError> {
-    Ok(match get_repo_path(None)? {
+pub fn get_local_config(gitpath: Option<PathBuf>) -> Result<PathBuf, GitXetRepoError> {
+    Ok(match get_repo_path(gitpath)? {
         Some(repo) => repo.join(LOCAL_CONFIG_PATH),
         None => PathBuf::default(),
     })

--- a/rust/gitxetcore/src/config_cmd.rs
+++ b/rust/gitxetcore/src/config_cmd.rs
@@ -77,7 +77,7 @@ fn handle_config_command_internal(args: &ConfigArgs) -> Result<(), ConfigError> 
         _ => return Err(InvalidCombination),
     };
 
-    let loader = create_config_loader().map_err(|_| ConfigLoadError)?;
+    let loader = create_config_loader(None).map_err(|_| ConfigLoadError)?;
     let key_ref = args.key.as_ref();
 
     match &command {


### PR DESCRIPTION
So running pyxet on a machine without git will not fail. Fix https://github.com/xetdata/xethub/issues/4816