### PR TITLE
Adding port to the endpoint override

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_url.rs
+++ b/rust/gitxetcore/src/git_integration/git_url.rs
@@ -89,25 +89,31 @@ impl XetPathInfo {
             })?;
         }
 
+        // closure to split out domain and port, returns Err if port is an invalid u16. 
+        let split_out_port = |domain: &str| -> Result<(String, Option<u16>)> {
+            let host_port_split = domain.split(':').collect::<Vec<_>>();
+            if host_port_split.len() == 2 {
+                Ok((
+                    host_port_split[0].to_string(),
+                    Some(host_port_split[1].parse::<u16>().map_err(|_| {
+                        GitXetRepoError::InvalidRemote(format!("Invalid port {}", host_port_split[1]))
+                    })?),
+                ))
+            } else {
+                Ok((domain.to_string(), None))
+            }
+        };
+
         // support force_domain with a scheme (http/https)
         let domain_split: Vec<_> = force_domain.split("://").collect::<Vec<_>>();
         let mut scheme = "https".to_owned();
-        let mut port = 443;
+        let port: Option<u16>;
         let domain;
         if domain_split.len() == 2 {
             scheme = domain_split[0].to_owned();
-            // split out the port from the domain if it exists
-            let host_port_split = domain_split[1].split(":").collect::<Vec<_>>();
-            if host_port_split.len() == 2 {
-                domain = host_port_split[0].to_string();
-                port = host_port_split[1].parse::<u16>().map_err(|_| {
-                    GitXetRepoError::InvalidRemote(format!("Invalid port {}", host_port_split[1]))
-                })?;
-            } else {
-                domain = domain_split[1].to_owned();
-            } 
+            (domain, port) = split_out_port(domain_split[1])?; 
         } else {
-            domain = force_domain.to_owned();
+            (domain, port) = split_out_port(force_domain)?;
         }
 
         if parse.scheme() != "xet" {
@@ -126,8 +132,8 @@ impl XetPathInfo {
                     parse.set_host(Some(&domain)).map_err(|_| {
                         GitXetRepoError::InvalidRemote(format!("Invalid domain {domain}"))
                     })?;
-                    parse.set_port(Some(port)).map_err(|_| {
-                        GitXetRepoError::InvalidRemote(format!("Invalid port {port}"))
+                    parse.set_port(port).map_err(|_| {
+                        GitXetRepoError::InvalidRemote(format!("Invalid port {:?}", port))
                     })?;
                 } else {
                     // this is of the for xet://user/repo/...
@@ -137,8 +143,8 @@ impl XetPathInfo {
                     parse.set_host(Some(&domain)).map_err(|_| {
                         GitXetRepoError::InvalidRemote(format!("Invalid domain {domain}"))
                     })?;
-                    parse.set_port(Some(port)).map_err(|_| {
-                        GitXetRepoError::InvalidRemote(format!("Invalid port {port}"))
+                    parse.set_port(port).map_err(|_| {
+                        GitXetRepoError::InvalidRemote(format!("Invalid port {:?}", port))
                     })?;
                     parse.set_path(&newpath);
                 }
@@ -173,10 +179,17 @@ impl XetPathInfo {
         // we leave url with the first 3 components. i.e. "/user/repo"
         let replacement_parse_path = components[..3].join("/");
 
+        let port_string; 
+        if let Some(parsed_port) = parse.port() {
+            port_string = format!(":{}", parsed_port)
+        } else {
+            port_string = "".to_owned()
+        };
+
         let ret = XetPathInfo {
             remote_url: format!(
-                "{scheme}://{}:{}{replacement_parse_path}",
-                parse.host().unwrap(), parse.port_or_known_default().unwrap_or(443), 
+                "{scheme}://{}{}{replacement_parse_path}",
+                parse.host().unwrap(), port_string, 
             ),
             branch,
             path,
@@ -302,6 +315,28 @@ mod tests {
             },
         )?;
 
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://xethub.com/user/repo/branch",
+            "https://localhost:1234",
+            &XetPathInfo {
+                remote_url: "https://localhost:1234/user/repo".to_owned(),
+                repo: "repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://xethub.com/user/repo/branch",
+            "http://localhost:1234",
+            &XetPathInfo {
+                remote_url: "http://localhost:1234/user/repo".to_owned(),
+                repo: "repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
         assert_xet_url_parse_err("xet://xethub.com/user");
 
         Ok(())
@@ -364,6 +399,28 @@ mod tests {
             "xetbeta.com",
             &XetPathInfo {
                 remote_url: "https://xetbeta.com/user/repo".to_owned(),
+                repo: "repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://user/repo/branch",
+            "http://localhost:3000",
+            &XetPathInfo {
+                remote_url: "http://localhost:3000/user/repo".to_owned(),
+                repo: "repo".to_owned(),
+                branch: "branch".to_owned(),
+                path: "".to_owned(),
+            },
+        )?;
+
+        assert_xet_url_with_domain_override_parse_result(
+            "xet://user/repo/branch",
+            "xetbeta.com:5500",
+            &XetPathInfo {
+                remote_url: "https://xetbeta.com:5500/user/repo".to_owned(),
                 repo: "repo".to_owned(),
                 branch: "branch".to_owned(),
                 path: "".to_owned(),


### PR DESCRIPTION
In order to use `git xet cp` for our upload function, it needs to be able to target our service running on localhost. This requires that we are able to specify the domain as well as the port in our endpoint override.