### PR TITLE
Possible fix for shard corruption issue.

### DIFF
--- a/rust/mdb_shard/src/intershard_reference_structs.rs
+++ b/rust/mdb_shard/src/intershard_reference_structs.rs
@@ -191,6 +191,8 @@ impl IntershardReferenceSequence {
                 .resize(INTERSHARD_REFERENCE_SIZE_CAP, Default::default());
         }
 
+        s.metadata = IntershardReferenceSequenceHeader::new(s.entries.len());
+
         s
     }
 
@@ -200,7 +202,7 @@ impl IntershardReferenceSequence {
     ) -> std::result::Result<usize, std::io::Error> {
         let mut n_bytes = 0;
 
-        n_bytes += self.metadata.serialize(writer)?;
+        n_bytes += IntershardReferenceSequenceHeader::new(self.entries.len()).serialize(writer)?;
 
         for isre in self.entries.iter() {
             n_bytes += isre.serialize(writer)?;


### PR DESCRIPTION
The issue was that the IntershardReference class used the entries vector to track everything, but the num_entries field of the header was not caught up to date.  In most cases this results in entries being ignored, but in the case of the corruption I witnessed, the value in the num_entries field was much larger than the number of entries. 