### PR TITLE
Add proper support for summarizing TSV

### DIFF
--- a/rust/gitxetcore/src/command/summary.rs
+++ b/rust/gitxetcore/src/command/summary.rs
@@ -151,7 +151,8 @@ async fn print_summary_from_blobid(
         SummaryType::Libmagic => Err(GitXetRepoError::InvalidOperation(
             "file type summarization from contents not supported".to_string(),
         )),
-        SummaryType::Csv => print_csv_summary_from_reader(&mut &content[..]),
+        // TODO: hardcoding ',' as the delimiter here is a bug. But not sure how else to assume delimiter since we don't have the file extension here.
+        SummaryType::Csv => print_csv_summary_from_reader(&mut &content[..], b','),
     }
 }
 

--- a/rust/gitxetcore/src/data/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data/data_processing_v1.rs
@@ -236,9 +236,13 @@ impl PointerFileTranslatorV1 {
 
         debug!("Including analyzers for path {:?}", &path);
 
-        if path.extension() == Some(OsStr::new("csv")) {
+        let ext = path.extension();
+        if ext == Some(OsStr::new("csv")) {
             info!("Including CSV analyzer (file extension .csv)");
-            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary));
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary, b','));
+        } else if ext == Some(OsStr::new("tsv")) {
+            info!("Including CSV analyzer (file extension .tsv)");
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary, b'\t'));
         }
 
         // Now, test whether to pass this file through or not.

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -365,9 +365,14 @@ impl PointerFileTranslatorV2 {
 
         debug!("Including analyzers for path {:?}", &path);
         let mut analyzers_active = false;
-        if path.extension() == Some(OsStr::new("csv")) {
+        let ext = path.extension();
+        if ext == Some(OsStr::new("csv")) {
             info!("Including CSV analyzer (file extension .csv)");
-            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary));
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary, b','));
+            analyzers_active = true;
+        } else if ext == Some(OsStr::new("tsv")) {
+            info!("Including CSV analyzer (file extension .tsv)");
+            analyzers.csv = Some(CSVAnalyzer::new(self.cfg.log.silent_summary, b'\t'));
             analyzers_active = true;
         }
 

--- a/rust/gitxetcore/src/summaries/csv.rs
+++ b/rust/gitxetcore/src/summaries/csv.rs
@@ -134,7 +134,7 @@ impl CSVAnalyzer {
             current_ends_write_index: 0,
             previous_leftover: Vec::with_capacity(1024),
             parse_warning: None,
-            silence_warnings: silence_warnings,
+            silence_warnings,
         }
     }
 }


### PR DESCRIPTION
Pass the `\t` delimiter through wherever we can detect that the file is a TSV rather than CSV. Previously, the csv_core module assumed a `,` delimiter wherever it was used.