### PR TITLE
Progress reporting for downloading mdb

### DIFF
--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -249,7 +249,7 @@ impl PointerFileTranslatorV2 {
         if let Some(sfi) = self.shard_manager.get_shard_handle(shard_hash, false).await {
             Ok(sfi)
         } else {
-            let shard_path = download_shard(
+            let (shard_path, _) = download_shard(
                 &self.cfg,
                 &self.cas,
                 shard_hash,
@@ -305,7 +305,8 @@ impl PointerFileTranslatorV2 {
                 return Ok::<(), GitXetRepoError>(());
             }
 
-            let p = download_shard(&self.cfg, &self.cas, &sh, &self.cfg.merkledb_v2_cache).await?;
+            let (p, _) =
+                download_shard(&self.cfg, &self.cas, &sh, &self.cfg.merkledb_v2_cache).await?;
             self.shard_manager
                 .register_shards_by_path(&[&p], true)
                 .await?;

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -12,10 +12,12 @@ use crate::merkledb_plumb::*;
 use crate::smudge_query_interface::FileReconstructionInterface;
 use crate::utils::*;
 use parutils::tokio_par_for_each;
+use progress_reporting::DataProgressReporter;
 use shard_client::ShardConnectionConfig;
 
 use bincode::Options;
 use cas_client::Staging;
+use common_constants::XET_PROGRAM_NAME;
 use git2::Oid;
 use mdb_shard::session_directory::consolidate_shards_in_directory;
 use mdb_shard::shard_file_handle::MDBShardFile;
@@ -332,11 +334,21 @@ pub async fn download_shards_to_cache(
     let cas = create_cas_client(config).await?;
     let cas_ref = &cas;
 
-    tokio_par_for_each(
+    let progress_reporter = DataProgressReporter::new(
+        &format!("{XET_PROGRAM_NAME}: Retrieving MerkleDB"),
+        Some(shards.len()),
+        None,
+    );
+
+    let pr_ref = progress_reporter.as_ref();
+
+    let ret = tokio_par_for_each(
         shards,
         MAX_CONCURRENT_DOWNLOADS,
         |shard_hash, _| async move {
-            download_shard(config, cas_ref, &shard_hash, cache_dir).await
+            let (path, nbytes) = download_shard(config, cas_ref, &shard_hash, cache_dir).await?;
+            pr_ref.register_progress(Some(1), Some(nbytes));
+            Ok(path)
         },
     )
     .await
@@ -345,16 +357,23 @@ pub async fn download_shards_to_cache(
             GitXetRepoError::InternalError(anyhow::anyhow!("Join Error on Shard Download"))
         }
         parutils::ParallelError::TaskError(e) => e,
-    })
+    });
+
+    progress_reporter.finalize();
+
+    ret
 }
 
+// Download a shard to local cache if not exists.
+// Returns the path to the downloaded file and the number of bytes transferred.
+// Returns the path to the existing file and 0 (transferred byte) if exists.
 #[allow(clippy::borrowed_box)]
 pub async fn download_shard(
     config: &XetConfig,
     cas: &Arc<dyn Staging + Send + Sync>,
     shard_hash: &MerkleHash,
     dest_dir: &Path,
-) -> errors::Result<PathBuf> {
+) -> errors::Result<(PathBuf, usize)> {
     let prefix = config.cas.shard_prefix();
 
     let shard_name = local_shard_name(shard_hash);
@@ -368,7 +387,7 @@ pub async fn download_shard(
         debug!(
             "download_shard: shard file {shard_name:?} already present in local cache, skipping download."
         );
-        return Ok(dest_file);
+        return Ok((dest_file, 0));
     } else {
         info!(
             "download_shard: shard file {shard_name:?} does not exist in local cache, downloading from cas."
@@ -387,7 +406,7 @@ pub async fn download_shard(
 
     write_all_file_safe(&dest_file, &bytes)?;
 
-    Ok(dest_file)
+    Ok((dest_file, bytes.len()))
 }
 
 /// Check if should convert MDB v1 shards.

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -335,7 +335,7 @@ pub async fn download_shards_to_cache(
     let cas_ref = &cas;
 
     let progress_reporter = DataProgressReporter::new(
-        &format!("{XET_PROGRAM_NAME}: Retrieving MerkleDB"),
+        &format!("{XET_PROGRAM_NAME}: Retrieving metadata"),
         Some(shards.len()),
         None,
     );


### PR DESCRIPTION
Reports progress when downloading MerkleDB on repo cloning. This can take a while on large repos.
<img width="908" alt="Screenshot 2024-01-12 at 5 38 00 PM" src="https://github.com/xetdata/xet-core/assets/4929549/f6065391-8662-4d69-9b7e-1b239452caa3">



Fix https://github.com/xetdata/xethub/issues/4939