### PR TITLE
Updated logic around user name and user email

### DIFF
--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -22,23 +22,11 @@ setup_isolated_environment() {
   export HOME=$PWD
   export base_dir="$HOME"
 
-  if [[ ! -e $GIT_CONFIG_GLOBAL ]] ; then
-    echo "[user]
-        name = Xet Tester
-        email = test@xetdata.com
-    " > $GIT_CONFIG_GLOBAL
-  else 
+  if [[ -e $GIT_CONFIG_GLOBAL ]] ; then
     die "These tests may overwrite global settings; please run \
   them in a directory without a .gitconfig present."
   fi
   
-  # Do some checks to make sure that everything is set up
-  username=$(git config --get user.name || echo "")
-  [[ ! -z $username ]] || die "Git config user.name not set."
-
-  useremail=$(git config --get user.email || echo "")
-  [[ ! -z $useremail  ]] || die "Git config user.email not set."
-
   git config --global init.defaultBranch main
   git config --global --unset-all filter.xet.process || echo "global already unset"
   git config --global --unset-all filter.xet.required || echo "global already unset"

--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -22,11 +22,23 @@ setup_isolated_environment() {
   export HOME=$PWD
   export base_dir="$HOME"
 
-  if [[ -e $GIT_CONFIG_GLOBAL ]] ; then
+  if [[ ! -e $GIT_CONFIG_GLOBAL ]] ; then
+    echo "[user]
+        name = Xet Tester
+        email = test@xetdata.com
+    " > $GIT_CONFIG_GLOBAL
+  else 
     die "These tests may overwrite global settings; please run \
   them in a directory without a .gitconfig present."
   fi
   
+  # Do some checks to make sure that everything is set up
+  username=$(git config --get user.name || echo "")
+  [[ ! -z $username ]] || die "Git config user.name not set."
+
+  useremail=$(git config --get user.email || echo "")
+  [[ ! -z $useremail  ]] || die "Git config user.email not set."
+
   git config --global init.defaultBranch main
   git config --global --unset-all filter.xet.process || echo "global already unset"
   git config --global --unset-all filter.xet.required || echo "global already unset"

--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -1,4 +1,4 @@
-use crate::git_integration::{clone_xet_repo, git_user_config::verify_user_config_on_clone};
+use crate::git_integration::clone_xet_repo;
 use clap::Args;
 
 use crate::config::XetConfig;
@@ -27,7 +27,6 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
     let arg_v: Vec<&str> = args.arguments.iter().map(|s| s.as_ref()).collect();
 
     // First check local config.
-    verify_user_config_on_clone(None)?;
     eprintln!("Preparing to clone Xet repository.");
 
     clone_xet_repo(

--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -1,4 +1,4 @@
-use crate::git_integration::{clone_xet_repo, git_user_config::verify_user_config};
+use crate::git_integration::{clone_xet_repo, git_user_config::verify_user_config_on_clone};
 use clap::Args;
 
 use crate::config::XetConfig;
@@ -27,7 +27,7 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
     let arg_v: Vec<&str> = args.arguments.iter().map(|s| s.as_ref()).collect();
 
     // First check local config.
-    verify_user_config(None)?;
+    verify_user_config_on_clone(None)?;
     eprintln!("Preparing to clone Xet repository.");
 
     clone_xet_repo(

--- a/rust/gitxetcore/src/command/dir_summary.rs
+++ b/rust/gitxetcore/src/command/dir_summary.rs
@@ -76,7 +76,7 @@ pub async fn dir_summary_command(config: XetConfig, args: &DirSummaryArgs) -> er
         })?;
 
         if !args.no_cache {
-            let sig = gitrepo.signature()?;
+            let sig = repo.signature();
             // use force: true to overwrite existing note (if any) since the format may have changed
             gitrepo.note(&sig, &sig, Some(notes_ref), oid, &content_str, true)?;
         }

--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -213,7 +213,7 @@ pub async fn handle_merkledb_plumb_command(
     cfg: XetConfig,
     command: &MerkleDBSubCommandShim,
 ) -> errors::Result<()> {
-    let version = get_mdb_version(cfg.repo_path()?)?;
+    let version = get_mdb_version(cfg.repo_path()?, &cfg)?;
     info!("MDB version: {version:?}");
     match &command.subcommand {
         MerkleDBCommand::FindGitDB(args) => match version {
@@ -281,10 +281,12 @@ pub async fn handle_merkledb_plumb_command(
         },
         MerkleDBCommand::MergeGit(args) => match version {
             ShardVersion::V1 => {
-                utils::merge_git_notes(&args.base, &args.head, GIT_NOTES_MERKLEDB_V1_REF_NAME).await
+                utils::merge_git_notes(&args.base, &args.head, GIT_NOTES_MERKLEDB_V1_REF_NAME, &cfg)
+                    .await
             }
             ShardVersion::V2 => {
-                utils::merge_git_notes(&args.base, &args.head, GIT_NOTES_MERKLEDB_V2_REF_NAME).await
+                utils::merge_git_notes(&args.base, &args.head, GIT_NOTES_MERKLEDB_V2_REF_NAME, &cfg)
+                    .await
             }
             ShardVersion::Uninitialized => {
                 error!("Repo is not initialized for Xet.");
@@ -396,7 +398,7 @@ pub async fn handle_merkledb_plumb_command(
         MerkleDBCommand::Version(args) => {
             println!("{{");
             if args.with_salt && version.need_salt() {
-                let reposalt = read_repo_salt_by_dir(cfg.repo_path()?)?;
+                let reposalt = read_repo_salt_by_dir(cfg.repo_path()?, &cfg)?;
                 if let Some(reposalt) = reposalt {
                     println!("\"repo_salt\" : \"{}\",", base64::encode(reposalt));
                 } else {

--- a/rust/gitxetcore/src/command/repo_size.rs
+++ b/rust/gitxetcore/src/command/repo_size.rs
@@ -73,7 +73,8 @@ pub async fn get_repo_size_at_reference(
     no_cache_read: bool,
     no_cache_write: bool,
 ) -> errors::Result<()> {
-    let repo = GitXetRepo::open(config)?.repo;
+    let xet_repo = GitXetRepo::open(config)?;
+    let repo = xet_repo.repo.clone();
     let notes_ref = "refs/notes/xet/repo-size";
     let oid = repo
         .revparse_single(reference)
@@ -112,7 +113,7 @@ pub async fn get_repo_size_at_reference(
 
         // cache the result in git notes
         if !no_cache_write {
-            let sig = repo.signature()?;
+            let sig = xet_repo.signature();
             let note = sum.to_string();
             repo.note(&sig, &sig, Some(notes_ref), oid, &note, false)?;
         }
@@ -293,7 +294,7 @@ pub async fn get_detailed_repo_size_at_reference(
 
         // cache the result in git notes
         if !no_cache_write {
-            let sig = gitrepo.signature()?;
+            let sig = repo.signature();
             gitrepo.note(&sig, &sig, Some(notes_ref), oid, &content_str, true)?;
         }
         println!("{content_str}");

--- a/rust/gitxetcore/src/command/summary.rs
+++ b/rust/gitxetcore/src/command/summary.rs
@@ -166,7 +166,7 @@ pub async fn summary_command(config: XetConfig, args: &SummaryArgs) -> errors::R
         } => print_summary_from_blobid(&config, summary_type, blobid).await,
         SummarySubCommand::ListGit => summaries_list_git(config).await,
         SummarySubCommand::MergeGit { base, head } => {
-            utils::merge_git_notes(base, head, GIT_NOTES_SUMMARIES_REF_NAME).await
+            utils::merge_git_notes(base, head, GIT_NOTES_SUMMARIES_REF_NAME, &config).await
         }
         SummarySubCommand::Query { merklehash } => summaries_query(config, merklehash).await,
         SummarySubCommand::Dump => summaries_dump(config).await,

--- a/rust/gitxetcore/src/constants.rs
+++ b/rust/gitxetcore/src/constants.rs
@@ -43,3 +43,6 @@ pub const SMALL_FILE_THRESHOLD: usize = 4 * GIT_MAX_PACKET_SIZE - 1;
 
 // Salt is 256-bit in length.
 pub const REPO_SALT_LEN: usize = 32;
+
+pub const XET_BACKUP_COMMIT_NAME: &str = "Xet System";
+pub const XET_BACKUP_COMMIT_EMAIL: &str = "system@xethub.com";

--- a/rust/gitxetcore/src/data_processing.rs
+++ b/rust/gitxetcore/src/data_processing.rs
@@ -292,6 +292,7 @@ impl PointerFileTranslator {
                 .repo_path_if_present
                 .as_ref()
                 .unwrap_or(&PathBuf::default()),
+            config,
         )?;
 
         match version {

--- a/rust/gitxetcore/src/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data_processing_v2.rs
@@ -106,7 +106,7 @@ impl PointerFileTranslatorV2 {
         };
 
         let repo_salt = if in_repo {
-            read_repo_salt_by_dir(config.repo_path()?)?
+            read_repo_salt_by_dir(config.repo_path()?, config)?
         } else {
             None
         };

--- a/rust/gitxetcore/src/git_integration/git_notes_wrapper.rs
+++ b/rust/gitxetcore/src/git_integration/git_notes_wrapper.rs
@@ -1,16 +1,19 @@
 use base64;
 
-use git2::Repository;
+use git2::{Repository, Signature};
 use std::sync::Arc;
 
 use std::path::Path;
 use tracing::error;
+
+use crate::config::XetConfig;
 
 use super::git_repo_plumbing::open_libgit2_repo;
 
 pub struct GitNotesWrapper {
     repo: Arc<Repository>,
     notes_ref: String,
+    write_signature: Signature<'static>,
 }
 
 /// A wrapper around git notes that provides storage of arbitrary blobs
@@ -63,19 +66,40 @@ pub struct GitNotesWrapper {
 impl GitNotesWrapper {
     /// Open will automatically try to the find a repository
     /// in the path, moving up the directory tree as needed
-    pub fn open<P: AsRef<Path>>(path: P, notes_ref: &str) -> Result<GitNotesWrapper, git2::Error> {
+    pub fn open<P: AsRef<Path>>(
+        path: P,
+        config: &XetConfig,
+        notes_ref: &str,
+    ) -> Result<GitNotesWrapper, git2::Error> {
         let repo = open_libgit2_repo(Some(path.as_ref()))?;
+        Self::from_repo(repo, config, notes_ref)
+    }
+
+    pub fn from_repo(
+        repo: Arc<Repository>,
+        config: &XetConfig,
+        notes_ref: &str,
+    ) -> Result<GitNotesWrapper, git2::Error> {
+        // If the user name is not set, use the xet version.  If that isn't set, use a default value.
+        let name = repo
+            .config()
+            .ok()
+            .map(|c| c.get_str("user.name").map(|s| s.to_owned()).ok())
+            .unwrap_or_else(|| config.user.name.clone())
+            .unwrap_or_else(|| "Xet Bookkeeping".to_owned());
+
+        let email = repo
+            .config()
+            .ok()
+            .map(|c| c.get_str("user.email").map(|s| s.to_owned()).ok())
+            .unwrap_or_else(|| config.user.email.clone())
+            .unwrap_or_else(|| "user@xethub.com".to_owned());
+
         Ok(GitNotesWrapper {
             repo,
             notes_ref: notes_ref.into(),
+            write_signature: Signature::now(&name, &email)?.to_owned(),
         })
-    }
-
-    pub fn from_repo(repo: Arc<Repository>, notes_ref: &str) -> GitNotesWrapper {
-        GitNotesWrapper {
-            repo,
-            notes_ref: notes_ref.into(),
-        }
     }
 
     /// Returns an iterator over git blobs
@@ -173,12 +197,11 @@ impl GitNotesWrapper {
     /// Adds some content into the repository. This can be read out later
     /// via notes_content_iterator()
     pub fn add_note<T: AsRef<[u8]>>(&self, content: T) -> Result<(), git2::Error> {
-        let sig = self.repo.signature()?;
         let content_str = base64::encode(content.as_ref());
         let blob_oid = self.repo.blob(content_str.as_bytes())?;
         let note_ok = self.repo.note(
-            &sig,
-            &sig,
+            &self.write_signature,
+            &self.write_signature,
             Some(&self.notes_ref),
             blob_oid,
             &content_str,

--- a/rust/gitxetcore/src/git_integration/git_repo_salt.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo_salt.rs
@@ -1,4 +1,5 @@
 use super::git_notes_wrapper::GitNotesWrapper;
+use crate::config::XetConfig;
 use crate::constants::*;
 use crate::errors::{GitXetRepoError, Result};
 use crate::git_integration::git_repo_plumbing::open_libgit2_repo;
@@ -9,7 +10,7 @@ use tracing::info;
 
 pub type RepoSalt = [u8; REPO_SALT_LEN];
 
-pub fn read_repo_salt_by_dir(git_dir: &Path) -> Result<Option<RepoSalt>> {
+pub fn read_repo_salt_by_dir(git_dir: &Path, config: &XetConfig) -> Result<Option<RepoSalt>> {
     let Ok(repo) = open_libgit2_repo(Some(git_dir)).map_err(|e| {
         info!("Error opening {git_dir:?} as git repository; error = {e:?}.");
         e
@@ -17,12 +18,12 @@ pub fn read_repo_salt_by_dir(git_dir: &Path) -> Result<Option<RepoSalt>> {
         return Ok(None);
     };
 
-    read_repo_salt(repo)
+    read_repo_salt(repo, config)
 }
 
 // Read one blob from the notesref as salt.
 // Return error if find more than one note.
-pub fn read_repo_salt(repo: Arc<Repository>) -> Result<Option<RepoSalt>> {
+pub fn read_repo_salt(repo: Arc<Repository>, config: &XetConfig) -> Result<Option<RepoSalt>> {
     let notesref = GIT_NOTES_REPO_SALT_REF_NAME;
 
     if repo.find_reference(notesref).is_err() {
@@ -30,7 +31,7 @@ pub fn read_repo_salt(repo: Arc<Repository>) -> Result<Option<RepoSalt>> {
         return Ok(None);
     }
 
-    let notes_wrapper = GitNotesWrapper::from_repo(repo, notesref);
+    let notes_wrapper = GitNotesWrapper::from_repo(repo, config, notesref)?;
     let mut iter = notes_wrapper.notes_content_iterator()?;
     let Some((_, salt_data)) = iter.next() else {
         info!("Error reading repo salt from notes: {notesref} present but empty.");

--- a/rust/gitxetcore/src/git_integration/git_user_config.rs
+++ b/rust/gitxetcore/src/git_integration/git_user_config.rs
@@ -30,7 +30,7 @@ pub fn is_user_identity_set(path: Option<PathBuf>) -> std::result::Result<bool, 
     Ok(!(username.trim().is_empty() || email.trim().is_empty()))
 }
 
-pub fn verify_user_config(path: Option<PathBuf>) -> std::result::Result<(), git2::Error> {
+pub fn verify_user_config_on_clone(path: Option<PathBuf>) -> std::result::Result<(), git2::Error> {
     if !is_user_identity_set(path)? {
         return Err(git2::Error::from_str(
             "Configure your Git user name and email before running git-xet commands. \

--- a/rust/gitxetcore/src/git_integration/git_user_config.rs
+++ b/rust/gitxetcore/src/git_integration/git_user_config.rs
@@ -1,42 +1,52 @@
-use std::path::PathBuf;
+use std::{path::Path, sync::Arc};
 
-use super::git_process_wrapping;
+use git2::Repository;
+use tracing::info;
 
-pub fn is_user_identity_set(path: Option<PathBuf>) -> std::result::Result<bool, git2::Error> {
-    let (_, username, _) = git_process_wrapping::run_git_captured(
-        path.as_ref(),
-        "config",
-        &["user.name"],
-        false,
-        None,
-    )
-    .map_err(|e| {
-        git2::Error::from_str(&format!("Error retrieving config setting user.name: {e:?}"))
-    })?;
+use crate::{
+    config::XetConfig,
+    constants::{XET_BACKUP_COMMIT_EMAIL, XET_BACKUP_COMMIT_NAME},
+};
 
-    let (_, email, _) = git_process_wrapping::run_git_captured(
-        path.as_ref(),
-        "config",
-        &["user.email"],
-        false,
-        None,
-    )
-    .map_err(|e| {
-        git2::Error::from_str(&format!(
-            "Error retrieving config setting user.email: {e:?}"
-        ))
-    })?;
+use super::open_libgit2_repo;
 
-    Ok(!(username.trim().is_empty() || email.trim().is_empty()))
+// Returns the user name and email from available sources
+pub fn get_user_info_for_commit(
+    config: Option<&XetConfig>,
+    path: Option<&Path>,
+    repo: Option<Arc<Repository>>,
+) -> (String, String) {
+    let repo = repo.or_else(|| open_libgit2_repo(path.map(|p| p.as_ref())).ok());
+    let git_config = repo.and_then(|r| r.config().ok());
+
+    let user_name = git_config
+        .as_ref()
+        .and_then(|cfg| cfg.get_str("user.name").ok().map(|s| s.to_owned()))
+        .or_else(|| config.and_then(|c| c.user.name.clone()))
+        .unwrap_or_else(|| XET_BACKUP_COMMIT_NAME.to_owned());
+    let user_email = git_config
+        .as_ref()
+        .and_then(|cfg| cfg.get_str("user.email").ok().map(|s| s.to_owned()))
+        .or_else(|| config.and_then(|c| c.user.email.clone()))
+        .unwrap_or_else(|| XET_BACKUP_COMMIT_EMAIL.to_owned());
+
+    (user_name, user_email)
 }
 
-pub fn verify_user_config_on_clone(path: Option<PathBuf>) -> std::result::Result<(), git2::Error> {
-    if !is_user_identity_set(path)? {
-        return Err(git2::Error::from_str(
-            "Configure your Git user name and email before running git-xet commands. \
-\n\n  git config --global user.name \"<Name>\"\n  git config --global user.email \"<Email>\"",
-        ));
-    }
+pub fn get_repo_signature(
+    config: Option<&XetConfig>,
+    path: Option<&Path>,
+    repo: Option<Arc<Repository>>,
+) -> git2::Signature<'static> {
+    let (name, email) = get_user_info_for_commit(config, path, repo);
 
-    Ok(())
+    // Unwrap here only
+    git2::Signature::now(&name, &email)
+        .unwrap_or_else(|e| {
+            info!(
+                "Error converting name {name} and email {email} into a signature: {e:?}; using defaults."
+            );
+            git2::Signature::now(XET_BACKUP_COMMIT_NAME, XET_BACKUP_COMMIT_EMAIL).unwrap()
+        })
+        .to_owned()
 }

--- a/rust/gitxetcore/src/git_integration/git_user_config.rs
+++ b/rust/gitxetcore/src/git_integration/git_user_config.rs
@@ -16,7 +16,7 @@ pub fn get_user_info_for_commit(
     path: Option<&Path>,
     repo: Option<Arc<Repository>>,
 ) -> (String, String) {
-    let repo = repo.or_else(|| open_libgit2_repo(path.map(|p| p.as_ref())).ok());
+    let repo = repo.or_else(|| open_libgit2_repo(path).ok());
     let git_config = repo.and_then(|r| r.config().ok());
 
     let user_name = git_config

--- a/rust/gitxetcore/src/merkledb_shard_plumb.rs
+++ b/rust/gitxetcore/src/merkledb_shard_plumb.rs
@@ -270,8 +270,8 @@ fn sync_mdb_shards_meta_from_git(
     let mut shard_metas = MDBShardMetaCollection::default();
 
     // Walk the ref notes tree and deserialize all into a collection.
-    let repo =
-        GitNotesWrapper::open(get_repo_path_from_config(config)?, notesref).map_err(|e| {
+    let repo = GitNotesWrapper::open(get_repo_path_from_config(config)?, config, notesref)
+        .map_err(|e| {
             format!(
                 "sync_mdb_shards_meta_from_git: Unable to access git notes at {notesref:?}: {e:?}"
             );
@@ -480,17 +480,18 @@ pub async fn upgrade_from_v1_to_v2(config: &XetConfig) -> errors::Result<()> {
     }
 
     // Read repo salt
-    let repo_salt = if let Some(repo_salt) = git_repo_salt::read_repo_salt(repo.repo.clone())? {
-        repo_salt
-    } else {
-        repo.set_repo_salt()?;
-        let Some(repo_salt) = git_repo_salt::read_repo_salt(repo.repo.clone())? else {
-            return Err(GitXetRepoError::RepoSaltUnavailable(
-                "Repo salt still not avaialbe after set".to_owned(),
-            ));
+    let repo_salt =
+        if let Some(repo_salt) = git_repo_salt::read_repo_salt(repo.repo.clone(), config)? {
+            repo_salt
+        } else {
+            repo.set_repo_salt()?;
+            let Some(repo_salt) = git_repo_salt::read_repo_salt(repo.repo.clone(), config)? else {
+                return Err(GitXetRepoError::RepoSaltUnavailable(
+                    "Repo salt still not avaialbe after set".to_owned(),
+                ));
+            };
+            repo_salt
         };
-        repo_salt
-    };
 
     // We cannot directly call sync_notes_to_dbs because repo may be
     // detected as V2, and that will skip syncing V1 MerkleDB from notes.
@@ -528,7 +529,12 @@ pub async fn upgrade_from_v1_to_v2(config: &XetConfig) -> errors::Result<()> {
 
     // Write the guard note
     info!("MDB upgrading: writing version guard note");
-    write_mdb_version_guard_note(&repo.repo_dir, get_merkledb_notes_name, &ShardVersion::V2)?;
+    write_mdb_version_guard_note(
+        &repo.repo_dir,
+        get_merkledb_notes_name,
+        &ShardVersion::V2,
+        config,
+    )?;
 
     // Push notes to remote
     info!("MDB upgrading: pushing notes to remote");
@@ -729,8 +735,8 @@ pub fn update_mdb_shards_to_git_notes(
     session_dir: &Path,
     notesref: &str,
 ) -> errors::Result<()> {
-    let repo =
-        GitNotesWrapper::open(get_repo_path_from_config(config)?, notesref).map_err(|e| {
+    let repo = GitNotesWrapper::open(get_repo_path_from_config(config)?, config, notesref)
+        .map_err(|e| {
             error!(
                 "update_mdb_shards_to_git_notes: Unable to access git notes at {notesref:?}: {e:?}"
             );
@@ -772,6 +778,7 @@ pub fn write_mdb_version_guard_note(
     repo_path: &Path,
     notesrefs: impl Fn(&ShardVersion) -> &'static str,
     version: &ShardVersion,
+    config: &XetConfig,
 ) -> errors::Result<()> {
     let mut v = *version;
 
@@ -779,7 +786,7 @@ pub fn write_mdb_version_guard_note(
 
     while let Some(lower_v) = v.get_lower() {
         let lower_refnotes = notesrefs(&lower_v);
-        add_note(repo_path, lower_refnotes, &guard_note)?;
+        add_note(repo_path, lower_refnotes, &guard_note, config)?;
 
         v = lower_v;
     }
@@ -787,7 +794,7 @@ pub fn write_mdb_version_guard_note(
     Ok(())
 }
 
-pub fn get_mdb_version(repo_path: &Path) -> errors::Result<ShardVersion> {
+pub fn get_mdb_version(repo_path: &Path, config: &XetConfig) -> errors::Result<ShardVersion> {
     if !repo_path.exists() {
         info!("get_mdb_version: Repo path {repo_path:?} does not exist; defaulting to ShardVersion::V2.");
         return Ok(ShardVersion::get_max());
@@ -805,7 +812,8 @@ pub fn get_mdb_version(repo_path: &Path) -> errors::Result<ShardVersion> {
     // First test if the MDB V1 shard note is present.
     {
         let guard_note = create_guard_note(&ShardVersion::V2)?;
-        let mdb_v1_notes = GitNotesWrapper::from_repo(repo.clone(), GIT_NOTES_MERKLEDB_V1_REF_NAME);
+        let mdb_v1_notes =
+            GitNotesWrapper::from_repo(repo.clone(), config, GIT_NOTES_MERKLEDB_V1_REF_NAME)?;
 
         if mdb_v1_notes.find_note(guard_note)? {
             info!("get_mdb_version: V1 guard note found; shard version = V2.");
@@ -843,7 +851,7 @@ fn create_guard_note(version: &ShardVersion) -> errors::Result<Vec<u8>> {
 pub fn add_empty_note(config: &XetConfig, notesref: &str) -> errors::Result<()> {
     let note_with_empty_db =
         encode_shard_meta_collection_to_note(&MDBShardMetaCollection::default())?;
-    add_note(config.repo_path()?, notesref, &note_with_empty_db)?;
+    add_note(config.repo_path()?, notesref, &note_with_empty_db, config)?;
     Ok(())
 }
 

--- a/rust/gitxetcore/src/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries_plumb.rs
@@ -166,10 +166,11 @@ async fn merge_db_from_git(
     db: &mut WholeRepoSummary,
     notesref: &str,
 ) -> anyhow::Result<()> {
-    let repo = GitNotesWrapper::open(config.get_implied_repo_path()?, notesref).map_err(|e| {
-        error!("merge_db_from_git: Unable to access git notes at {notesref:?}: {e:?}");
-        e
-    })?;
+    let repo =
+        GitNotesWrapper::open(config.get_implied_repo_path()?, config, notesref).map_err(|e| {
+            error!("merge_db_from_git: Unable to access git notes at {notesref:?}: {e:?}");
+            e
+        })?;
 
     let mut blob_strm = iter(
         repo.notes_content_iterator()
@@ -235,10 +236,11 @@ pub async fn update_summaries_to_git(
     let vec = encode_summary_db_to_note(&diffdb)?;
     drop(diffdb);
 
-    let repo = GitNotesWrapper::open(config.get_implied_repo_path()?, notesref).map_err(|e| {
-        error!("update_summaries_to_git: Unable to access git notes at {notesref:?}: {e:?}");
-        e
-    })?;
+    let repo =
+        GitNotesWrapper::open(config.get_implied_repo_path()?, config, notesref).map_err(|e| {
+            error!("update_summaries_to_git: Unable to access git notes at {notesref:?}: {e:?}");
+            e
+        })?;
 
     repo.add_note(vec).map_err(|e| {
         error!("update_summaries_to_git: Error inserting new note in update_summaries_to_git ({notesref:?}): {e:?}");

--- a/rust/gitxetcore/src/utils.rs
+++ b/rust/gitxetcore/src/utils.rs
@@ -100,8 +100,13 @@ pub fn create_temp_file(dir: &Path, suffix: &str) -> io::Result<NamedTempFile> {
     Ok(tempfile)
 }
 
-pub fn add_note(repo_path: &Path, notesref: &str, note: &[u8]) -> errors::Result<()> {
-    let repo = GitNotesWrapper::open(repo_path, notesref).map_err(|e| {
+pub fn add_note(
+    repo_path: &Path,
+    notesref: &str,
+    note: &[u8],
+    config: &XetConfig,
+) -> errors::Result<()> {
+    let repo = GitNotesWrapper::open(repo_path, config, notesref).map_err(|e| {
         error!("add_note: Unable to access git notes at {notesref:?}: {e:?}");
         e
     })?;
@@ -114,11 +119,16 @@ pub fn add_note(repo_path: &Path, notesref: &str, note: &[u8]) -> errors::Result
 }
 
 /// Walks the ref notes of head repo, takes in notes that do not exist in base.
-pub async fn merge_git_notes(base: &Path, head: &Path, notesref: &str) -> errors::Result<()> {
-    let base = GitNotesWrapper::open(base, notesref)?;
+pub async fn merge_git_notes(
+    base: &Path,
+    head: &Path,
+    notesref: &str,
+    config: &XetConfig,
+) -> errors::Result<()> {
+    let base = GitNotesWrapper::open(base, config, notesref)?;
     let base_notes_oids = base.notes_name_iterator()?.collect::<HashSet<_>>();
 
-    let head = GitNotesWrapper::open(head, notesref)?;
+    let head = GitNotesWrapper::open(head, config, notesref)?;
     for (oid, blob) in head.notes_content_iterator()? {
         if !base_notes_oids.contains(&oid) {
             base.add_note(&blob)?;


### PR DESCRIPTION
This PR updates the logic around handling the user.name and user.email fields in the config.  These were needed for adding notes, as the notes needed a signature field to be filled out.  However, as these fields are rarely visible, we now use the following logic: 
- If user.name and user.email are available from git, use those.   
- Otherwise, if the user name and email are available from the xet config, use those. 
- Finally, if none of these are available, use "Xet System" for the name and "system@xethub.com" for the backup values. 

Now, with this change, there are no longer any checks for these fields.   Tests are updated to ensure they work in this environment.  

Resolves https://github.com/xetdata/xethub/issues/5021, https://github.com/xetdata/xethub/issues/4718, https://github.com/xetdata/xethub/issues/2561.
