### PR TITLE
Error Printer track caller

### DIFF
--- a/rust/error_printer/src/lib.rs
+++ b/rust/error_printer/src/lib.rs
@@ -14,40 +14,68 @@ pub trait ErrorPrinter {
 impl<T, E: Debug> ErrorPrinter for Result<T, E> {
     /// If self is an Err(e), prints out the given string to tracing::error,
     /// appending "error: {e}" to the end of the message.
+    #[track_caller]
     fn log_error<M: Display>(self, message: M) -> Self {
         match &self {
             Ok(_) => {}
-            Err(e) => error!("{}, error: {:?}", message, e),
+            Err(e) => {
+                let location = std::panic::Location::caller();
+                error!(
+                    caller = format!("{}:{}", location.file(), location.line()),
+                    "{}, error: {:?}", message, e
+                )
+            }
         }
         self
     }
 
     /// If self is an Err(e), prints out the given string to tracing::warn,
     /// appending "error: {e}" to the end of the message.
+    #[track_caller]
     fn warn_error<M: Display>(self, message: M) -> Self {
         match &self {
             Ok(_) => {}
-            Err(e) => warn!("{}, error: {:?}", message, e),
+            Err(e) => {
+                let location = std::panic::Location::caller();
+                warn!(
+                    caller = format!("{}:{}", location.file(), location.line()),
+                    "{}, error: {:?}", message, e
+                )
+            }
         }
         self
     }
 
     /// If self is an Err(e), prints out the given string to tracing::debug,
     /// appending "error: {e}" to the end of the message.
+    #[track_caller]
     fn debug_error<M: Display>(self, message: M) -> Self {
         match &self {
             Ok(_) => {}
-            Err(e) => debug!("{}, error: {:?}", message, e),
+            Err(e) => {
+                let location = std::panic::Location::caller();
+                debug!(
+                    caller = format!("{}:{}", location.file(), location.line()),
+                    "{}, error: {:?}", message, e
+                )
+            }
         }
         self
     }
 
     /// If self is an Err(e), prints out the given string to tracing::info,
     /// appending "error: {e}" to the end of the message.
+    #[track_caller]
     fn info_error<M: Display>(self, message: M) -> Self {
         match &self {
             Ok(_) => {}
-            Err(e) => info!("{}, error: {:?}", message, e),
+            Err(e) => {
+                let location = std::panic::Location::caller();
+                info!(
+                    caller = format!("{}:{}", location.file(), location.line()),
+                    "{}, error: {:?}", message, e
+                )
+            }
         }
         self
     }

--- a/rust/error_printer/src/lib.rs
+++ b/rust/error_printer/src/lib.rs
@@ -1,6 +1,10 @@
 use std::fmt::{Debug, Display};
 use tracing::{debug, error, info, warn};
 
+/// A helper trait to log errors.
+/// The logging functions will track the caller's callsite.
+/// For a chain of calls A -> B -> C -> ErrorPrinter, the
+/// topmost function without #[track_caller] is deemed the callsite.
 pub trait ErrorPrinter {
     fn log_error<M: Display>(self, message: M) -> Self;
 


### PR DESCRIPTION
The current error_printer implementation makes it difficult to track where the errors come from, because `error!()`, `warn!()`, `info!()`, `debug!()` all log calling location with `file!()` and `line!()`, which is inside `error_printer/src/lib.rs`. For example, using error_printer inside `gitxetcore/src/command/merkledb.rs` like below
```
use error_printer::ErrorPrinter;
let err = GitXetRepoError::CasClientError("hello".to_owned());
let eerr = Err::<(), GitXetRepoError>(err);
eerr.log_error("log error")
    .warn_error("warn error")
    .debug_error("debug error")
    .info_error("info error");
```
will print
```
2024-03-22T23:10:14.190210Z ERROR gitxet: error_printer/src/lib.rs:20: log error, error: CasClientError("hello") 
2024-03-22T23:10:14.190316Z  WARN gitxet: error_printer/src/lib.rs:30: warn error, error: CasClientError("hello") 
2024-03-22T23:10:14.190331Z DEBUG gitxet: error_printer/src/lib.rs:40: debug error, error: CasClientError("hello") 
2024-03-22T23:10:14.190344Z  INFO gitxet: error_printer/src/lib.rs:50: info error, error: CasClientError("hello") 
```

This PR makes it track and print the more useful caller location:
```
2024-03-22T23:07:37.323974Z ERROR gitxet: error_printer/src/lib.rs:23: log error, error: CasClientError("hello") caller="/Users/di/xetdata/xet-core/rust/gitxetcore/src/command/merkledb.rs:219"
2024-03-22T23:07:37.324063Z  WARN gitxet: error_printer/src/lib.rs:40: warn error, error: CasClientError("hello") caller="/Users/di/xetdata/xet-core/rust/gitxetcore/src/command/merkledb.rs:220"
2024-03-22T23:07:37.324081Z DEBUG gitxet: error_printer/src/lib.rs:57: debug error, error: CasClientError("hello") caller="/Users/di/xetdata/xet-core/rust/gitxetcore/src/command/merkledb.rs:221"
2024-03-22T23:07:37.324096Z  INFO gitxet: error_printer/src/lib.rs:74: info error, error: CasClientError("hello") caller="/Users/di/xetdata/xet-core/rust/gitxetcore/src/command/merkledb.rs:222"
```