### PR TITLE
Switched backend for global dedup to mdbx

### DIFF
--- a/rust/shard_client/Cargo.toml
+++ b/rust/shard_client/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 mdb_shard = {path = "../mdb_shard"}
 merkledb = {path = "../merkledb"}
 progress_reporting = {path = "../progress_reporting"}
-heed = "0.11"
+heed = {version = "0.11", features = ["mdbx-sys", "raw_value", "serde", "serde-bincode"]}
 
 # trace-propagation
 opentelemetry = { version = "0.17", features = ["trace", "rt-tokio"] }


### PR DESCRIPTION
Instead of using lmdb for the backend of heed, use the newer mdbx.  This was the original intent but could not get it to compiler.  (Mdbx does not rely on memmap).