### PR TITLE
Make integration tests run faster

### DIFF
--- a/rust/gitxet/tests/integration_tests.rs
+++ b/rust/gitxet/tests/integration_tests.rs
@@ -73,7 +73,20 @@ impl IntegrationTest {
         // to avoid issues with a lesser git.
         cmd.env("HOME", tmp_path_path.as_os_str());
 
-        cmd.env("XET_LOG_LEVEL", "debug");
+        // Set defaults for all of these, but allow them to be overridden
+        cmd.env(
+            "XET_LOG_LEVEL",
+            std::env::var_os("XET_LOG_LEVEL").unwrap_or("error".into()),
+        );
+        cmd.env(
+            "XET_GLOBAL_DEDUP_POLICY",
+            std::env::var_os("XET_GLOBAL_DEDUP_POLICY").unwrap_or("always".into()),
+        );
+        cmd.env(
+            "XET_SHARD_QUERY_POLICY",
+            std::env::var_os("XET_SHARD_QUERY_POLICY").unwrap_or("LocalFirst".into()),
+        );
+
         cmd.env("XET_AXE_ENABLED", "false");
 
         // Now, run the script.

--- a/rust/gitxet/tests/integration_tests/initialize.sh
+++ b/rust/gitxet/tests/integration_tests/initialize.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-export XET_LOG_LEVEL=debug
 export XET_LOG_FORMAT=compact
 export XET_DISABLE_VERSION_CHECK="1"
 


### PR DESCRIPTION
Speeds up the integration tests by not making them run at debug level by default.  They will now respect local environment variables when run locally.