### PR TITLE
Lower exception backtrace from error to info so it won't accidentally show up. 

### DIFF
--- a/rust/gitxetcore/src/environment/log.rs
+++ b/rust/gitxetcore/src/environment/log.rs
@@ -20,8 +20,8 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 fn log_exception(source: &str) {
-    tracing::error!(
-        "Error: {source} error; context={:?}",
+    tracing::info!(
+        "Error reported: {source} error; context={:?}",
         std::backtrace::Backtrace::force_capture()
     );
 }


### PR DESCRIPTION
This PR:
- lowers the exception backtrace logging level to info in most situations so that it never shows up to users, but does keep the information there. 
- Logged at error level in telemetry situations. 
