### PR TITLE
pull out error printer and some usages

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,5 +21,6 @@ members = [
     "xet_error",
     "xet_config",
     "xetblob",
-    "lazy", "error_printer",
+    "lazy",
+    "error_printer",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,5 +21,5 @@ members = [
     "xet_error",
     "xet_config",
     "xetblob",
-    "lazy",
+    "lazy", "error_printer",
 ]

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -10,6 +10,7 @@ strict = []
 
 [dependencies]
 common_constants = {path = "../common_constants"}
+error_printer = {path = "../error_printer"}
 utils = {path = "../utils"}
 merkledb = {path = "../merkledb"}
 merklehash = { path = "../merklehash" } 

--- a/rust/error_printer/Cargo.toml
+++ b/rust/error_printer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "error_printer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1.40"

--- a/rust/error_printer/src/lib.rs
+++ b/rust/error_printer/src/lib.rs
@@ -1,0 +1,54 @@
+use std::fmt::{Debug, Display};
+use tracing::{debug, error, info, warn};
+
+pub trait ErrorPrinter {
+    fn log_error<M: Display>(self, message: M) -> Self;
+
+    fn warn_error<M: Display>(self, message: M) -> Self;
+
+    fn debug_error<M: Display>(self, message: M) -> Self;
+
+    fn info_error<M: Display>(self, message: M) -> Self;
+}
+
+impl<T, E: Debug> ErrorPrinter for Result<T, E> {
+    /// If self is an Err(e), prints out the given string to tracing::error,
+    /// appending "error: {e}" to the end of the message.
+    fn log_error<M: Display>(self, message: M) -> Self {
+        match &self {
+            Ok(_) => {}
+            Err(e) => error!("{}, error: {:?}", message, e),
+        }
+        self
+    }
+
+    /// If self is an Err(e), prints out the given string to tracing::warn,
+    /// appending "error: {e}" to the end of the message.
+    fn warn_error<M: Display>(self, message: M) -> Self {
+        match &self {
+            Ok(_) => {}
+            Err(e) => warn!("{}, error: {:?}", message, e),
+        }
+        self
+    }
+
+    /// If self is an Err(e), prints out the given string to tracing::debug,
+    /// appending "error: {e}" to the end of the message.
+    fn debug_error<M: Display>(self, message: M) -> Self {
+        match &self {
+            Ok(_) => {}
+            Err(e) => debug!("{}, error: {:?}", message, e),
+        }
+        self
+    }
+
+    /// If self is an Err(e), prints out the given string to tracing::info,
+    /// appending "error: {e}" to the end of the message.
+    fn info_error<M: Display>(self, message: M) -> Self {
+        match &self {
+            Ok(_) => {}
+            Err(e) => info!("{}, error: {:?}", message, e),
+        }
+        self
+    }
+}

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 hex = "0.4.3"
 xet_error = {path = "../xet_error"}
+error_printer = {path = "../error_printer"}
 tracing = "0.1.*"
 more-asserts = "0.3.*"
 futures = "0.3.28"

--- a/rust/gitxetcore/src/command/repo_size.rs
+++ b/rust/gitxetcore/src/command/repo_size.rs
@@ -5,7 +5,7 @@ use merkledb::*;
 use merklehash::*;
 use pointer_file::PointerFile;
 use std::collections::{HashMap, HashSet};
-use tracing::error;
+use error_printer::ErrorPrinter;
 
 #[derive(Args, Debug)]
 pub struct RepoSizeArgs {
@@ -281,10 +281,8 @@ pub async fn get_detailed_repo_size_at_reference(
         // we need to recompute the stats
         // load the merkledb
         let _ = repo.sync_notes_to_dbs().await;
-        let mdb = MerkleMemDB::open(&config.merkledb).map_err(|e| {
-            error!("Unable to open {:?}: {e:?}", &config.merkledb);
-            e
-        })?;
+        let mdb = MerkleMemDB::open(&config.merkledb)
+            .log_error(format!("Unable to open {:?}", &config.merkledb))?;
         let commit = gitrepo.find_commit(oid)?;
         let detailed_size = compute_detailed_repo_size(gitrepo, &mdb, &commit)?;
         let content_str = serde_json::to_string_pretty(&detailed_size).map_err(|_| {

--- a/rust/gitxetcore/src/diff/fetcher.rs
+++ b/rust/gitxetcore/src/diff/fetcher.rs
@@ -12,7 +12,7 @@ use crate::diff::error::DiffError;
 use crate::diff::error::DiffError::{FailedSummaryCalculation, NoSummaries, NotInRepoDir};
 use crate::diff::util::RefOrT;
 use crate::git_integration::GitXetRepo;
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use crate::summaries::analysis::FileSummary;
 use crate::summaries::csv::summarize_csv_from_reader;
 use crate::summaries::summary_type::SummaryType;

--- a/rust/gitxetcore/src/git_integration/git_repo_salt.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo_salt.rs
@@ -6,14 +6,12 @@ use git2::Repository;
 use std::path::Path;
 use std::sync::Arc;
 use tracing::info;
+use error_printer::ErrorPrinter;
 
 pub type RepoSalt = [u8; REPO_SALT_LEN];
 
 pub fn read_repo_salt_by_dir(git_dir: &Path) -> Result<Option<RepoSalt>> {
-    let Ok(repo) = open_libgit2_repo(Some(git_dir)).map_err(|e| {
-        info!("Error opening {git_dir:?} as git repository; error = {e:?}.");
-        e
-    }) else {
+    let Ok(repo) = open_libgit2_repo(Some(git_dir)).info_error(format!("Error opening {git_dir:?} as git repository")) else {
         return Ok(None);
     };
 

--- a/rust/gitxetcore/src/log.rs
+++ b/rust/gitxetcore/src/log.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::fs::OpenOptions;
 use std::{env, io, process};
 
@@ -13,39 +13,11 @@ use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
 use opentelemetry::sdk::trace;
 use opentelemetry::sdk::trace::XrayIdGenerator;
 use opentelemetry::Context;
-use tracing::{debug, error, info_span, warn, Span};
+use tracing::{debug, info_span, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
-
-pub trait ErrorPrinter {
-    fn log_error<M: Display>(self, message: M) -> Self;
-
-    fn warn_error<M: Display>(self, message: M) -> Self;
-}
-
-impl<T, E: Debug> ErrorPrinter for Result<T, E> {
-    /// If self is an Err(e), prints out the given string to tracing::error,
-    /// appending "error: {e}" to the end of the message.
-    fn log_error<M: Display>(self, message: M) -> Self {
-        match &self {
-            Ok(_) => {}
-            Err(e) => error!("{}, error: {:?}", message, e),
-        }
-        self
-    }
-
-    /// If self is an Err(e), prints out the given string to tracing::warn,
-    /// appending "error: {e}" to the end of the message.
-    fn warn_error<M: Display>(self, message: M) -> Self {
-        match &self {
-            Ok(_) => {}
-            Err(e) => warn!("{}, error: {:?}", message, e),
-        }
-        self
-    }
-}
 
 fn log_exception(source: &str) {
     tracing::error!(

--- a/rust/gitxetcore/src/upgrade_checks.rs
+++ b/rust/gitxetcore/src/upgrade_checks.rs
@@ -10,6 +10,7 @@ use std::{
 use tokio::sync::Mutex;
 use tracing::{debug, error, info};
 use version_compare::{self, Cmp};
+use error_printer::ErrorPrinter;
 
 use crate::config::XetConfig;
 use crate::constants::CURRENT_VERSION;
@@ -273,17 +274,11 @@ impl VersionCheckInfo {
             return None;
         }
 
-        let Ok(file_contents) = std::fs::read_to_string(version_check_filename).map_err(|e| {
-            info!("Error reading version file {version_check_filename:?}: {e:?})");
-            e
-        }) else {
+        let Ok(file_contents) = std::fs::read_to_string(version_check_filename).info_error(format!("Error reading version file {version_check_filename:?}"))else {
             return None;
         };
 
-        if let Ok(mut vci) = serde_json::from_str::<VersionCheckInfo>(&file_contents).map_err(|e| {
-            info!("Error decoding version file contents from {version_check_filename:?}: {e:?})");
-            e
-        }) {
+        if let Ok(mut vci) = serde_json::from_str::<VersionCheckInfo>(&file_contents).info_error(format!("Error decoding version file contents from {version_check_filename:?}")) {
             vci.version_check_filename = Some(version_check_filename.to_owned());
             info!("Loaded version check information {vci:?}.");
             Some(vci)

--- a/rust/gitxetcore/src/xetmnt/watch/metadata.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata.rs
@@ -13,7 +13,7 @@ use tracing::info;
 use cache::StatCache;
 use symbol::Symbols;
 
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use crate::xetmnt::watch::contents::EntryContent;
 use crate::xetmnt::watch::metadata::filesystem::{FileSystem, LookupStrategy};
 

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/cache.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/cache.rs
@@ -1,4 +1,4 @@
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use lru::LruCache;
 use nfsserve::nfs::nfsstat3::NFS3ERR_IO;
 use nfsserve::nfs::{fattr3, fileid3, nfsstat3};

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/filesystem.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/filesystem.rs
@@ -10,7 +10,7 @@ use nfsserve::nfs::nfsstat3::{NFS3ERR_BAD_COOKIE, NFS3ERR_IO, NFS3ERR_NOENT, NFS
 use nfsserve::nfs::{fattr3, fileid3, filename3, nfsstat3};
 use tracing::error;
 
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use crate::xetmnt::watch::contents::{DirectoryMetadata, EntryContent};
 use crate::xetmnt::watch::metadata::symbol::Symbols;
 use crate::xetmnt::watch::metadata::FSObject;

--- a/rust/gitxetcore/src/xetmnt/watch/metadata/symbol.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/metadata/symbol.rs
@@ -1,4 +1,4 @@
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use intaglio::osstr::SymbolTable;
 use intaglio::Symbol;
 use nfsserve::nfs::nfsstat3::{NFS3ERR_INVAL, NFS3ERR_IO};

--- a/rust/gitxetcore/src/xetmnt/watch/watcher.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/watcher.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use crate::data_processing::PointerFileTranslator;
 use crate::git_integration::get_git_executable;
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use crate::xetmnt::watch::metadata::FSMetadata;
 
 const REMOTE: &str = "origin";

--- a/rust/gitxetcore/src/xetmnt/watch/xetfs_watch.rs
+++ b/rust/gitxetcore/src/xetmnt/watch/xetfs_watch.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info};
 use crate::config::XetConfig;
 use crate::constants as gitxet_constants;
 use crate::data_processing::PointerFileTranslator;
-use crate::log::ErrorPrinter;
+use error_printer::ErrorPrinter;
 use crate::xetmnt::watch::contents::EntryContent;
 use crate::xetmnt::watch::metadata::FSMetadata;
 use crate::xetmnt::watch::metrics::{MOUNT_PASSTHROUGH_BYTES_READ, MOUNT_POINTER_BYTES_READ};


### PR DESCRIPTION
Make ErrorPrinter trait be exported out of it's own error_printer crate so that it can be imported from non-gitxetcore crates as well as projects outside of this repository.

Expand the ErrorPrinter trait to give info_error and debug_error functions so that we can log with different tracing levels.