### PR TITLE
Adding size threshold as a config

### DIFF
--- a/rust/gitxetcore/src/config/errors.rs
+++ b/rust/gitxetcore/src/config/errors.rs
@@ -40,6 +40,9 @@ pub enum ConfigError {
     #[error("cas.prefix: {0} has invalid characters. Valid characters include ascii alphanumeric and: {1}")]
     InvalidCasPrefix(String, &'static str),
 
+    #[error("cas.sizethreshold: {0} is larger than the maximum supported threshold: {1} bytes")]
+    InvalidCasSizeThreshold(usize, usize),
+
     #[error("cache.path: {0} couldn't be created: {1}")]
     InvalidCachePath(PathBuf, io::Error),
 

--- a/rust/gitxetcore/src/config/util.rs
+++ b/rust/gitxetcore/src/config/util.rs
@@ -64,7 +64,7 @@ pub fn get_override_cfg(overrides: &CliOverrides) -> Cfg {
     if let Some(cas_endpoint) = overrides.cas.as_ref() {
         cas_overrides = Some(Cas {
             server: Some(cas_endpoint.clone()),
-            prefix: None,
+            ..Default::default()
         })
     }
 

--- a/rust/gitxetcore/src/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data_processing_v1.rs
@@ -27,7 +27,7 @@ use crate::config::XetConfig;
 use crate::constants::{
     CURRENT_VERSION, DERIVE_BLOCKS_CACHE_COUNT, GIT_NOTES_SUMMARIES_REF_NAME,
     MAX_CONCURRENT_DOWNLOADS, MAX_CONCURRENT_PREFETCHES, MAX_CONCURRENT_PREFETCH_DOWNLOADS,
-    MAX_CONCURRENT_UPLOADS, PREFETCH_TRACK_COUNT, PREFETCH_WINDOW_SIZE_BYTES, SMALL_FILE_THRESHOLD,
+    MAX_CONCURRENT_UPLOADS, PREFETCH_TRACK_COUNT, PREFETCH_WINDOW_SIZE_BYTES,
 };
 use crate::data_processing::{
     create_cas_client, data_from_chunks_to_writer, get_from_cas, pointer_file_from_reader,
@@ -138,7 +138,7 @@ impl PointerFileTranslatorV1 {
             summarydb,
             cas,
             prefix: config.cas.prefix.clone(),
-            small_file_threshold: SMALL_FILE_THRESHOLD,
+            small_file_threshold: config.cas.size_threshold,
             cas_accumulator: Arc::new(Mutex::new(CasAccumulator::default())),
             prefetches: Arc::new(Mutex::new(HashMap::new())),
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),
@@ -160,7 +160,7 @@ impl PointerFileTranslatorV1 {
             summarydb,
             cas,
             prefix: config.cas.prefix.clone(),
-            small_file_threshold: SMALL_FILE_THRESHOLD,
+            small_file_threshold: config.cas.size_threshold,
             cas_accumulator: Arc::new(Mutex::new(CasAccumulator::default())),
             prefetches: Arc::new(Mutex::new(HashMap::new())),
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),
@@ -867,7 +867,7 @@ impl PointerFileTranslatorV1 {
             summarydb,
             cas,
             prefix: "".into(),
-            small_file_threshold: SMALL_FILE_THRESHOLD,
+            small_file_threshold: crate::constants::SMALL_FILE_THRESHOLD,
             cas_accumulator: Arc::new(Mutex::new(CasAccumulator::default())),
             prefetches: Arc::new(Mutex::new(HashMap::new())),
             prefetched: Arc::new(Mutex::new(LruCache::new(PREFETCH_TRACK_COUNT))),

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -131,7 +131,7 @@ impl PointerFileTranslatorV2 {
             summarydb,
             cas: cas_client,
             prefix: config.cas.prefix.clone(),
-            small_file_threshold: SMALL_FILE_THRESHOLD,
+            small_file_threshold: config.cas.size_threshold,
             cas_data: Arc::new(Default::default()),
             repo_salt,
             cfg: config.clone(),

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -128,6 +128,7 @@ impl Cfg {
             cas: Some(Cas {
                 server: None,
                 prefix: None,
+                sizethreshold: None,
             }),
             cache: Some(Cache {
                 path: Some(default_cache_path),
@@ -241,6 +242,10 @@ pub struct Cas {
     pub server: Option<String>,
     /// Optional prefix for any calls to CAS.
     pub prefix: Option<String>,
+    /// Optional size threshold (in bytes) for cleaning text files into pointer files.
+    /// Setting this to 0 will cause all files to be treated as pointer files.
+    /// The threshold has to be <= SMALL_FILE_THRESHOLD
+    pub sizethreshold: Option<usize>
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
@@ -340,6 +345,7 @@ mod serialization_tests {
             cas: Some(Cas {
                 server: Some("localhost:40000".to_string()),
                 prefix: Some("test_prefix".to_string()),
+                sizethreshold: Some(1234),
             }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),
@@ -375,6 +381,7 @@ smudge = false
 [cas]
 server = "localhost:40000"
 prefix = "test_prefix"
+sizethreshold = 1234
 
 [cache]
 path = "/tmp/xet.log"
@@ -502,6 +509,7 @@ token = "abc123"
             cas: Some(Cas {
                 server: Some("localhost:40000".to_string()),
                 prefix: Some("test_prefix2".to_string()),
+                sizethreshold: Some(5723),
             }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),
@@ -536,6 +544,7 @@ smudge = true
 [cas]
 server = "localhost:40000"
 prefix = "test_prefix2"
+sizethreshold = 5723
 
 [cache]
 path = "/tmp/xet.log"
@@ -596,6 +605,7 @@ pth = "localhost"
             cas: Some(Cas {
                 server: Some("localhost:40000".to_string()),
                 prefix: Some("test_prefix2".to_string()),
+                sizethreshold: None,
             }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -252,7 +252,7 @@ mod tests {
             smudge: None,
             cas: Some(Cas {
                 prefix: Some("test".to_string()),
-                server: Default::default(),
+                ..Default::default()
             }),
             cache: Some(Cache {
                 path: Default::default(),
@@ -328,6 +328,7 @@ mod tests {
             cas: Some(Cas {
                 prefix: Some("".to_string()),
                 server: Some("some_server:5020".to_string()),
+                sizethreshold: None,
             }),
             log: Some(Log {
                 level: Some("debug".to_string()),
@@ -340,7 +341,7 @@ mod tests {
         let global_cfg = Cfg {
             cas: Some(Cas {
                 prefix: Some("prefix_global".to_string()),
-                server: None,
+                ..Default::default()
             }),
             log: Some(Log {
                 path: Some("/tmp/xet.log".into()),
@@ -384,7 +385,7 @@ mod tests {
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_server:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -393,6 +394,7 @@ mod tests {
             cas: Some(Cas {
                 server: Some("some_global_server:5020".to_string()),
                 prefix: Some("global".to_string()),
+                sizethreshold: None,
             }),
             ..Default::default()
         };
@@ -428,7 +430,7 @@ mod tests {
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_local_server:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -437,6 +439,7 @@ mod tests {
             cas: Some(Cas {
                 server: Some("some_global_server:5020".to_string()),
                 prefix: Some("global".to_string()),
+                sizethreshold: None,
             }),
             ..Default::default()
         };
@@ -463,7 +466,7 @@ mod tests {
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_server:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -488,7 +491,7 @@ server = "other_server:5000"
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_server2:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -546,7 +549,7 @@ prefix = "foo"
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_server:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -567,7 +570,7 @@ prefix = "foo"
         let local_cfg = Cfg {
             cas: Some(Cas {
                 server: Some("some_server:5020".to_string()),
-                prefix: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -576,8 +579,8 @@ prefix = "foo"
 
         let override_cfg = Cfg {
             cas: Some(Cas {
-                server: None,
                 prefix: Some("override_pre".to_string()),
+                ..Default::default()
             }),
             cache: Some(Cache {
                 size: Some(5020304),


### PR DESCRIPTION
Changes the small file threshold used in the pointer file translators from a constant to a config (e.g. `XET_CAS_SIZETHRESHOLD`). This allows applications like xet sync to treat all uploaded files as pointer files (by setting the threshold to 0) so that the sync doesn't overwhelm XetHub when uploading a dataset of thousands of moderately sized (~100KB) text files. 

We limit this config to be in the range: `[0, SMALL_FILE_THRESHOLD]` so that users don't try to upload files larger than our current pointer-file threshold.