### PR TITLE
client work cas compression in transit

### DIFF
--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -50,6 +50,8 @@ itertools = "0.10"
 tokio-rustls = "0.25.0"
 rustls-pemfile = "2.0.0"
 hyper-rustls = { version = "0.26.0", features = ["http2"] }
+lz4 = "1.24.0"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 trait-set = "0.3.0"

--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -51,7 +51,6 @@ tokio-rustls = "0.25.0"
 rustls-pemfile = "2.0.0"
 hyper-rustls = { version = "0.26.0", features = ["http2"] }
 lz4 = "1.24.0"
-once_cell = "1.19.0"
 
 [dev-dependencies]
 trait-set = "0.3.0"

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -39,7 +39,7 @@ const BASE_RETRY_DELAY_MS: u64 = 3000;
 
 
 lazy_static! {
-    static ref ACCEPTED_ENCODINGS_HEADER_VALUE: HeaderValue = HeaderValue::from_str(multiple_accepted_encoding_header_value(vec![CompressionScheme::Lz4, CompressionScheme::None]).as_str()).unwrap_or_else(|_| HeaderValue::from_static("")); 
+    static ref ACCEPTED_ENCODINGS_HEADER_VALUE: HeaderValue = HeaderValue::from_str(multiple_accepted_encoding_header_value(vec![CompressionScheme::Lz4, CompressionScheme::None]).as_str()).unwrap_or_else(|_| HeaderValue::from_static(""));
 }
 
 pub struct DataTransport {
@@ -267,7 +267,7 @@ impl DataTransport {
             .to_vec();
         let payload_size = bytes.len();
         let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-        debug!("GET; encoding: {}, uncompressed size: {:?}, payload (maybe compressed size) {}", encoding.as_str_name(), uncompressed_size, payload_size);
+        info!("GET; encoding: ({}), uncompressed size: ({}), payload ({})  prefix: ({}), hash: ({})", encoding.as_str_name(), uncompressed_size.unwrap_or_default(), payload_size, prefix, hash);
         Ok(bytes)
     }
 
@@ -322,7 +322,7 @@ impl DataTransport {
                         .to_vec();
                     let payload_size = bytes.len();
                     let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-                    debug!("GET RANGE; encoding: {}, uncompressed size: {:?}, payload (maybe compressed size) {}", encoding.as_str_name(), uncompressed_size, payload_size);
+                    info!("GET RANGE; encoding: ({}), uncompressed size: ({}), payload ({}) prefix: ({}), hash: ({})", encoding.as_str_name(), uncompressed_size.unwrap_or_default(), payload_size, prefix, hash);
                     Ok(bytes.to_vec())
                 },
                 is_status_retriable_and_print,
@@ -337,7 +337,7 @@ impl DataTransport {
     pub async fn put(&self, prefix: &str, hash: &MerkleHash, data: &[u8], encoding: CompressionScheme) -> Result<()> {
         let full_size = data.len();
         let data = maybe_encode(data, encoding)?;
-        debug!("PUT: encoding: {}, original_size: {}, maybe compressed_size: {}", encoding.as_str_name(), full_size, data.len());
+        info!("PUT; encoding: ({}), uncompressed size: ({}), payload: ({}), prefix: ({}), hash: ({})", encoding.as_str_name(), full_size, data.len(), prefix, hash);
         let resp = self
             .retry_strategy
             .retry(

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -262,8 +262,9 @@ impl DataTransport {
             .await?
             .to_bytes()
             .to_vec();
+        let payload_size = bytes.len();
         let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-        eprintln!("\n\n\nASSAFPRINT\nget\nencoding: {}, origsize: {:?}\n\n\n\n", encoding.as_str_name(), uncompressed_size);
+        debug!("GET; encoding: {}, uncompressed size: {:?}, payload (maybe compressed size) {}", encoding.as_str_name(), uncompressed_size, payload_size);
         Ok(bytes)
     }
 
@@ -316,8 +317,9 @@ impl DataTransport {
                         .await?
                         .to_bytes()
                         .to_vec();
+                    let payload_size = bytes.len();
                     let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-                    eprintln!("\n\n\nASSAFPRINT\nget_range\nencoding: {}, origsize: {:?}\n\n\n\n", encoding.as_str_name(), uncompressed_size);
+                    debug!("GET RANGE; encoding: {}, uncompressed size: {:?}, payload (maybe compressed size) {}", encoding.as_str_name(), uncompressed_size, payload_size);
                     Ok(bytes.to_vec())
                 },
                 is_status_retriable_and_print,
@@ -332,7 +334,7 @@ impl DataTransport {
     pub async fn put(&self, prefix: &str, hash: &MerkleHash, data: &[u8], encoding: CompressionScheme) -> Result<()> {
         let full_size = data.len();
         let data = maybe_encode(data, encoding)?;
-        eprintln!("\n\n\nASSAFPRINT\nput\nencoding: {}, origsize: {}, newsize: {}\n\n\n\n", encoding.as_str_name(), full_size, data.len());
+        debug!("PUT: encoding: {}, original_size: {}, maybe compressed_size: {}", encoding.as_str_name(), full_size, data.len());
         let resp = self
             .retry_strategy
             .retry(

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use cas::constants::*;
 use std::time::Duration;
 
@@ -8,16 +9,14 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use http_body_util::{BodyExt, Full};
-use hyper::body::Bytes;
-use hyper::{
-    header::RANGE,
-    header::{HeaderMap, HeaderName, HeaderValue},
-    Method, Request, Version,
-};
+use hyper::body::{Bytes};
+use hyper::{header::RANGE, header::{HeaderMap, HeaderName, HeaderValue}, Method, Request, Version, Response};
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
+use lz4::block::CompressionMode;
+use once_cell::sync::Lazy;
 use opentelemetry::propagation::{Injector, TextMapPropagator};
 use retry_strategy::RetryStrategy;
 use rustls_pemfile::Item;
@@ -26,7 +25,8 @@ use tokio_rustls::rustls::pki_types::CertificateDer;
 use tracing::{debug, error, info, info_span, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use cas::common::CompressionScheme;
-use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CAS_CONTENT_ENCODING_HEADER, CAS_INFLATED_SIZE_HEADER};
+use cas::compression::{CAS_ACCEPT_ENCODING_HEADER, CAS_CONTENT_ENCODING_HEADER, CAS_INFLATED_SIZE_HEADER, multiple_accepted_encoding_header_value};
+use error_printer::ErrorPrinter;
 use xet_error::Error;
 
 use merklehash::MerkleHash;
@@ -36,6 +36,8 @@ const HTTP2_KEEPALIVE_MILLIS: u64 = 500;
 const HTTP2_WINDOW_SIZE: u32 = 2147418112;
 const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 3000;
+
+static ACCEPTED_ENCODINGS_HEADER_VALUE: Lazy<HeaderValue> = Lazy::new(|| HeaderValue::from_str(multiple_accepted_encoding_header_value(vec![CompressionScheme::Lz4, CompressionScheme::None]).as_str()).unwrap_or_else(|_| HeaderValue::from_static("")));
 
 pub struct DataTransport {
     http2_client: Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
@@ -195,11 +197,7 @@ impl DataTransport {
             .version(Version::HTTP_2);
 
         if method == Method::GET {
-            let cas_accept_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
-            req = req.header(CAS_ACCEPT_ENCODING_HEADER, cas_accept_encoding_value);
-        } else if method == Method::POST {
-            let cas_content_encoding_value = HeaderValue::from_static(Into::into(CompressionScheme::None));
-            req = req.header(CAS_CONTENT_ENCODING_HEADER, cas_content_encoding_value);
+            req = req.header(CAS_ACCEPT_ENCODING_HEADER, ACCEPTED_ENCODINGS_HEADER_VALUE.clone());
         }
 
         if trace_forwarding() {
@@ -256,13 +254,17 @@ impl DataTransport {
             ));
         }
         debug!("Received Response from HTTP2 GET: {}", status);
+        let (encoding, uncompressed_size) = get_encoding_info(&resp).unwrap_or((CompressionScheme::None, None));
         // Get the body
         let bytes = resp
             .collect()
             .instrument(info_span!("transport.read_body"))
             .await?
-            .to_bytes();
-        Ok(bytes.to_vec())
+            .to_bytes()
+            .to_vec();
+        let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
+        eprintln!("\n\n\nASSAFPRINT\nget\nencoding: {}, origsize: {:?}\n\n\n\n", encoding.as_str_name(), uncompressed_size);
+        Ok(bytes)
     }
 
     // Single get range to the H2 server
@@ -306,12 +308,16 @@ impl DataTransport {
                         )));
                     }
                     debug!("Received Response from HTTP2 GET range: {}", status);
+                    let (encoding, uncompressed_size) = get_encoding_info(&resp).unwrap_or((CompressionScheme::None, None));
                     // Get the body
-                    let bytes = resp
+                    let bytes: Vec<u8> = resp
                         .collect()
                         .instrument(info_span!("transport.read_body"))
                         .await?
-                        .to_bytes();
+                        .to_bytes()
+                        .to_vec();
+                    let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
+                    eprintln!("\n\n\nASSAFPRINT\nget_range\nencoding: {}, origsize: {:?}\n\n\n\n", encoding.as_str_name(), uncompressed_size);
                     Ok(bytes.to_vec())
                 },
                 is_status_retriable_and_print,
@@ -323,18 +329,21 @@ impl DataTransport {
     }
 
     // Single put to the H2 server
-    pub async fn put(&self, prefix: &str, hash: &MerkleHash, data: &[u8]) -> Result<()> {
+    pub async fn put(&self, prefix: &str, hash: &MerkleHash, data: &[u8], encoding: CompressionScheme) -> Result<()> {
+        let full_size = data.len();
+        let data = maybe_encode(data, encoding)?;
+        eprintln!("\n\n\nASSAFPRINT\nput\nencoding: {}, origsize: {}, newsize: {}\n\n\n\n", encoding.as_str_name(), full_size, data.len());
         let resp = self
             .retry_strategy
             .retry(
                 || async {
-                    let full_size = data.len();
                     // compression of data to be done here, for now none.
                     let mut req = self
-                        .setup_request(Method::POST, prefix, hash, Some(data.to_owned()))
+                        .setup_request(Method::POST, prefix, hash, Some(data.clone()))
                         .map_err(RetryError::from)?;
                     let headers = req.headers_mut();
                     headers.insert(CAS_INFLATED_SIZE_HEADER, HeaderValue::from(full_size));
+                    headers.insert(CAS_CONTENT_ENCODING_HEADER, HeaderValue::from_static(encoding.into()));
 
                     let resp = self
                         .http2_client
@@ -363,6 +372,37 @@ impl DataTransport {
         debug!("Received Response from HTTP2 POST: {}", status);
 
         Ok(())
+    }
+}
+
+fn maybe_decode<'a, T: Into<&'a [u8]>>(bytes: T, encoding: CompressionScheme, uncompressed_size: Option<i32>) -> Result<Vec<u8>> {
+   if let CompressionScheme::Lz4 = encoding {
+       if uncompressed_size.is_none() {
+           return Err(anyhow!("Missing uncompressed size when attempting to decompress LZ4"));
+       }
+       return lz4::block::decompress(bytes.into(), uncompressed_size).map_err(|e| anyhow!(e));
+   }
+    Ok(bytes.into().to_vec())
+}
+
+fn get_encoding_info<T>(response: &Response<T>) -> Option<(CompressionScheme, Option<i32>)> {
+    let headers = response.headers();
+    let value = headers.get(CAS_CONTENT_ENCODING_HEADER)?;
+    let as_str = value.to_str().ok()?;
+    let compression_scheme = CompressionScheme::from_str(as_str).ok()?;
+
+    let value = headers.get(CAS_INFLATED_SIZE_HEADER)?;
+    let as_str = value.to_str().ok()?;
+    let uncompressed_size: Option<i32> = as_str.parse().ok();
+    Some((compression_scheme, uncompressed_size))
+}
+
+fn maybe_encode<'a, T: Into<&'a [u8]>>(data: T, encoding: CompressionScheme) -> Result<Vec<u8>> {
+    if let CompressionScheme::Lz4 = encoding {
+        lz4::block::compress(data.into(), Some(CompressionMode::DEFAULT), false).log_error("LZ4 compression error").map_err(|e| anyhow!(e))
+    } else {
+        // None
+        Ok(data.into().to_vec())
     }
 }
 

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -15,8 +15,8 @@ use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
+use lazy_static::lazy_static;
 use lz4::block::CompressionMode;
-use once_cell::sync::Lazy;
 use opentelemetry::propagation::{Injector, TextMapPropagator};
 use retry_strategy::RetryStrategy;
 use rustls_pemfile::Item;
@@ -37,7 +37,10 @@ const HTTP2_WINDOW_SIZE: u32 = 2147418112;
 const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 3000;
 
-static ACCEPTED_ENCODINGS_HEADER_VALUE: Lazy<HeaderValue> = Lazy::new(|| HeaderValue::from_str(multiple_accepted_encoding_header_value(vec![CompressionScheme::Lz4, CompressionScheme::None]).as_str()).unwrap_or_else(|_| HeaderValue::from_static("")));
+
+lazy_static! {
+    static ref ACCEPTED_ENCODINGS_HEADER_VALUE: HeaderValue = HeaderValue::from_str(multiple_accepted_encoding_header_value(vec![CompressionScheme::Lz4, CompressionScheme::None]).as_str()).unwrap_or_else(|_| HeaderValue::from_static("")); 
+}
 
 pub struct DataTransport {
     http2_client: Client<HttpsConnector<HttpConnector>, Full<Bytes>>,

--- a/rust/cas_client/src/grpc.rs
+++ b/rust/cas_client/src/grpc.rs
@@ -19,6 +19,7 @@ use tracing::{debug, info, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
+use cas::common::CompressionScheme;
 use cas::{
     cas::{
         cas_client::CasClient, GetRangeRequest, GetRequest, HeadRequest, PutCompleteRequest,
@@ -27,7 +28,6 @@ use cas::{
     common::{EndpointConfig, InitiateRequest, InitiateResponse, Key, Scheme},
     constants::*,
 };
-use cas::common::CompressionScheme;
 use merklehash::MerkleHash;
 
 use crate::CasClientError;
@@ -295,7 +295,7 @@ impl Drop for GrpcClient {
 pub struct EndpointsInfo {
     pub data_plane_endpoint: EndpointConfig,
     pub put_complete_endpoint: EndpointConfig,
-    pub accepted_encodings: Vec<CompressionScheme>
+    pub accepted_encodings: Vec<CompressionScheme>,
 }
 
 impl GrpcClient {
@@ -406,7 +406,10 @@ impl GrpcClient {
             accepted_encodings,
         } = response.into_inner();
 
-        let accepted_encodings = accepted_encodings.into_iter().filter_map(|i| CompressionScheme::try_from(i).ok()).collect();
+        let accepted_encodings = accepted_encodings
+            .into_iter()
+            .filter_map(|i| CompressionScheme::try_from(i).ok())
+            .collect();
 
         if data_plane_endpoint.is_none() || put_complete_endpoint.is_none() {
             info!("CAS initiate response indicates cas protocol version < v0.2.0, defaulting to v0.1.0 config");
@@ -424,7 +427,7 @@ impl GrpcClient {
                     scheme: Scheme::Http.into(),
                     ..Default::default()
                 },
-                accepted_encodings
+                accepted_encodings,
             });
         }
         debug!(
@@ -437,7 +440,7 @@ impl GrpcClient {
         Ok(EndpointsInfo {
             data_plane_endpoint: data_plane_endpoint.unwrap(),
             put_complete_endpoint: put_complete_endpoint.unwrap(),
-            accepted_encodings
+            accepted_encodings,
         })
     }
 

--- a/rust/cas_client/src/remote_client.rs
+++ b/rust/cas_client/src/remote_client.rs
@@ -6,11 +6,11 @@ use tracing::{debug, debug_span, error, info, info_span, Instrument};
 
 use merklehash::MerkleHash;
 
+use cas::common::CompressionScheme;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use cas::common::CompressionScheme;
 
 use crate::cas_connection_pool::{self, CasConnectionConfig, FromConnectionConfig};
 use crate::data_transport::DataTransport;
@@ -197,9 +197,10 @@ impl RemoteClient {
             .await?;
 
         let EndpointsInfo {
-            data_plane_endpoint, put_complete_endpoint, accepted_encodings
-        } =
-            lb_grpc_client.initiate(prefix, hash, len).await?;
+            data_plane_endpoint,
+            put_complete_endpoint,
+            accepted_encodings,
+        } = lb_grpc_client.initiate(prefix, hash, len).await?;
         drop(lb_grpc_client);
 
         debug!("cas initiate response; data plane endpoint: {data_plane_endpoint}; put complete endpoint: {put_complete_endpoint}");
@@ -225,7 +226,11 @@ impl RemoteClient {
         chunk_boundaries: &[u64],
     ) -> Result<()> {
         debug!("H2 Put executed with {} {}", prefix, hash);
-        let InitiateResponseEndpoints { h2, put_complete, accepted_encodings } = self
+        let InitiateResponseEndpoints {
+            h2,
+            put_complete,
+            accepted_encodings,
+        } = self
             .initiate_cas_server_query(prefix, hash, data.len())
             .instrument(debug_span!("remote_client.initiate"))
             .await?;


### PR DESCRIPTION
client side work adding LZ4 compression in transit on the CAS H2 dataplane.

- on the download path, client advertises acceptable formats via an H2 request header
- on upload path, CAS server will reply with acceptable formats in gRPC InitiateResponse