### PR TITLE
summarize compute from stdin and add force option for from-blob-id

### DIFF
--- a/rust/gitxetcore/src/errors.rs
+++ b/rust/gitxetcore/src/errors.rs
@@ -6,13 +6,13 @@ use std::path::PathBuf;
 use std::process::{ExitCode, Termination};
 
 use cas::errors::SingleflightError;
+use cas_client::CasClientError;
 use lazy::error::LazyError;
 use merklehash::MerkleHash;
+use parutils::ParallelError;
 use xet_error::Error;
 
 use crate::config::ConfigError;
-use cas_client::CasClientError;
-use parutils::ParallelError;
 
 #[derive(Error, Debug)]
 pub enum GitXetRepoError {
@@ -121,6 +121,9 @@ pub enum GitXetRepoError {
 
     #[error("Bincode Serialization/Deserialization error: {0}")]
     BincodeError(#[from] Box<bincode::ErrorKind>),
+
+    #[error("Summary DB not found error: {0}")]
+    SummaryDBNotFoundError(String),
 }
 
 // Define our own result type here (this seems to be the standard).
@@ -192,6 +195,7 @@ impl From<GitXetRepoError> for ExitCode {
             GitXetRepoError::WalkDirError(_) => 35,
             GitXetRepoError::DataHashBytesParseError(_) => 36,
             GitXetRepoError::BincodeError(_) => 37,
+            GitXetRepoError::SummaryDBNotFoundError(_) => 38,
         })
     }
 }


### PR DESCRIPTION
- Adds a git-xet summary subcommand to summarize file contents from stdin
- minor refactors of summary.rs functions, shared code between different compute command impls
- adds a `-f/--force` on `git-xet summary compute-from-blob-id` that skips attempting to look in summary DB in git notes
  - for blob that holds a pointer file, this will attempt to compute the hash by smudging the hash.