### PR TITLE
Refresh repo salt on every repo open

### DIFF
--- a/rust/gitxetcore/src/data/mdb.rs
+++ b/rust/gitxetcore/src/data/mdb.rs
@@ -23,7 +23,6 @@ use shard_client::ShardConnectionConfig;
 
 use bincode::Options;
 use cas_client::Staging;
-use common_constants::XET_PROGRAM_NAME;
 use git2::Oid;
 use mdb_shard::session_directory::consolidate_shards_in_directory;
 use mdb_shard::shard_file_handle::MDBShardFile;
@@ -335,14 +334,15 @@ pub async fn download_shards_to_cache(
     cache_dir: &Path,
     shards: Vec<MerkleHash>,
 ) -> errors::Result<Vec<PathBuf>> {
+    if shards.is_empty() {
+        return Ok(vec![]);
+    }
+
     let cas = create_cas_client(config).await?;
     let cas_ref = &cas;
 
-    let progress_reporter = DataProgressReporter::new(
-        &format!("{XET_PROGRAM_NAME}: Retrieving metadata"),
-        Some(shards.len()),
-        None,
-    );
+    let progress_reporter =
+        DataProgressReporter::new("Xet: Retrieving metadata", Some(shards.len()), None);
 
     let pr_ref = progress_reporter.as_ref();
 

--- a/rust/gitxetcore/src/xetblob/bbq_queries.rs
+++ b/rust/gitxetcore/src/xetblob/bbq_queries.rs
@@ -108,7 +108,7 @@ impl BbqClient {
     /// query_type is a HTTP method as is one of 'get','post','patch','delete','put'
     pub async fn perform_api_query_internal(
         &self,
-        remote_base_url: Url,
+        remote_base_url: &Url,
         op: &str,
         http_command: &str,
         body: &str,
@@ -116,7 +116,7 @@ impl BbqClient {
         let base_path = remote_base_url.path();
         let api_path = format!("/api/xet/repos{base_path}/{op}");
         let api_path = api_path.trim_end_matches('/');
-        let mut api_url = remote_base_url;
+        let mut api_url = remote_base_url.clone();
         info!("Querying {}", api_path);
         api_url.set_path(api_path);
         if http_command != "get"
@@ -236,7 +236,7 @@ impl BbqClient {
     /// remote_base_url is https://domain/
     pub async fn perform_api_query(
         &self,
-        remote_base_url: Url,
+        remote_base_url: &Url,
         op: &str,
         http_command: &str,
         body: &str,

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -132,7 +132,7 @@ impl XetRepo {
                 let repo_path = rootpath.join(dirname);
                 std::fs::create_dir_all(&repo_path)?;
                 // check if there are already contents under the directory and
-                // if it represents the same repo
+                // if they represent the same repo as "remote" on server
                 Self::verify_repo_info(&repo_path, &repo_info, &raw_response)?;
 
                 Self::open_v2_repo(Some(config), overrides, &repo_path, bbq_client, repo_info).await
@@ -294,7 +294,7 @@ impl XetRepo {
         let repo_changed = match saved_repo_info {
             // Either:
             // 1. no repo info found; or
-            // 2. a V1 repo was deleted and recreated under the same name as a V2 repo; or
+            // 2. a V1 repo was deleted and recreated under the same name as a V2 repo;
             None => true,
             // a V2 repo was deleted and recreated under the same name
             Some(sri) => sri.xet != repo_info.xet,

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -1,6 +1,3 @@
-use self::git_repo_salt::repo_salt_from_bytes;
-use self::remote_shard_interface::GlobalDedupPolicy;
-
 use super::atomic_commit_queries::*;
 use super::bbq_queries::*;
 use super::file_open_flags::*;
@@ -18,13 +15,16 @@ use crate::git_integration::*;
 use crate::summaries::*;
 use anyhow::anyhow;
 use cas::gitbaretools::{Action, JSONCommand};
+use cas::safeio::write_all_file_safe;
 use core::panic;
+use git_repo_salt::repo_salt_from_bytes;
 use mdb_shard::constants::MDB_SHARD_MIN_TARGET_SIZE;
 use mdb_shard::session_directory::consolidate_shards_in_directory;
 use mdb_shard::shard_version::ShardVersion;
 use merkledb::constants::TARGET_CDC_CHUNK_SIZE;
 use merkledb::MerkleMemDB;
 use merklehash::MerkleHash;
+use remote_shard_interface::GlobalDedupPolicy;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
 use std::path::{Path, PathBuf};
@@ -35,6 +35,7 @@ use tracing::{debug, error, info};
 use url::Url;
 
 const TARGET_SINGLE_COMMIT_MAX_SIZE: usize = 16 * 1024 * 1024;
+const XET_REPO_INFO_FILE: &str = ".xetblob";
 
 /// Describes a single Xet Repo and manages the MerkleDB within
 pub struct XetRepo {
@@ -81,15 +82,15 @@ pub struct XetRepoWriteTransaction {
 }
 
 impl XetRepo {
-    /// Create a new local MerkleDB clone
+    /// Open a remote repo using a local path as temporary metadata storage location.
     /// If no xet config is provided, one is automatically loaded from global
     /// environment.
-    pub async fn new(
+    pub async fn open(
         config: Option<XetConfig>,
         overrides: Option<CliOverrides>,
         remote: &str,
-        clone_rootpath: &Path,
-        clone_dirname: &str,
+        rootpath: &Path,
+        dirname: &str,
         bbq_client: &BbqClient,
     ) -> anyhow::Result<Self> {
         let config = if let Some(config) = config {
@@ -109,96 +110,117 @@ impl XetRepo {
 
         let remote = config.build_authenticated_remote_url(&remote);
 
-        eprintln!("Initializing repository on first access");
         let url = git_remote_to_base_url(&remote)?;
 
         // query for MDB version and repo salt
-        let response = bbq_client.perform_api_query(url, "", "get", "").await?;
-        let res_str = String::from_utf8(response.clone())?;
-        debug!("{res_str:?}");
-        let repo_info: RepoInfo = serde_json::de::from_slice(&response)?;
+        let (repo_info, raw_response) = get_repo_info(&url, bbq_client).await?;
         let mdb_version: ShardVersion = repo_info.xet.mdb_version.parse()?;
 
         match mdb_version {
             ShardVersion::V1 => {
-                clone_xet_repo(
-                    Some(&config),
-                    &[
-                        "--bare",
-                        "-c",
-                        // only fetch MDB v1 refs notes.
-                        "remote.origin.fetch=+refs/notes/xet/merkledb:refs/notes/xet/merkledb",
-                        &remote,
-                        clone_dirname,
-                    ],
-                    true,
-                    Some(&clone_rootpath.to_path_buf()),
-                    false,
-                    false,
-                    true,
-                )?;
+                Self::open_v1_repo(
+                    Some(config),
+                    overrides,
+                    &remote,
+                    rootpath,
+                    dirname,
+                    bbq_client,
+                )
+                .await
             }
             ShardVersion::V2 => {
-                // make a directory,
-                // write out mdb version, repo salt, remote...
-                std::fs::create_dir_all(clone_rootpath.join(clone_dirname))?;
-                std::fs::write(
-                    clone_rootpath.join(clone_dirname).join(".xetblob"),
-                    response,
-                )?;
-            }
-            ShardVersion::Uninitialized => todo!(), // impossible and deadly route
-        };
+                let repo_path = rootpath.join(dirname);
+                std::fs::create_dir_all(&repo_path)?;
+                // check if there are already contents under the directory and
+                // if it represents the same repo
+                Self::verify_repo_info(&repo_path, &repo_info, &raw_response)?;
 
-        eprintln!("Initialization complete");
-        let repo_path = clone_rootpath.join(clone_dirname);
-        XetRepo::open(Some(config), overrides, &repo_path, bbq_client).await
+                Self::open_v2_repo(Some(config), overrides, &repo_path, bbq_client, repo_info).await
+            }
+            ShardVersion::Uninitialized => {
+                eprintln!("Detect incorrect repo metadata information, please contact the administrator for help.");
+                Err(anyhow!("Uninitialized repo"))
+            } // impossible and deadly route
+        }
     }
 
-    /// open an existing local MerkleDB clone
-    /// If no xet config is provided, one is automatically loaded from global
-    /// environment.
-    pub async fn open(
-        cfg: Option<XetConfig>,
+    /// Open an existing local V1 repo or clone it to local.
+    async fn open_v1_repo(
+        config: Option<XetConfig>,
         overrides: Option<CliOverrides>,
-        path: &Path,
+        remote: &str,
+        clone_rootpath: &Path,
+        clone_dirname: &str,
         bbq_client: &BbqClient,
     ) -> anyhow::Result<Self> {
-        let xetblob = path.join(".xetblob");
-        let mut config;
-        let repo_info: Option<RepoInfo>;
-
-        if xetblob.exists() {
-            let repo_info_str = std::fs::read(&xetblob)?;
-            let repo_info_de: RepoInfo = serde_json::de::from_slice(&repo_info_str)?;
-            config = if let Some(cfg) = cfg {
-                cfg.switch_repo_info(
-                    remote_to_repo_info(&repo_info_de.repo.html_url),
-                    overrides.clone(),
-                )?
-                .switch_xetblob_path(path, overrides)?
-            } else {
-                XetConfig::new(None, None, ConfigGitPathOption::NoPath)?
-            };
-            repo_info = Some(repo_info_de);
-        } else {
-            repo_info = None;
-            config = if let Some(cfg) = cfg {
-                cfg.switch_repo_path(
-                    ConfigGitPathOption::PathDiscover(path.to_path_buf()),
-                    overrides,
-                )?
-            } else {
-                XetConfig::new(
-                    None,
-                    None,
-                    ConfigGitPathOption::PathDiscover(path.to_path_buf()),
-                )?
-            };
+        let clone_path = clone_rootpath.join(clone_dirname);
+        if !clone_path.exists() {
+            eprintln!("Initializing repository on first access");
+            clone_xet_repo(
+                config.as_ref(),
+                &[
+                    "--bare",
+                    "-c",
+                    // only fetch MDB v1 refs notes.
+                    "remote.origin.fetch=+refs/notes/xet/merkledb:refs/notes/xet/merkledb",
+                    &remote,
+                    clone_dirname,
+                ],
+                true,
+                Some(&clone_rootpath.to_path_buf()),
+                false,
+                false,
+                true,
+            )?;
+            eprintln!("Initialization complete");
         }
+
+        let mut config = if let Some(cfg) = config {
+            cfg.switch_repo_path(
+                ConfigGitPathOption::PathDiscover(clone_path.to_path_buf()),
+                overrides,
+            )?
+        } else {
+            XetConfig::new(
+                None,
+                None,
+                ConfigGitPathOption::PathDiscover(clone_path.to_path_buf()),
+            )?
+        };
         // disable staging
         config.staging_path = None;
 
+        XetRepo::open_with_config_and_repo_info(config, None, bbq_client).await
+    }
+
+    /// Open an existing local V2 repo.
+    async fn open_v2_repo(
+        config: Option<XetConfig>,
+        overrides: Option<CliOverrides>,
+        path: &Path,
+        bbq_client: &BbqClient,
+        repo_info: RepoInfo,
+    ) -> anyhow::Result<Self> {
+        let mut config = if let Some(cfg) = config {
+            cfg.switch_repo_info(
+                remote_to_repo_info(&repo_info.repo.html_url),
+                overrides.clone(),
+            )?
+            .switch_xetblob_path(path, overrides)?
+        } else {
+            XetConfig::new(None, None, ConfigGitPathOption::NoPath)?
+        };
+        // disable staging
+        config.staging_path = None;
+
+        Self::open_with_config_and_repo_info(config, Some(repo_info), bbq_client).await
+    }
+
+    async fn open_with_config_and_repo_info(
+        config: XetConfig,
+        repo_info: Option<RepoInfo>,
+        bbq_client: &BbqClient,
+    ) -> anyhow::Result<Self> {
         let remote = if let Some(repo_info) = repo_info.as_ref() {
             repo_info.repo.html_url.clone()
         } else {
@@ -218,9 +240,6 @@ impl XetRepo {
         // associate auth and make a bbq base path
         let remote = config.build_authenticated_remote_url(&remote);
         let url = git_remote_to_base_url(&remote)?;
-        if !path.exists() {
-            return Err(anyhow!("path {path:?} does not exist"));
-        }
 
         let mut translator = if let Some(repo_info) = repo_info.as_ref() {
             let repo_salt_raw = repo_info
@@ -255,6 +274,40 @@ impl XetRepo {
             bbq_client: bbq_client.clone(),
             repo_info,
         })
+    }
+
+    fn verify_repo_info(
+        path: &Path,
+        repo_info: &RepoInfo,
+        raw_response: &[u8],
+    ) -> anyhow::Result<()> {
+        let xet_repo_info_file = path.join(XET_REPO_INFO_FILE);
+
+        let saved_repo_info: Option<RepoInfo> = if xet_repo_info_file.exists() {
+            Some(serde_json::de::from_slice(&std::fs::read(
+                &xet_repo_info_file,
+            )?)?)
+        } else {
+            None
+        };
+
+        let repo_changed = match saved_repo_info {
+            // Either:
+            // 1. no repo info found; or
+            // 2. a V1 repo was deleted and recreated under the same name as a V2 repo; or
+            None => true,
+            // a V2 repo was deleted and recreated under the same name
+            Some(sri) => sri.xet != repo_info.xet,
+        };
+
+        // repo changed, delete all contents and write out the repo info
+        if repo_changed {
+            std::fs::remove_dir_all(path)?;
+            std::fs::create_dir_all(path)?;
+            write_all_file_safe(&path.join(XET_REPO_INFO_FILE), raw_response)?;
+        }
+
+        Ok(())
     }
 
     /// Performs a git pull to fetch the latest merkledb from the remote git repo


### PR DESCRIPTION
Related issue: https://github.com/xetdata/xethub/issues/5518

With global dedup the repo salt is used to query dedup shards. Right now repo salt is downloaded once and stored into a local folder with name computed from the tuple `(remote, username, token)`. If a user deletes a repo and creates one with the same name pyxet and git-xet cp don't detect this change will use the invalid repo salt on disk. 

In this PR:
- xetblob verifies the repo salt on every repo open: if the salt doesn't match delete all files under the directory.
- removes message "Initializing repository on first access\nInitialization complete" for first accessing a v2 repo.

Tests:
pytest tests:
```
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % pytest tests       
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.10.10, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/di/xetdata/pyxet/python/pyxet
collected 38 items                                                                                                                                                                           

tests/arrow_test.py s...ss                                                                                                                                                             [ 15%]
tests/cli_cp_test.py ........                                                                                                                                                          [ 36%]
tests/file_test.py ................                                                                                                                                                    [ 78%]
tests/fsspec_test.py .                                                                                                                                                                 [ 81%]
tests/pandas_test.py ...                                                                                                                                                               [ 89%]
tests/sync_test.py ..ss                                                                                                                                                                [100%]

========================================================================= 33 passed, 5 skipped in 345.07s (0:05:45) ==========================================================================
```

Test delete and recreate repo under the same name:

```
# starting from empty ~/.xet/repos

(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % ll ~/.xet/repos 
total 0
drwxr-xr-x  2 di  staff   64 Mar  4 17:33 .
drwxr-xr-x  8 di  staff  256 Mar  4 16:39 ..
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % export XET_ENDPOINT=hub.xetsvc.com

# create a new repo

(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet repo make xet://seanses-dev/repoA --private
Private repository created at xet://seanses-dev/repoA
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cat xet://seanses-dev/repoA/main/.gitattributes
* filter=xet diff=xet merge=xet -text
*.gitattributes filter=
*.xet/** filter=
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % ll ~/.xet/repos/c853ff...
total 8
drwxr-xr-x  4 di  staff   128 Mar  4 17:36 .
drwxr-xr-x  4 di  staff   128 Mar  4 17:36 ..
-rw-------  1 di  staff  2094 Mar  4 17:36 .xetblob
drwxr-xr-x  4 di  staff   128 Mar  4 17:36 xet
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % cat ~/.xet/repos/c853ff.../.xetblob 
{"repo":{"id":1029,...,"http_url_to_repo":"https://hub.xetsvc.com/seanses-dev/repoA.git"},"xet":{"mdb_version":"2","repo_salt":"MFwsTY..."}}

# see the repo salt is MFwsTY...

(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cp ~/tt/Flickr30k/flickr30k_images/90011335.jpg xet://seanses-dev/repoA/main
copy /Users/di/tt/Flickr30k/flickr30k_images/90011335.jpg... to xet://seanses-dev/repoA/main: (113.26 KiB / 113.26 KiB) | 18.21 KiB/s, done.
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % find ~/.xet/repos/c853ff... -type f             
/Users/di/.xet/repos/c853ff.../xet/merkledbv2-cache/efbfdd....mdb
/Users/di/.xet/repos/c853ff.../.xetblob

# delete the repoA on Xetea; recreate one using the same name

(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet repo make xet://seanses-dev/repoA --private                                                       
Private repository created at xet://seanses-dev/repoA
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cat xet://seanses-dev/repoA/main/.gitattributes                                                   
* filter=xet diff=xet merge=xet -text
*.gitattributes filter=
*.xet/** filter=
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % cat ~/.xet/repos/c853ff.../.xetblob          
{"repo":{"id":1030,...,"http_url_to_repo":"https://hub.xetsvc.com/seanses-dev/repoA.git"},"xet":{"mdb_version":"2","repo_salt":"LJn64e..."}}

# see the repo salt is LJn64e...

(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % find ~/.xet/repos/c853ff... -type f
/Users/di/.xet/repos/c853ff.../.xetblob

# see the shard file was removed when a repo change was detected
```
