### PR TITLE
Revert "Add backtrace to ErrorPrinter"

### DIFF
--- a/rust/error_printer/src/lib.rs
+++ b/rust/error_printer/src/lib.rs
@@ -26,10 +26,7 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 error!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
-                    "{}, error: {:?}",
-                    message,
-                    e,
+                    "{}, error: {:?}", message, e
                 )
             }
         }
@@ -46,10 +43,7 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 warn!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
-                    "{}, error: {:?}",
-                    message,
-                    e,
+                    "{}, error: {:?}", message, e
                 )
             }
         }
@@ -66,10 +60,7 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 debug!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
-                    "{}, error: {:?}",
-                    message,
-                    e
+                    "{}, error: {:?}", message, e
                 )
             }
         }
@@ -86,10 +77,7 @@ impl<T, E: Debug> ErrorPrinter for Result<T, E> {
                 let location = std::panic::Location::caller();
                 info!(
                     caller = format!("{}:{}", location.file(), location.line()),
-                    context = format!("{:?}", std::backtrace::Backtrace::force_capture()),
-                    "{}, error: {:?}",
-                    message,
-                    e
+                    "{}, error: {:?}", message, e
                 )
             }
         }

--- a/rust/gitxetcore/src/environment/log.rs
+++ b/rust/gitxetcore/src/environment/log.rs
@@ -19,14 +19,14 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
-fn log_exception_info(source: &str) {
+pub fn log_exception_info(source: &str) {
     tracing::info!(
         "Error reported: {source} error; context={:?}",
         std::backtrace::Backtrace::force_capture()
     );
 }
 
-fn log_exception_error(source: &str) {
+pub fn log_exception_error(source: &str) {
     tracing::error!(
         "Error reported: {source} error; context={:?}",
         std::backtrace::Backtrace::force_capture()


### PR DESCRIPTION
Reverts xetdata/xet-core#310. It adds too much backtrace and it's not helpful because at the time of calling the logging functions `log_error` etc. the backtrace for where the error was first generated is already gone.