### PR TITLE
Add threshold to csv summary

### DIFF
--- a/rust/gitxetcore/src/summaries/constants.rs
+++ b/rust/gitxetcore/src/summaries/constants.rs
@@ -1,0 +1,9 @@
+/// Only store csv summary for that of size at least 256 KiB.
+/// Set to equal "SMALL_FILE_THRESHOLD" so regular users don't see unexpected behavior.
+pub const CSV_SUMMARY_SIZE_THRESHOLD_MIN: usize = 256 * 1024;
+
+/// Compute csv summary up to 50 columns.
+pub const CSV_SUMMARY_COLUMN_THRESHOLD_MAX: usize = 50;
+
+/// Set this env var to tune "CSV_SUMMARY_SIZE_THRESHOLD_MIN"
+pub const CSV_SUMMARY_SIZE_THRESHOLD_MIN_ENV_VAR: &str = "XET_CSV_MIN_SIZE";

--- a/rust/gitxetcore/src/summaries/csv.rs
+++ b/rust/gitxetcore/src/summaries/csv.rs
@@ -117,10 +117,8 @@ impl CSVAnalyzer {
     pub fn finalize(&mut self) -> Result<Option<CSVSummary>> {
         let size_threshold_min: usize = std::env::var_os(CSV_SUMMARY_SIZE_THRESHOLD_MIN_ENV_VAR)
             .as_ref()
-            .map(|osstr| osstr.to_str())
-            .flatten()
-            .map(|s| s.parse().ok())
-            .flatten()
+            .and_then(|osstr| osstr.to_str())
+            .and_then(|s| s.parse().ok())
             .unwrap_or(CSV_SUMMARY_SIZE_THRESHOLD_MIN);
 
         if self.total_bytes < size_threshold_min {

--- a/rust/gitxetcore/src/summaries/mod.rs
+++ b/rust/gitxetcore/src/summaries/mod.rs
@@ -1,11 +1,13 @@
 pub mod analysis;
 pub mod csv;
 pub mod summary_type;
-pub use libmagic::libmagic;
+
+mod constants;
 mod summaries_plumb;
 
 pub use analysis::{FileAnalyzers, FileSummary};
 pub use csv::{summarize_csv_from_reader, CSVAnalyzer};
+pub use libmagic::libmagic;
 pub use summaries_plumb::*;
 pub use summary_type::SummaryType;
 pub use WholeRepoSummary;


### PR DESCRIPTION
Fix https://github.com/xetdata/xethub/issues/5559

With this PR by default a CSV summary will not be created for files under 256 KiB. This can be tuned by `export XET_CSV_MIN_SIZE = [file size in bytes]`