### PR TITLE
Turn off remote capabilities in git2

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -42,7 +42,10 @@ async-trait = "0.1.53"
 tracing-attributes = "0.1"
 tracing-subscriber = {version = "0.3", features = ["tracing-log"]}
 clap = { version = "3.1.6", features = ["derive"] }
-git2 = "0.18.2"
+
+# Use git2 without remote capabilities, since we don't use those anyway.
+git2 = {version = "0.18.2", default-features = false, features = []}
+
 base64 = "0.13.0"
 fallible-iterator = "0.2.0"
 atoi = "1.0.0"


### PR DESCRIPTION
This avoids openssl compilation issues in pyxet, and avoids having multiple openssl versions packed in our executable. 