### PR TITLE
git-xet client uses HTTPS endpoint

### DIFF
--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -41,7 +41,7 @@ tracing-opentelemetry = "0.17.2"
 progress_reporting = {path = "../progress_reporting"}
 serde_json = "1.0"
 hyper = { version = "1.1.0", features = ["client", "http2"] }
-hyper-util = "0.1.2"
+hyper-util = { version = "0.1.2", features = ["http2", "tokio", "client"] }
 http-body-util = "0.1.0"
 tokio-native-tls = "0.3.1"
 hyper-tls = "0.6.0"

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -40,10 +40,11 @@ opentelemetry-http = "0.6.0"
 tracing-opentelemetry = "0.17.2"
 progress_reporting = {path = "../progress_reporting"}
 serde_json = "1.0"
-
-# HTTP2 GET AND POST support
-h2 = "0.3.13"
-hyper = "0.14.18"
+hyper = { version = "1.1.0", features = ["client", "http2"] }
+hyper-util = "0.1.2"
+http-body-util = "0.1.0"
+tokio-native-tls = "0.3.1"
+hyper-tls = "0.6.0"
 bytes = "1"
 itertools = "0.10"
 

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -54,3 +54,4 @@ hyper-rustls = { version = "0.26.0", features = ["http2"] }
 trait-set = "0.3.0"
 lazy_static = "1.4.0"
 tokio-stream = { version = "0.1", features = ["net"] }
+rcgen = "0.12.0"

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -44,9 +44,11 @@ hyper = { version = "1.1.0", features = ["client", "http2"] }
 hyper-util = { version = "0.1.2", features = ["http2", "tokio", "client"] }
 http-body-util = "0.1.0"
 tokio-native-tls = "0.3.1"
-hyper-tls = "0.6.0"
 bytes = "1"
 itertools = "0.10"
+tokio-rustls = "0.25.0"
+rustls-pemfile = "2.0.0"
+hyper-rustls = { version = "0.26.0", features = ["http2"] }
 
 [dev-dependencies]
 trait-set = "0.3.0"

--- a/rust/cas_client/src/cas_connection_pool.rs
+++ b/rust/cas_client/src/cas_connection_pool.rs
@@ -47,8 +47,7 @@ pub struct CasConnectionConfig {
     pub auth: String,
     pub repo_paths: String,
     pub git_xet_version: String,
-    // TODO: this should really be shared somewhere, large string
-    pub root_ca: Option<String>,
+    pub root_ca: Option<Arc<String>>,
 }
 
 impl CasConnectionConfig {
@@ -71,7 +70,7 @@ impl CasConnectionConfig {
     }
 
     pub fn with_root_ca(mut self, root_ca: String) -> Self {
-        self.root_ca = Some(root_ca);
+        self.root_ca = Some(Arc::new(root_ca));
         self
     }
 }

--- a/rust/cas_client/src/cas_connection_pool.rs
+++ b/rust/cas_client/src/cas_connection_pool.rs
@@ -69,8 +69,8 @@ impl CasConnectionConfig {
         }
     }
 
-    pub fn with_root_ca(mut self, root_ca: String) -> Self {
-        self.root_ca = Some(Arc::new(root_ca));
+    pub fn with_root_ca<T: Into<String>>(mut self, root_ca: T) -> Self {
+        self.root_ca = Some(Arc::new(root_ca.into()));
         self
     }
 }

--- a/rust/cas_client/src/cas_connection_pool.rs
+++ b/rust/cas_client/src/cas_connection_pool.rs
@@ -40,11 +40,15 @@ const ASYNC_RUNTIME: Runtime = Runtime::Tokio1;
 /// CAS connections (both gRPC and H2)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CasConnectionConfig {
+    // this endpoint contains the scheme info (http/https)
+    // ideally we'd have the scheme separately.
     pub endpoint: String,
     pub user_id: String,
     pub auth: String,
     pub repo_paths: String,
     pub git_xet_version: String,
+    // TODO: this should really be shared somewhere, large string
+    pub root_ca: Option<String>,
 }
 
 impl CasConnectionConfig {
@@ -62,7 +66,13 @@ impl CasConnectionConfig {
             auth,
             repo_paths: serde_json::to_string(&repo_paths).unwrap_or_else(|_| "[]".to_string()),
             git_xet_version,
+            root_ca: None
         }
+    }
+
+    pub fn with_root_ca(mut self, root_ca: String) -> Self {
+        self.root_ca = Some(root_ca);
+        self
     }
 }
 

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -372,8 +372,14 @@ impl<'a> Injector for HeaderInjector<'a> {
 #[cfg(test)]
 mod tests {
     use std::vec;
+    use lazy_static::lazy_static;
 
     use super::*;
+
+    // cert to use for testing
+    lazy_static! {
+        static ref CERT: rcgen::Certificate = rcgen::generate_simple_self_signed(vec![]).unwrap();
+    }
 
     #[tokio::test]
     async fn test_from_config() {
@@ -385,7 +391,7 @@ mod tests {
             repo_paths: "repo".to_string(),
             git_xet_version: "0.1.0".to_string(),
             root_ca: None,
-        };
+        }.with_root_ca(CERT.serialize_pem().unwrap());
         let dt = DataTransport::from_config(config).await.unwrap();
         assert_eq!(dt.authority(), endpoint);
     }
@@ -415,7 +421,7 @@ mod tests {
                 "".to_string(),
                 inner_vec.clone(),
                 "".to_string(),
-            );
+            ).with_root_ca(CERT.serialize_pem().unwrap());
             let client = DataTransport::from_config(config).await.unwrap();
             let hello = "hello".as_bytes().to_vec();
             let hash = merklehash::compute_data_hash(&hello[..]);
@@ -440,7 +446,7 @@ mod tests {
             auth.to_string(),
             vec![],
             git_xet_version.to_string(),
-        );
+        ).with_root_ca(CERT.serialize_pem().unwrap());
         let client = DataTransport::from_config(cas_connection_config)
             .await
             .unwrap();

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -243,7 +243,9 @@ impl RemoteClient {
 
         debug!("Data transport completed");
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(put_complete.endpoint).with_root_ca(put_complete.root_ca);
+        let cas_connection_config = self
+            .get_cas_connection_config_for_endpoint(put_complete.endpoint)
+            .with_root_ca(put_complete.root_ca);
         let grpc_client = self
             .get_grpc_connection_for_config(cas_connection_config)
             .await?;
@@ -298,7 +300,9 @@ impl RemoteClient {
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(h2.endpoint).with_root_ca(h2.root_ca);
+        let cas_connection_config = self
+            .get_cas_connection_config_for_endpoint(h2.endpoint)
+            .with_root_ca(h2.root_ca);
         let transport = self
             .dt_connection_map
             .get_connection_for_config(cas_connection_config)
@@ -346,7 +350,9 @@ impl RemoteClient {
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(h2.endpoint).with_root_ca(h2.root_ca);
+        let cas_connection_config = self
+            .get_cas_connection_config_for_endpoint(h2.endpoint)
+            .with_root_ca(h2.root_ca);
         let transport = self
             .dt_connection_map
             .get_connection_for_config(cas_connection_config)

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -227,7 +227,7 @@ impl RemoteClient {
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        debug!("H2 Put initiate response h2 endpoint: {}, put complete endpoint {}", h2.endpoint, put_complete.endpoint);
+        debug!("H2 Put initiate response h2 endpoint: {}, put complete endpoint {}\nh2 cert: {}, put complete cert {}", h2.endpoint, put_complete.endpoint, h2.root_ca, put_complete.root_ca);
 
         {
             // separate scoped to drop transport so that the connection can be reclaimed by the pool

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -31,7 +31,12 @@ use retry_strategy::RetryStrategy;
 ///     h2 get + h2 put; port, host, and scheme from initiate rpc response
 ///     grpc put_complete; port, host, and scheme from initiate rpc response
 ///     defaults to 0.1.0 if initiate does not respond with required info
-const _CAS_PROTOCOL_VERSION: &str = "0.2.0";
+/// 0.3.0:
+///     grpc initiate; port 443; scheme https; widely trusted certificate
+///     h2 get + h2 put; port, host and scheme from initiate rpc response; includes custom root certificate authority
+///     grpc put_complete; port, host and scheme from initiate rpc response; includes custom root certificate authority
+///     defaults to 0.2.0 if initiate does not respond with correct info
+const _CAS_PROTOCOL_VERSION: &str = "0.3.0";
 
 lazy_static! {
     pub static ref CAS_PROTOCOL_VERSION: String =
@@ -93,6 +98,19 @@ pub struct RemoteClient {
     length_singleflight: singleflight::Group<u64, CasClientError>,
     length_cache: Arc<Mutex<HashMap<String, u64>>>,
     git_xet_version: String,
+}
+
+// DTO's for organization moving around endpoint info
+#[derive(Clone)]
+struct InitiateResponseEndpointInfo {
+    endpoint: String,
+    root_ca: String,
+}
+
+#[derive(Clone)]
+struct InitiateResponseEndpoints {
+    h2: InitiateResponseEndpointInfo,
+    put_complete: InitiateResponseEndpointInfo,
 }
 
 impl RemoteClient {
@@ -169,7 +187,7 @@ impl RemoteClient {
         prefix: &str,
         hash: &MerkleHash,
         len: usize,
-    ) -> Result<(String, String)> {
+    ) -> Result<InitiateResponseEndpoints> {
         let cas_connection_config =
             self.get_cas_connection_config_for_endpoint(self.lb_endpoint.clone());
         let lb_grpc_client = self
@@ -182,10 +200,16 @@ impl RemoteClient {
 
         debug!("cas initiate response; data plane endpoint: {data_plane_endpoint}; put complete endpoint: {put_complete_endpoint}");
 
-        Ok((
-            data_plane_endpoint.to_string(),
-            put_complete_endpoint.to_string(),
-        ))
+        Ok(InitiateResponseEndpoints{
+            h2: InitiateResponseEndpointInfo {
+                endpoint: data_plane_endpoint.to_string(),
+                root_ca: data_plane_endpoint.root_ca_certificate,
+            },
+            put_complete: InitiateResponseEndpointInfo {
+                endpoint: put_complete_endpoint.to_string(),
+                root_ca: put_complete_endpoint.root_ca_certificate,
+            },
+        })
     }
 
     async fn put_impl_h2(
@@ -196,18 +220,20 @@ impl RemoteClient {
         chunk_boundaries: &[u64],
     ) -> Result<()> {
         debug!("H2 Put executed with {} {}", prefix, hash);
-        let (http_direct, grpc_direct) = self
+        let InitiateResponseEndpoints {
+            h2, put_complete
+        } = self
             .initiate_cas_server_query(prefix, hash, data.len())
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        debug!("H2 Put initiate response h2 endpoint: {http_direct}, put complete endpoint {grpc_direct}");
+        debug!("H2 Put initiate response h2 endpoint: {}, put complete endpoint {}", h2.endpoint, put_complete.endpoint);
 
         {
             // separate scoped to drop transport so that the connection can be reclaimed by the pool
             let transport = self
                 .dt_connection_map
-                .get_connection_for_config(self.get_cas_connection_config_for_endpoint(http_direct))
+                .get_connection_for_config(self.get_cas_connection_config_for_endpoint(h2.endpoint).with_root_ca(h2.root_ca))
                 .await?;
             transport
                 .put(prefix, hash, data)
@@ -217,7 +243,7 @@ impl RemoteClient {
 
         debug!("Data transport completed");
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(grpc_direct);
+        let cas_connection_config = self.get_cas_connection_config_for_endpoint(put_complete.endpoint).with_root_ca(put_complete.root_ca);
         let grpc_client = self
             .get_grpc_connection_for_config(cas_connection_config)
             .await?;
@@ -267,12 +293,12 @@ impl RemoteClient {
     async fn get_impl_h2(&self, prefix: &str, hash: &MerkleHash) -> Result<Vec<u8>> {
         debug!("H2 Get executed with {} {}", prefix, hash);
 
-        let (http_direct, _) = self
+        let InitiateResponseEndpoints { h2, ..} = self
             .initiate_cas_server_query(prefix, hash, 0)
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(http_direct);
+        let cas_connection_config = self.get_cas_connection_config_for_endpoint(h2.endpoint).with_root_ca(h2.root_ca);
         let transport = self
             .dt_connection_map
             .get_connection_for_config(cas_connection_config)
@@ -315,12 +341,12 @@ impl RemoteClient {
     ) -> Result<Vec<Vec<u8>>> {
         debug!("H2 GetRange executed with {} {}", prefix, hash);
 
-        let (http_direct, _) = self
+        let InitiateResponseEndpoints { h2, ..} = self
             .initiate_cas_server_query(prefix, hash, 0)
             .instrument(debug_span!("remote_client.initiate"))
             .await?;
 
-        let cas_connection_config = self.get_cas_connection_config_for_endpoint(http_direct);
+        let cas_connection_config = self.get_cas_connection_config_for_endpoint(h2.endpoint).with_root_ca(h2.root_ca);
         let transport = self
             .dt_connection_map
             .get_connection_for_config(cas_connection_config)
@@ -508,7 +534,7 @@ impl RemoteClient {
         // While strictly by locking patterns we should release the
         // lock here, create the client, then re-acquire the lock to insert
         // into the map, in practice *thousands* of threads could call this
-        // method simultaneuously leading to a "race" where we create
+        // method simultaneously leading to a "race" where we create
         // thousands of connections.
         //
         // Really we need to "single-flight" connection creation per endpoint.

--- a/rust/shard_client/Cargo.toml
+++ b/rust/shard_client/Cargo.toml
@@ -38,7 +38,6 @@ serde_json = "1.0"
 mdb_shard = {path = "../mdb_shard"}
 
 # HTTP2 GET AND POST support
-h2 = "0.3.13"
 hyper = "0.14.18"
 bytes = "1"
 itertools = "0.10"

--- a/rust/shard_client/src/shard_client.rs
+++ b/rust/shard_client/src/shard_client.rs
@@ -341,8 +341,6 @@ impl FileReconstructor for GrpcShardClient {
 
         let response_info = response.into_inner();
 
-        // let shard_key = response_info.shard_id.unwrap();
-
         Ok(Some((
             MDBFileInfo {
                 metadata: FileDataSequenceHeader::new(


### PR DESCRIPTION
This PR should not merge before EOD PST of Tuesday 1/23/2024.

- Bump CAS Protocol version.
- Makes git-xet client's cas_client use the HTTPS data plane CAS protocol.
- processes certificate from initiate requests.