### PR TITLE
Fixed new clippy errors from upgraded rust version.

### DIFF
--- a/rust/cas_client/src/local_client.rs
+++ b/rust/cas_client/src/local_client.rs
@@ -202,7 +202,7 @@ impl LocalClient {
     }
 }
 
-fn validate_root_hash(data: &Vec<u8>, chunk_boundaries: &Vec<u64>, hash: &MerkleHash) -> bool {
+fn validate_root_hash(data: &[u8], chunk_boundaries: &[u64], hash: &MerkleHash) -> bool {
     // at least 1 chunk, and last entry in chunk boundary must match the length
     if chunk_boundaries.is_empty()
         || chunk_boundaries[chunk_boundaries.len() - 1] as usize != data.len()

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -216,7 +216,7 @@ impl RemoteClient {
         &self,
         prefix: &str,
         hash: &MerkleHash,
-        data: &Vec<u8>,
+        data: &[u8],
         chunk_boundaries: &[u64],
     ) -> Result<()> {
         debug!("H2 Put executed with {} {}", prefix, hash);

--- a/rust/gitxetcore/src/stream/git_stream_frame.rs
+++ b/rust/gitxetcore/src/stream/git_stream_frame.rs
@@ -36,7 +36,7 @@ fn starts_with(a: &[u8], b: &[u8]) -> bool {
 }
 
 // Utility to return the value location for a key=value string.
-fn get_value_for_key(bytes: &[u8], search: &Vec<u8>) -> Option<usize> {
+fn get_value_for_key(bytes: &[u8], search: &[u8]) -> Option<usize> {
     if bytes.len() > search.len() {
         return None;
     }
@@ -233,7 +233,7 @@ pub enum GitFrame {
 }
 
 impl GitFrame {
-    pub fn parse_version(buffer: &Vec<u8>) -> Result<u32> {
+    pub fn parse_version(buffer: &[u8]) -> Result<u32> {
         if let Some(first) = get_value_for_key(b"version=", buffer) {
             return match atoi::<u32>(&buffer[first..]) {
                 Some(v) => Ok(v),
@@ -242,10 +242,10 @@ impl GitFrame {
                 )),
             };
         }
-        write_buff_error!("Unable to parse version from ", &buffer[..])
+        write_buff_error!("Unable to parse version from ", buffer)
     }
 
-    pub fn parse_can_delay(buffer: &Vec<u8>) -> Result<u32> {
+    pub fn parse_can_delay(buffer: &[u8]) -> Result<u32> {
         if let Some(first) = get_value_for_key(b"can-delay=", buffer) {
             return match atoi::<u32>(&buffer[first..]) {
                 Some(v) => Ok(v),
@@ -254,7 +254,7 @@ impl GitFrame {
                 )),
             };
         }
-        write_buff_error!("Unable to parse can-delay from ", &buffer[..])
+        write_buff_error!("Unable to parse can-delay from ", buffer)
     }
 
     /// Parses the data into a GitFrame object. Returns an Err on

--- a/rust/lazy/src/lazy_pathlist_config.rs
+++ b/rust/lazy/src/lazy_pathlist_config.rs
@@ -158,15 +158,10 @@ impl Drop for LazyPathListConfigFile {
         );
 
         let mut buf = vec![];
-        #[allow(clippy::blocks_in_if_conditions)]
+
         for p in self.config.pathlist.iter() {
-            if writeln!(&mut buf, "{p}")
-                .map_err(|e| {
-                    error!("Error writing lazy config path {p:?}: {e:?}");
-                    e
-                })
-                .is_err()
-            {
+            if let Err(e) = writeln!(&mut buf, "{p}") {
+                error!("Error writing lazy config path {p:?}: {e:?}");
                 return;
             };
         }

--- a/rust/merkledb/src/internal_methods.rs
+++ b/rust/merkledb/src/internal_methods.rs
@@ -56,7 +56,7 @@ pub fn node_from_children(
  */
 pub fn merge_one_level(
     db: &mut (impl MerkleDBBase + ?Sized),
-    nodes: &Vec<MerkleNode>,
+    nodes: &[MerkleNode],
 ) -> (Vec<MerkleNodeId>, Vec<MerkleNode>) {
     /*
      * We basically loop through the set of nodes tracking a window between

--- a/rust/shard_client/src/lib.rs
+++ b/rust/shard_client/src/lib.rs
@@ -1,3 +1,9 @@
+#![allow(
+    unknown_lints,
+    renamed_and_removed_lints,
+    clippy::blocks_in_conditions,
+    clippy::blocks_in_if_conditions
+)]
 use crate::error::Result;
 use async_trait::async_trait;
 use local_shard_client::LocalShardClient;

--- a/rust/xet_error/impl/src/lib.rs
+++ b/rust/xet_error/impl/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(
     unknown_lints,
+    renamed_and_removed_lints,
+    clippy::blocks_in_conditions,
     clippy::blocks_in_if_conditions,
     clippy::cast_lossless,
     clippy::cast_possible_truncation,


### PR DESCRIPTION
Locally upgraded rust to v. 1.76.0; this PR fixes new clippy errors. 