### PR TITLE
prelude to compression on the wire for dataplane

### DIFF
--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -204,9 +204,9 @@ impl DataTransport {
             let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
             req = req.header(cas_accept_encoding_header, cas_accept_encoding_value);
         } else if method == Method::POST {
-            let cas_accept_encoding_header = HeaderName::from_static(CAS_CONTENT_ENCODING_HEADER);
-            let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
-            req = req.header(cas_accept_encoding_header, cas_accept_encoding_value);
+            let cas_content_encoding_header = HeaderName::from_static(CAS_CONTENT_ENCODING_HEADER);
+            let cas_content_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
+            req = req.header(cas_content_encoding_header, cas_content_encoding_value);
         }
 
         if trace_forwarding() {

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -25,7 +25,7 @@ use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::CertificateDer;
 use tracing::{debug, error, info, info_span, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CompressionScheme};
+use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CAS_CONTENT_ENCODING_HEADER, CompressionScheme};
 use xet_error::Error;
 
 use merklehash::MerkleHash;
@@ -187,10 +187,9 @@ impl DataTransport {
         let git_xet_version = self.cas_connection_config.git_xet_version.clone();
         let cas_protocol_version_header = HeaderName::from_static(CAS_PROTOCOL_VERSION_HEADER);
         let cas_protocol_version = CAS_PROTOCOL_VERSION.clone();
-        let is_get = method == Method::GET;
 
         let mut req = Request::builder()
-            .method(method)
+            .method(method.clone())
             .header(user_id_header, user_id)
             .header(auth_header, auth)
             .header(request_id_header, request_id)
@@ -200,11 +199,16 @@ impl DataTransport {
             .uri(&dest)
             .version(Version::HTTP_2);
 
-        if is_get {
+        if method == Method::GET {
             let cas_accept_encoding_header = HeaderName::from_static(CAS_ACCEPT_ENCODING_HEADER);
             let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
             req = req.header(cas_accept_encoding_header, cas_accept_encoding_value);
+        } else if method == Method::POST {
+            let cas_accept_encoding_header = HeaderName::from_static(CAS_CONTENT_ENCODING_HEADER);
+            let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
+            req = req.header(cas_accept_encoding_header, cas_accept_encoding_value);
         }
+
         if trace_forwarding() {
             if let Some(headers) = req.headers_mut() {
                 let mut injector = HeaderInjector(headers);

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -1,0 +1,37 @@
+use anyhow::anyhow;
+
+pub const CAS_CONTENT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
+pub const CAS_ACCEPT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
+
+#[derive(Debug, Clone, Copy)]
+pub enum CompressionScheme {
+    None,
+    LZ4,
+}
+
+impl Default for CompressionScheme {
+    fn default() -> Self {
+        CompressionScheme::None
+    }
+}
+
+impl From<CompressionScheme> for &'static str {
+    fn from(value: CompressionScheme) -> Self {
+       match value {
+           CompressionScheme::None => "none",
+           CompressionScheme::LZ4 => "lz4",
+       }
+    }
+}
+
+impl TryFrom<&str> for CompressionScheme {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "lz4" => Ok(CompressionScheme::LZ4),
+            "" | "none" => Ok(CompressionScheme::None),
+            _ => Err(anyhow!("could not convert &str to CompressionScheme"))
+        }
+    }
+}

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -1,18 +1,14 @@
+use std::str::FromStr;
 use anyhow::anyhow;
 
 pub const CAS_CONTENT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
 pub const CAS_ACCEPT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum CompressionScheme {
+    #[default]
     None,
     LZ4,
-}
-
-impl Default for CompressionScheme {
-    fn default() -> Self {
-        CompressionScheme::None
-    }
 }
 
 impl From<CompressionScheme> for &'static str {
@@ -24,11 +20,11 @@ impl From<CompressionScheme> for &'static str {
     }
 }
 
-impl TryFrom<&str> for CompressionScheme {
-    type Error = anyhow::Error;
+impl FromStr for CompressionScheme {
+    type Err = anyhow::Error;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
             "lz4" => Ok(CompressionScheme::LZ4),
             "" | "none" => Ok(CompressionScheme::None),
             _ => Err(anyhow!("could not convert &str to CompressionScheme"))

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -33,6 +33,7 @@ pub mod shard {
 
 pub mod consistenthash;
 pub mod constants;
+pub mod compression;
 pub mod errors;
 pub mod gitbaretools;
 pub mod key;
@@ -41,6 +42,7 @@ pub mod singleflight;
 pub mod version;
 
 mod output_bytes;
+
 pub use output_bytes::output_bytes;
 
 impl TryFrom<cas::Range> for Range<u64> {


### PR DESCRIPTION
Adds header on client to accept encoding, though set to none at the moment until server side implementation can support and respect this header.

This PR is needed so that the CAS server can use utils::CompressionScheme and share the header values.