### PR TITLE
compression refactor to protobuf type

### DIFF
--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -25,7 +25,8 @@ use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::CertificateDer;
 use tracing::{debug, error, info, info_span, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CAS_CONTENT_ENCODING_HEADER, CompressionScheme};
+use cas::common::CompressionScheme;
+use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CAS_CONTENT_ENCODING_HEADER, CAS_INFLATED_SIZE_HEADER};
 use xet_error::Error;
 
 use merklehash::MerkleHash;
@@ -175,38 +176,30 @@ impl DataTransport {
     ) -> Result<Request<Full<Bytes>>> {
         let dest = self.get_uri(prefix, hash);
         debug!("Calling {} with address: {}", method, dest);
-        let user_id_header = HeaderName::from_static(USER_ID_HEADER);
         let user_id = self.cas_connection_config.user_id.clone();
-        let auth_header = HeaderName::from_static(AUTH_HEADER);
         let auth = self.cas_connection_config.auth.clone();
-        let request_id_header = HeaderName::from_static(REQUEST_ID_HEADER);
         let request_id = get_request_id();
-        let repo_path_header = HeaderName::from_static(REPO_PATHS_HEADER);
         let repo_paths = self.cas_connection_config.repo_paths.clone();
-        let git_xet_version_header = HeaderName::from_static(GIT_XET_VERSION_HEADER);
         let git_xet_version = self.cas_connection_config.git_xet_version.clone();
-        let cas_protocol_version_header = HeaderName::from_static(CAS_PROTOCOL_VERSION_HEADER);
         let cas_protocol_version = CAS_PROTOCOL_VERSION.clone();
 
         let mut req = Request::builder()
             .method(method.clone())
-            .header(user_id_header, user_id)
-            .header(auth_header, auth)
-            .header(request_id_header, request_id)
-            .header(repo_path_header, repo_paths)
-            .header(git_xet_version_header, git_xet_version)
-            .header(cas_protocol_version_header, cas_protocol_version)
+            .header(USER_ID_HEADER, user_id)
+            .header(AUTH_HEADER, auth)
+            .header(REQUEST_ID_HEADER, request_id)
+            .header(REPO_PATHS_HEADER, repo_paths)
+            .header(GIT_XET_VERSION_HEADER, git_xet_version)
+            .header(CAS_PROTOCOL_VERSION_HEADER, cas_protocol_version)
             .uri(&dest)
             .version(Version::HTTP_2);
 
         if method == Method::GET {
-            let cas_accept_encoding_header = HeaderName::from_static(CAS_ACCEPT_ENCODING_HEADER);
             let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
-            req = req.header(cas_accept_encoding_header, cas_accept_encoding_value);
+            req = req.header(CAS_ACCEPT_ENCODING_HEADER, cas_accept_encoding_value);
         } else if method == Method::POST {
-            let cas_content_encoding_header = HeaderName::from_static(CAS_CONTENT_ENCODING_HEADER);
             let cas_content_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
-            req = req.header(cas_content_encoding_header, cas_content_encoding_value);
+            req = req.header(CAS_CONTENT_ENCODING_HEADER, cas_content_encoding_value);
         }
 
         if trace_forwarding() {
@@ -335,9 +328,13 @@ impl DataTransport {
             .retry_strategy
             .retry(
                 || async {
-                    let req = self
+                    let full_size = data.len();
+                    // compression of data to be done here, for now none.
+                    let mut req = self
                         .setup_request(Method::POST, prefix, hash, Some(data.to_owned()))
                         .map_err(RetryError::from)?;
+                    let headers = req.headers_mut();
+                    headers.insert(CAS_INFLATED_SIZE_HEADER, HeaderValue::from(full_size));
 
                     let resp = self
                         .http2_client

--- a/rust/cas_client/src/grpc.rs
+++ b/rust/cas_client/src/grpc.rs
@@ -395,6 +395,7 @@ impl GrpcClient {
             data_plane_endpoint,
             put_complete_endpoint,
             cas_hostname,
+            ..
         } = response.into_inner();
 
         if data_plane_endpoint.is_none() || put_complete_endpoint.is_none() {

--- a/rust/utils/proto/common.proto
+++ b/rust/utils/proto/common.proto
@@ -12,6 +12,11 @@ message InitiateRequest {
   uint64 payload_size = 2;
 }
 
+enum CompressionScheme {
+  None = 0;
+  LZ4 = 1;
+}
+
 enum Scheme {
   HTTP = 0;
   HTTPS = 1;
@@ -30,6 +35,8 @@ message InitiateResponse {
   
   EndpointConfig data_plane_endpoint = 2;
   EndpointConfig put_complete_endpoint = 3;
+
+  repeated CompressionScheme accepted_encodings = 4;
 }
 
 message Empty {

--- a/rust/utils/proto/common.proto
+++ b/rust/utils/proto/common.proto
@@ -13,7 +13,7 @@ message InitiateRequest {
 }
 
 enum CompressionScheme {
-  None = 0;
+  NONE = 0;
   LZ4 = 1;
 }
 

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -53,6 +53,8 @@ mod tests {
     fn test_from_str() {
         assert_eq!(CompressionScheme::from_str("LZ4").unwrap(), CompressionScheme::Lz4);
         assert_eq!(CompressionScheme::from_str("NONE").unwrap(), CompressionScheme::None);
+        assert_eq!(CompressionScheme::from_str("NoNE").unwrap(), CompressionScheme::None);
+        assert_eq!(CompressionScheme::from_str("none").unwrap(), CompressionScheme::None);
         assert_eq!(CompressionScheme::from_str("").unwrap(), CompressionScheme::None);
         assert!(CompressionScheme::from_str("not-scheme").is_err());
     }

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -1,22 +1,14 @@
 use std::str::FromStr;
 use anyhow::anyhow;
+use crate::common::CompressionScheme;
 
 pub const CAS_CONTENT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
 pub const CAS_ACCEPT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
-
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
-pub enum CompressionScheme {
-    #[default]
-    None,
-    LZ4,
-}
+pub const CAS_INFLATED_SIZE_HEADER: &str = "xet-cas-inflated-size";
 
 impl From<&CompressionScheme> for &'static str {
     fn from(value: &CompressionScheme) -> Self {
-       match value {
-           CompressionScheme::None => "none",
-           CompressionScheme::LZ4 => "lz4",
-       }
+        value.as_str_name()
     }
 }
 
@@ -30,11 +22,10 @@ impl FromStr for CompressionScheme {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "lz4" => Ok(CompressionScheme::LZ4),
-            "" | "none" => Ok(CompressionScheme::None),
-            _ => Err(anyhow!("could not convert &str to CompressionScheme"))
+        if s.is_empty() {
+            return Ok(CompressionScheme::None)
         }
+        Self::from_str_name(s).ok_or_else(|| anyhow!("could not convert &str to CompressionScheme"))
     }
 }
 
@@ -50,24 +41,24 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!(CompressionScheme::from_str("lz4").unwrap(), CompressionScheme::LZ4);
-        assert_eq!(CompressionScheme::from_str("none").unwrap(), CompressionScheme::None);
+        assert_eq!(CompressionScheme::from_str("LZ4").unwrap(), CompressionScheme::Lz4);
+        assert_eq!(CompressionScheme::from_str("None").unwrap(), CompressionScheme::None);
         assert_eq!(CompressionScheme::from_str("").unwrap(), CompressionScheme::None);
         assert!(CompressionScheme::from_str("not-scheme").is_err());
     }
 
     #[test]
     fn test_to_str() {
-        assert_eq!(Into::<&str>::into(CompressionScheme::LZ4), "lz4");
+        assert_eq!(Into::<&str>::into(CompressionScheme::Lz4), "LZ4");
         assert_eq!(Into::<&str>::into(CompressionScheme::None), "none");
     }
 
     #[test]
     fn test_multiple_accepted_encoding_header_value() {
-        let multi = vec![CompressionScheme::LZ4, CompressionScheme::None];
+        let multi = vec![CompressionScheme::Lz4, CompressionScheme::None];
         assert_eq!(multiple_accepted_encoding_header_value(multi), "lz4;none".to_string());
 
-        let singular = vec![CompressionScheme::LZ4];
+        let singular = vec![CompressionScheme::Lz4];
         assert_eq!(multiple_accepted_encoding_header_value(singular), "lz4".to_string());
     }
 }

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -30,7 +30,7 @@ impl FromStr for CompressionScheme {
 }
 
 pub fn multiple_accepted_encoding_header_value(list: Vec<CompressionScheme>) -> String {
-    let as_strs: Vec<&str> = list.iter().map(Into::into).collect();
+    let as_strs: Vec<&str> = list.iter().map(CompressionScheme::as_str_name).collect();
     as_strs.join(";").to_string()
 }
 
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn test_from_str() {
         assert_eq!(CompressionScheme::from_str("LZ4").unwrap(), CompressionScheme::Lz4);
-        assert_eq!(CompressionScheme::from_str("None").unwrap(), CompressionScheme::None);
+        assert_eq!(CompressionScheme::from_str("NONE").unwrap(), CompressionScheme::None);
         assert_eq!(CompressionScheme::from_str("").unwrap(), CompressionScheme::None);
         assert!(CompressionScheme::from_str("not-scheme").is_err());
     }
@@ -50,15 +50,15 @@ mod tests {
     #[test]
     fn test_to_str() {
         assert_eq!(Into::<&str>::into(CompressionScheme::Lz4), "LZ4");
-        assert_eq!(Into::<&str>::into(CompressionScheme::None), "none");
+        assert_eq!(Into::<&str>::into(CompressionScheme::None), "NONE");
     }
 
     #[test]
     fn test_multiple_accepted_encoding_header_value() {
         let multi = vec![CompressionScheme::Lz4, CompressionScheme::None];
-        assert_eq!(multiple_accepted_encoding_header_value(multi), "lz4;none".to_string());
+        assert_eq!(multiple_accepted_encoding_header_value(multi), "LZ4;NONE".to_string());
 
         let singular = vec![CompressionScheme::Lz4];
-        assert_eq!(multiple_accepted_encoding_header_value(singular), "lz4".to_string());
+        assert_eq!(multiple_accepted_encoding_header_value(singular), "LZ4".to_string());
     }
 }

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -44,6 +44,7 @@ pub mod version;
 mod output_bytes;
 
 pub use output_bytes::output_bytes;
+use crate::common::{CompressionScheme, InitiateResponse};
 
 impl TryFrom<cas::Range> for Range<u64> {
     type Error = Status;
@@ -88,6 +89,12 @@ impl std::fmt::Display for common::EndpointConfig {
         } = self;
         let scheme_parsed = common::Scheme::try_from(*scheme).unwrap_or_default();
         write!(f, "{scheme_parsed}://{host}:{port}")
+    }
+}
+
+impl InitiateResponse {
+    pub fn get_accepted_encodings_parsed(&self) -> Vec<CompressionScheme> {
+        self.accepted_encodings.iter().filter_map(|i| CompressionScheme::try_from(*i).ok()).collect()
     }
 }
 


### PR DESCRIPTION
Refactor CompressionScheme type to be defined in protobuf so the CAS server will report accepted encodings for put operation.