### PR TITLE
Fix Summary Schema

### DIFF
--- a/rust/gitxetcore/src/command/dir_summary.rs
+++ b/rust/gitxetcore/src/command/dir_summary.rs
@@ -112,9 +112,10 @@ impl Default for DirSummaries {
 }
 
 fn compute_file_summary(path: &str) -> errors::Result<FileSummary> {
-    let mut ret = FileSummary::default();
-    ret.libmagic = Some(summarize_libmagic(Path::new(path))?);
-    Ok(ret)
+    Ok(FileSummary {
+        libmagic: Some(summarize_libmagic(Path::new(path))?),
+        ..Default::default()
+    })
 }
 
 pub async fn compute_dir_summaries(

--- a/rust/gitxetcore/src/command/summary.rs
+++ b/rust/gitxetcore/src/command/summary.rs
@@ -8,7 +8,9 @@ use std::{
 };
 use tracing::warn;
 use tableau_summary::tds::printer::{print_tds_summary, print_tds_summary_from_reader};
+use tableau_summary::tds::TdsSummary;
 use tableau_summary::twb::printer::{print_twb_summary, print_twb_summary_from_reader};
+use tableau_summary::twb::TwbSummary;
 
 use crate::{config::XetConfig, errors::GitXetRepoError, utils};
 use crate::{
@@ -103,8 +105,20 @@ async fn print_summary_from_db(
     match summary_type {
         SummaryType::Libmagic => print_stored_summary_impl(&summary.libmagic),
         SummaryType::Csv => print_stored_summary_impl(&summary.csv),
-        SummaryType::Twb => print_stored_summary_impl(&summary.twb),
-        SummaryType::Tds => print_stored_summary_impl(&summary.tds),
+        SummaryType::Twb => {
+            if let Some(sum) = summary.additional_summaries.as_ref() {
+                print_stored_summary_impl(&sum.twb)
+            } else {
+                print_stored_summary_impl::<TwbSummary>(&None)
+            }
+        },
+        SummaryType::Tds => {
+            if let Some(sum) = summary.additional_summaries.as_ref() {
+                print_stored_summary_impl(&sum.tds)
+            } else {
+                print_stored_summary_impl::<TdsSummary>(&None)
+            }
+        },
     }?;
     Ok(())
 }

--- a/rust/gitxetcore/src/diff/fetcher.rs
+++ b/rust/gitxetcore/src/diff/fetcher.rs
@@ -121,8 +121,10 @@ impl SummaryFetcher {
             let libmagic_summary = summarize_libmagic(Path::new(file_path))
                 .map_err(|e| FailedSummaryCalculation(anyhow!(e)))?;
             let summary_type = get_type_from_libmagic(&libmagic_summary);
-            let mut summary = FileSummary::default();
-            summary.libmagic = Some(libmagic_summary);
+            let mut summary = FileSummary {
+                libmagic: Some(libmagic_summary),
+                ..Default::default()
+            };
             let mut additional_summary = SummaryExt::new();
             // then use the summary_type to build the summary
             match summary_type {

--- a/rust/gitxetcore/src/diff/fetcher.rs
+++ b/rust/gitxetcore/src/diff/fetcher.rs
@@ -1,23 +1,24 @@
 use std::ffi::OsStr;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use git2::{ErrorCode, Repository};
 
-use crate::data::PointerFile;
-use ::libmagic::libmagic::{summarize_libmagic, LibmagicSummary};
+use ::libmagic::libmagic::{LibmagicSummary, summarize_libmagic};
+use error_printer::ErrorPrinter;
+use tableau_summary::tds::printer::summarize_tds_from_reader;
+use tableau_summary::twb::printer::summarize_twb_from_reader;
 
 use crate::config::XetConfig;
 use crate::constants::{GIT_NOTES_SUMMARIES_REF_NAME, POINTER_FILE_LIMIT, SMALL_FILE_THRESHOLD};
+use crate::data::PointerFile;
 use crate::diff::error::DiffError;
 use crate::diff::error::DiffError::{FailedSummaryCalculation, NoSummaries, NotInRepoDir};
 use crate::diff::util::RefOrT;
 use crate::git_integration::GitXetRepo;
 use crate::summaries::*;
-use error_printer::ErrorPrinter;
-use std::sync::Arc;
-use tableau_summary::tds::printer::summarize_tds_from_reader;
-use tableau_summary::twb::printer::summarize_twb_from_reader;
+use crate::summaries::analysis::SummaryExt;
 
 /// Fetches FileSummaries for hashes or blob_ids.
 ///
@@ -43,9 +44,9 @@ impl SummaryFetcher {
             &config.summarydb,
             GIT_NOTES_SUMMARIES_REF_NAME,
         )
-        .await
-        .log_error("Error loading git notes")
-        .map_err(|_| NoSummaries)
+            .await
+            .log_error("Error loading git notes")
+            .map_err(|_| NoSummaries)
     }
 
     fn load_repo(config: XetConfig) -> Result<Arc<Repository>, DiffError> {
@@ -104,7 +105,7 @@ impl SummaryFetcher {
                 return match e {
                     NoSummaries => Ok(RefOrT::None),
                     _ => Err(e),
-                }
+                };
             }
         };
         check_can_summarize(&blob)?;
@@ -122,6 +123,7 @@ impl SummaryFetcher {
             let summary_type = get_type_from_libmagic(&libmagic_summary);
             let mut summary = FileSummary::default();
             summary.libmagic = Some(libmagic_summary);
+            let mut additional_summary = SummaryExt::new();
             // then use the summary_type to build the summary
             match summary_type {
                 SummaryType::Csv => {
@@ -130,15 +132,16 @@ impl SummaryFetcher {
                         .map_err(|e| FailedSummaryCalculation(anyhow!(e)))?;
                 }
                 SummaryType::Twb => {
-                    summary.twb = summarize_twb_from_reader(&mut &content[..])
+                    additional_summary.twb = summarize_twb_from_reader(&mut &content[..])
                         .map_err(FailedSummaryCalculation)?;
                 }
                 SummaryType::Tds => {
-                    summary.tds = summarize_tds_from_reader(&mut &content[..])
+                    additional_summary.tds = summarize_tds_from_reader(&mut &content[..])
                         .map_err(FailedSummaryCalculation)?;
                 }
                 SummaryType::Libmagic => {}
             }
+            summary.additional_summaries = Some(additional_summary);
             summary.into()
         };
         Ok(summary)

--- a/rust/gitxetcore/src/summaries/analysis.rs
+++ b/rust/gitxetcore/src/summaries/analysis.rs
@@ -111,14 +111,14 @@ pub struct FileSummary {
     // for historical reasons this is called libmagic but does not use libmagic
     pub libmagic: Option<LibmagicSummary>,
 
+    // A buffer to allow us to add more to the serialized options
+    _buffer: Option<()>,
+
     // Tableau workbook summary
     pub twb: Option<TwbSummary>,
 
     // Tableau datasource summary
     pub tds: Option<TdsSummary>,
-
-    // A buffer to allow us to add more to the serialized options
-    _buffer: Option<()>,
 }
 
 impl FileSummary {

--- a/rust/gitxetcore/src/summaries/analysis.rs
+++ b/rust/gitxetcore/src/summaries/analysis.rs
@@ -20,7 +20,7 @@ lazy_static::lazy_static! {
     static ref CSV_WARNING_COUNTER: AtomicUsize = AtomicUsize::new(0);
 }
 const CSV_WARNING_THRESHOLD: usize = 3;
-pub const ADDITIONAL_SUMMARY_VERSION: u32 = 1;
+pub const ADDITIONAL_SUMMARY_VERSION: u32 = 0;
 
 impl FileAnalyzers {
     fn process_chunk_impl(&mut self, chunk: &[u8]) -> Result<()> {

--- a/rust/gitxetcore/src/summaries/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries/summaries_plumb.rs
@@ -6,7 +6,6 @@ use std::{
     mem::swap,
     path::{Path, PathBuf},
 };
-
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 


### PR DESCRIPTION
Moves the Tableau summaries to a versioned `SummaryExt` struct that will hold additional summaries. This seems to be working locally for csv files summarized earlier and seems to work for tableau files too.