### PR TITLE
Better logging for global dedup

### DIFF
--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -505,6 +505,8 @@ impl PointerFileTranslatorV2 {
                                     e }) 
                                 else { return false; };
 
+                                info!("global dedup: New shard {shard_hash:?} can be used for deduplication of {path:?}; reprocessing file.");
+
                                 true
                             });
 


### PR DESCRIPTION
When new shards are discovered for global dedup, log them to info (instead of just debug).