### PR TITLE
cas protocol initiate root ca field

### DIFF
--- a/rust/cas_client/src/grpc.rs
+++ b/rust/cas_client/src/grpc.rs
@@ -395,11 +395,13 @@ impl GrpcClient {
                     host: cas_hostname.clone(),
                     port: DEFAULT_H2_PORT.into(),
                     scheme: Scheme::Http.into(),
+                    ..Default::default()
                 },
                 EndpointConfig {
                     host: cas_hostname,
                     port: DEFAULT_PUT_COMPLETE_PORT.into(),
                     scheme: Scheme::Http.into(),
+                    ..Default::default()
                 },
             ));
         }

--- a/rust/utils/Cargo.toml
+++ b/rust/utils/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 tonic = {version = "0.10.2", features = ["tls", "tls-roots", "transport"] }
 prost = "0.12.3"
-prost-types = "0.9"
+prost-types = "0.12.3"
 serde = {version = "1.0", features = ["derive"] }
 merklehash = { path = "../merklehash"} 
 xet_error = {path = "../xet_error"}

--- a/rust/utils/proto/common.proto
+++ b/rust/utils/proto/common.proto
@@ -21,6 +21,7 @@ message EndpointConfig {
   string host = 1;
   int32 port = 2;
   Scheme scheme = 3;
+  string root_ca_certificate = 4;
 }
 
 message InitiateResponse {

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for common::Scheme {
 
 impl std::fmt::Display for common::EndpointConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let common::EndpointConfig { host, port, scheme } = self;
+        let common::EndpointConfig { host, port, scheme, .. } = self;
         let scheme_parsed = common::Scheme::try_from(*scheme).unwrap_or_default();
         write!(f, "{scheme_parsed}://{host}:{port}")
     }

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -123,6 +123,7 @@ mod tests {
             host: host.to_string(),
             port,
             scheme: common::Scheme::Http.into(),
+            root_ca_certificate: String::new(),
         };
 
         assert_eq!(e1.to_string(), format!("http://{host}:{port}"));
@@ -131,6 +132,7 @@ mod tests {
             host: host.to_string(),
             port,
             scheme: common::Scheme::Https.into(),
+            root_ca_certificate: String::from("abcd"),
         };
 
         assert_eq!(e2.to_string(), format!("https://{host}:{port}"));


### PR DESCRIPTION
Adds root ca certificate field to CAS Initiate Response needed for upcoming Encryption in Transit work.