### PR TITLE
Updated printing around the filter and pre-push process. 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "libmagic",
     "cache",
+    "common_constants",
     "merklehash",
     "merkledb",
     "mdb_shard",

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -9,6 +9,7 @@ strict = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+common_constants = {path = "../common_constants"}
 utils = {path = "../utils"}
 merkledb = {path = "../merkledb"}
 merklehash = { path = "../merklehash" } 

--- a/rust/cas_client/src/staging_client.rs
+++ b/rust/cas_client/src/staging_client.rs
@@ -18,6 +18,7 @@ use crate::interface::Client;
 use crate::local_client::LocalClient;
 use crate::staging_trait::*;
 use crate::PassthroughStagingClient;
+use common_constants::XET_PROGRAM_NAME;
 
 #[derive(Debug)]
 pub struct StagingClient {
@@ -118,8 +119,11 @@ impl StagingUpload for StagingClient {
         );
 
         let pb = if self.progressbar && !entries.is_empty() {
-            let pb =
-                DataProgressReporter::new("Xet: Uploading data blocks", Some(entries.len()), None);
+            let pb = DataProgressReporter::new(
+                &format!("{XET_PROGRAM_NAME}: Uploading data blocks"),
+                Some(entries.len()),
+                None,
+            );
 
             pb.register_progress(Some(0), Some(0)); // draw the bar immediately
 

--- a/rust/common_constants/Cargo.toml
+++ b/rust/common_constants/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "common_constants"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/common_constants/src/lib.rs
+++ b/rust/common_constants/src/lib.rs
@@ -1,0 +1,35 @@
+/// The maximum number of simultaneous download streams
+pub const MAX_CONCURRENT_DOWNLOADS: usize = 16;
+/// The maximum number of simultaneous upload streams
+pub const MAX_CONCURRENT_UPLOADS: usize = 16;
+
+/// The maximum number of simultaneous streams per prefetch call
+pub const MAX_CONCURRENT_PREFETCH_DOWNLOADS: usize = 4;
+/// The maximum number of simultaneous prefetches
+pub const MAX_CONCURRENT_PREFETCHES: usize = 4;
+/// This is the amount to download per prefetch
+pub const PREFETCH_WINDOW_SIZE_BYTES: u64 = 32 * 1024 * 1024;
+/// Number of historical prefetches to track
+pub const PREFETCH_TRACK_COUNT: usize = 32;
+
+/// Number of block derivations to memoize
+pub const DERIVE_BLOCKS_CACHE_COUNT: usize = 512;
+
+/// scheme for a local filesystem based CAS server
+pub const LOCAL_CAS_SCHEME: &str = "local://";
+
+/// The allowed endupoints usable with xet svc.
+pub const XET_ALLOWED_ENDPOINTS: &[&str] = &["xethub.com", "xetsvc.com", "xetbeta.com"];
+
+/// The minimum git version compatible with git xet.
+pub const MINIMUM_GIT_VERSION: &str = "2.29";
+
+/// The current version
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// A program tag name for reporting things:
+pub const XET_PROGRAM_NAME: &str = concat!("Git-Xet ", env!("CARGO_PKG_VERSION"));
+
+/// Maximum number of entries in the file construction cache
+/// which stores File Hash -> reconstruction instructions
+pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 
 
 [dependencies]
+common_constants = { path = "../common_constants" }
 cas_client = { path = "../cas_client"}
 xet_config = {path = "../xet_config"}
 merkledb = {path = "../merkledb"}

--- a/rust/gitxetcore/src/command/filter.rs
+++ b/rust/gitxetcore/src/command/filter.rs
@@ -2,7 +2,6 @@ use tracing::{info, info_span};
 use tracing_futures::Instrument;
 
 use crate::config::XetConfig;
-use crate::constants;
 use crate::data_processing::PointerFileTranslator;
 use crate::errors;
 use crate::git_integration::GitXetRepo;
@@ -10,7 +9,7 @@ use crate::stream::git_stream::GitStreamInterface;
 
 /// Filter command handler
 pub async fn filter_command(config: XetConfig) -> errors::Result<()> {
-    eprintln!("git-xet {} filter started", constants::CURRENT_VERSION);
+    // eprintln!("git-xet {} ", constants::CURRENT_VERSION);
     info!("Establishing Git Handshake.");
 
     // Sync up the notes to the local mdb

--- a/rust/gitxetcore/src/command/filter.rs
+++ b/rust/gitxetcore/src/command/filter.rs
@@ -9,7 +9,6 @@ use crate::stream::git_stream::GitStreamInterface;
 
 /// Filter command handler
 pub async fn filter_command(config: XetConfig) -> errors::Result<()> {
-    // eprintln!("git-xet {} ", constants::CURRENT_VERSION);
     info!("Establishing Git Handshake.");
 
     // Sync up the notes to the local mdb

--- a/rust/gitxetcore/src/config/log.rs
+++ b/rust/gitxetcore/src/config/log.rs
@@ -2,6 +2,7 @@ use crate::config;
 use crate::config::util::get_sanitized_invocation_command;
 use crate::config::ConfigError;
 use crate::config::ConfigError::{LogPathNotFile, LogPathReadOnly};
+use crate::constants::XET_PROGRAM_NAME;
 use atty::Stream;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
@@ -106,7 +107,7 @@ impl TryFrom<Option<&Log>> for LogSettings {
                         if std::env::var("XET_PRINT_LOG_FILE_PATH").unwrap_or("0".to_owned()) != "0"
                         {
                             let prog = get_sanitized_invocation_command(true);
-                            eprintln!("Xet: ({prog}) Writing logs to file {path:?}",);
+                            eprintln!("{XET_PROGRAM_NAME}: ({prog}) Writing logs to file {path:?}");
                         }
                         Some(path)
                     }

--- a/rust/gitxetcore/src/constants.rs
+++ b/rust/gitxetcore/src/constants.rs
@@ -1,3 +1,5 @@
+pub use common_constants::*;
+
 // TODO: .git is not reliably the git subfolder; need to use the proper version.
 pub const CAS_STAGING_SUBDIR: &str = "xet/staging";
 pub const GIT_NOTES_MERKLEDB_V1_REF_SUFFIX: &str = "xet/merkledb";
@@ -38,39 +40,6 @@ pub const POINTER_FILE_LIMIT: usize = GIT_MAX_PACKET_SIZE - 1;
 /// so we can read exactly up to that multiple of packets to determine if it
 /// is a small file.
 pub const SMALL_FILE_THRESHOLD: usize = 4 * GIT_MAX_PACKET_SIZE - 1;
-
-/// The maximum number of simultaneous download streams
-pub const MAX_CONCURRENT_DOWNLOADS: usize = 16;
-/// The maximum number of simultaneous upload streams
-pub const MAX_CONCURRENT_UPLOADS: usize = 16;
-
-/// The maximum number of simultaneous streams per prefetch call
-pub const MAX_CONCURRENT_PREFETCH_DOWNLOADS: usize = 4;
-/// The maximum number of simultaneous prefetches
-pub const MAX_CONCURRENT_PREFETCHES: usize = 4;
-/// This is the amount to download per prefetch
-pub const PREFETCH_WINDOW_SIZE_BYTES: u64 = 32 * 1024 * 1024;
-/// Number of historical prefetches to track
-pub const PREFETCH_TRACK_COUNT: usize = 32;
-
-/// Number of block derivations to memoize
-pub const DERIVE_BLOCKS_CACHE_COUNT: usize = 512;
-
-/// scheme for a local filesystem based CAS server
-pub const LOCAL_CAS_SCHEME: &str = "local://";
-
-/// The allowed endupoints usable with xet svc.
-pub const XET_ALLOWED_ENDPOINTS: &[&str] = &["xethub.com", "xetsvc.com", "xetbeta.com"];
-
-/// The minimum git version compatible with git xet.
-pub const MINIMUM_GIT_VERSION: &str = "2.29";
-
-/// The current version
-pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Maximum number of entries in the file construction cache
-/// which stores File Hash -> reconstruction instructions
-pub const FILE_RECONSTRUCTION_CACHE_SIZE: usize = 65536;
 
 // Salt is 256-bit in length.
 pub const REPO_SALT_LEN: usize = 32;

--- a/rust/gitxetcore/src/stream/git_stream.rs
+++ b/rust/gitxetcore/src/stream/git_stream.rs
@@ -203,12 +203,12 @@ impl<R: Read + Send + 'static, W: Write> GitStreamInterface<R, W> {
             total_active_smudging_volume: 0,
             lfs_pointers_present_on_smudge: Arc::new(AtomicBool::new(false)),
             clean_progress: Some(DataProgressReporter::new_inactive(
-                &format!("{XET_PROGRAM_NAME}: Processing data "),
+                &format!("{XET_PROGRAM_NAME}: Processing data"),
                 None,
                 None,
             )),
             smudge_progress: Some(DataProgressReporter::new_inactive(
-                &format!("{XET_PROGRAM_NAME}: Retrieving data "),
+                &format!("{XET_PROGRAM_NAME}: Retrieving data"),
                 None,
                 None,
             )),

--- a/rust/gitxetcore/src/stream/git_stream.rs
+++ b/rust/gitxetcore/src/stream/git_stream.rs
@@ -14,6 +14,7 @@ use crate::{
     stream::stream_reader::{GitStreamReadIterator, StreamStatus},
     stream::stream_writer::GitStreamWriter,
 };
+use common_constants::XET_PROGRAM_NAME;
 use fallible_iterator::FallibleIterator;
 use lazy_static::lazy_static;
 use pointer_file::PointerFile;
@@ -202,12 +203,12 @@ impl<R: Read + Send + 'static, W: Write> GitStreamInterface<R, W> {
             total_active_smudging_volume: 0,
             lfs_pointers_present_on_smudge: Arc::new(AtomicBool::new(false)),
             clean_progress: Some(DataProgressReporter::new_inactive(
-                "Xet: Deduplicating data blocks",
+                &format!("{XET_PROGRAM_NAME}: Processing data "),
                 None,
                 None,
             )),
             smudge_progress: Some(DataProgressReporter::new_inactive(
-                "Xet: Retrieving data blocks",
+                &format!("{XET_PROGRAM_NAME}: Retrieving data "),
                 None,
                 None,
             )),


### PR DESCRIPTION
Updated what gets printed on filter and pre-push hooks.  
- Eliminated the git-xet filter started message. 
- Moved version info to the progress printing.
- Moved constants to a common spot so places outside of gitxetcore can access constants not needed for git integration.

Now, instead of the filter printing on dedup:

```
git-xet 0.12.8 filter started
Xet: Deduplicating data blocks: 54.15 MiB | 54.15 MiB/s, done.
```

It now prints just:
```
Git-Xet 0.12.8: Processing data: 54.15 MiB | 54.15 MiB/s, done.
```

Instead of printing on download:

```
git-xet 0.12.8 filter started
Xet: Downloading data blocks: 54.15 MiB | 54.15 MiB/s, done.
```

It now prints just:
```
Git-Xet 0.12.8: Downloading data: 54.15 MiB | 54.15 MiB/s, done.
```

And on push upload, instead of:

```
"Xet: Uploading data blocks:  54.15 MiB | 54.15 MiB/s, done."
```

It prints 

```
"Git-Xet 0.12.8: Uploading data blocks:  54.15 MiB | 54.15 MiB/s, done."
```





