### PR TITLE
Rename constant for global dedup queries; redo API to use constant internally.

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -124,6 +124,10 @@ reqwest = {version = "0.11.4", features = ["json"]}
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "^0", features = ["vendored"] }
 
+# Pinning some versions due to OSX compilation issues.
+openssl-src = "~300.1.5+3.1.3"
+
+
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "2.1"

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -42,7 +42,7 @@ async-trait = "0.1.53"
 tracing-attributes = "0.1"
 tracing-subscriber = {version = "0.3", features = ["tracing-log"]}
 clap = { version = "3.1.6", features = ["derive"] }
-git2 = "0.14.4"
+git2 = "0.18.2"
 base64 = "0.13.0"
 fallible-iterator = "0.2.0"
 atoi = "1.0.0"
@@ -120,9 +120,9 @@ reqwest = {version = "0.11.4", features = ["json", "webpki-roots"]}
 [target.'cfg(not(macos))'.dependencies]
 reqwest = {version = "0.11.4", features = ["json"]}
 
-# needed to support cross-compilation on linux/mac
+# needed to support cross-compilation on linux/mac; use highest version available (determined by git2)
 [target.'cfg(not(windows))'.dependencies]
-openssl = { version = "0.10.38", features = ["vendored"] }
+openssl = { version = "^0", features = ["vendored"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/rust/mdb_shard/src/constants.rs
+++ b/rust/mdb_shard/src/constants.rs
@@ -1,4 +1,9 @@
 pub const MDB_SHARD_TARGET_SIZE: u64 = 64 * 1024 * 1024;
 pub const MDB_SHARD_MIN_TARGET_SIZE: u64 = 48 * 1024 * 1024;
 
-pub const MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULES: u64 = 1024;
+pub const MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS: u64 = 1024;
+
+// How the MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS is used.
+pub fn hash_is_global_dedup_eligible(h: &merklehash::MerkleHash) -> bool {
+    (*h) % MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULUS == 0
+}

--- a/rust/mdb_shard/src/lib.rs
+++ b/rust/mdb_shard/src/lib.rs
@@ -15,6 +15,7 @@ pub mod shard_in_memory;
 pub mod shard_version;
 pub mod utils;
 
+pub use constants::hash_is_global_dedup_eligible;
 pub use constants::MDB_SHARD_TARGET_SIZE;
 pub use intershard_reference_structs::IntershardReferenceSequence;
 pub use shard_file_handle::MDBShardFile;

--- a/rust/mdb_shard/src/shard_format.rs
+++ b/rust/mdb_shard/src/shard_format.rs
@@ -1,3 +1,4 @@
+use crate::constants::*;
 use crate::error::{MDBShardError, Result};
 use crate::intershard_reference_structs::IntershardReferenceSequence;
 use crate::serialization_utils::*;
@@ -867,7 +868,6 @@ impl MDBShardInfo {
     /// or the hash of the first chunk of a file present in the shard.
     pub fn read_cas_chunks_for_global_dedup<R: Read + Seek>(
         reader: &mut R,
-        hash_filter_modulus: u64,
     ) -> Result<Vec<MerkleHash>> {
         let mut ret = Vec::new();
 
@@ -881,7 +881,7 @@ impl MDBShardInfo {
         for (i, cas_info) in cas_chunks.iter().enumerate() {
             cas_block_lookup.insert(cas_info.metadata.cas_hash, i);
             for chunk in cas_info.chunks.iter() {
-                if chunk.chunk_hash % hash_filter_modulus == 0 {
+                if hash_is_global_dedup_eligible(&chunk.chunk_hash) {
                     ret.push(chunk.chunk_hash);
                 }
             }

--- a/rust/shard_client/src/local_shard_client.rs
+++ b/rust/shard_client/src/local_shard_client.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use cas_client::{Client, LocalClient};
 use itertools::Itertools;
-use mdb_shard::constants::MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULES;
 use mdb_shard::error::MDBShardError;
 use mdb_shard::file_structs::MDBFileInfo;
 use mdb_shard::shard_dedup_probe::ShardDedupProber;
@@ -110,10 +109,7 @@ impl RegistrationClient for LocalShardClient {
 
         let mut shard_reader = shard.get_reader()?;
 
-        let chunk_hashes = MDBShardInfo::read_cas_chunks_for_global_dedup(
-            &mut shard_reader,
-            MDB_SHARD_GLOBAL_DEDUP_CHUNK_MODULES,
-        )?;
+        let chunk_hashes = MDBShardInfo::read_cas_chunks_for_global_dedup(&mut shard_reader)?;
 
         self.global_dedup
             .batch_add(&chunk_hashes, hash, prefix, salt)

--- a/rust/xetblob/Cargo.toml
+++ b/rust/xetblob/Cargo.toml
@@ -12,34 +12,8 @@ path = "src/bin/xetcmd.rs"
 
 [dependencies]
 gitxetcore = { path = "../gitxetcore"}
-pointer_file = { path = "../pointer_file" }
-mdb_shard = { path = "../mdb_shard"}
+clap = { version = "3.1.6", features = ["derive"] }
 anyhow = "1"
 url = "2.3"
-tracing = "0.1.*"
 tokio = { version = "1.36", features = ["full"] }
-serde = {version = "1.0.142", features = ["derive"] }
-serde_json = "1.0.83"
-dirs = "4.0.0"
-blake3 = "1.0.0"
-clap = { version = "3.1.6", features = ["derive"] }
 tabled = "0.12.0"
-merkledb = { path = "../merkledb" }
-async-trait = "0.1.53"
-git2 = "0.14.4"
-base64 = "0.13.0"
-merklehash = {path = "../merklehash"}
-utils = {path = "../utils"}
-tempdir = "0.3.7"
-parutils = {path = "../parutils"}
-shellexpand = "1.0.0"
-
-
-# use embedded webpki root certs for MacOS as native certs take a very long time
-# to load, which affects startup time significantly
-[target.'cfg(macos)'.dependencies]
-reqwest = {version = "0.11.4", features = ["json", "webpki-roots"]}
-
-[target.'cfg(not(macos))'.dependencies]
-reqwest = {version = "0.11.4", features = ["json"]}
-


### PR DESCRIPTION
Since the sampling proportion is a value shared by all clients and the server, and it's used as a constant anyway, it makes sense to just fold it into the code.

This will require a slight update on the xethub side once this PR is merged in.  