### PR TITLE
Add backtrace to ErrorPrinter

### DIFF
--- a/rust/error_printer/src/lib.rs
+++ b/rust/error_printer/src/lib.rs
@@ -26,7 +26,10 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 error!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    "{}, error: {:?}", message, e
+                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
+                    "{}, error: {:?}",
+                    message,
+                    e,
                 )
             }
         }
@@ -43,7 +46,10 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 warn!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    "{}, error: {:?}", message, e
+                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
+                    "{}, error: {:?}",
+                    message,
+                    e,
                 )
             }
         }
@@ -60,7 +66,10 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 debug!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    "{}, error: {:?}", message, e
+                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
+                    "{}, error: {:?}",
+                    message,
+                    e
                 )
             }
         }
@@ -77,7 +86,10 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 info!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    "{}, error: {:?}", message, e
+                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
+                    "{}, error: {:?}",
+                    message,
+                    e
                 )
             }
         }


### PR DESCRIPTION
This makes the logging functions in ErrorPrinter to also include a backtrace.