### PR TITLE
Handles no smudge config correctly

### DIFF
--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -32,7 +32,8 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
     clone_xet_repo(
         Some(&config),
         &arg_v[..],
-        args.no_smudge || args.lazy,
+        // config.force_no_smudge may come from env var `XET_NO_SMUDGE` or git-xet global config `smudge`
+        args.no_smudge || args.lazy || config.force_no_smudge,
         None,
         true,
         true,

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -555,7 +555,7 @@ fn no_version_check_from_env() -> bool {
 /// Some(true) if XET_NO_SMUDGE is set to other values in the environment;
 /// None if XET_NO_SMUDGE is not set in the environment.
 fn no_smudge_from_env() -> Option<bool> {
-    std::env::var_os(XET_NO_SMUDGE_ENV).and_then(|v| Some(v != "0"))
+    std::env::var_os(XET_NO_SMUDGE_ENV).map(|v| v != "0")
 }
 
 /// Loads the current known cfg reading system and environment variables.

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -551,32 +551,23 @@ fn no_version_check_from_env() -> bool {
     }
 }
 
-/// Returns true if XET_NO_SMUDGE=1 is set in the environment
-fn no_smudge_from_env() -> bool {
-    match std::env::var_os(XET_NO_SMUDGE_ENV) {
-        Some(v) => v != "0",
-
-        None => false,
-    }
-}
-
-/// Try to remove XET_NO_SMUDGE from the environment. This is to avoid
-/// polluting the config parsing from ENV
-fn remove_no_smudge_from_env() {
-    std::env::remove_var(XET_NO_SMUDGE_ENV);
+/// Returns Some(false) if XET_NO_SMUDGE=0 is set in the environment;
+/// Some(true) if XET_NO_SMUDGE is set to other values in the environment;
+/// None if XET_NO_SMUDGE is not set in the environment.
+fn no_smudge_from_env() -> Option<bool> {
+    std::env::var_os(XET_NO_SMUDGE_ENV).and_then(|v| Some(v != "0"))
 }
 
 /// Loads the current known cfg reading system and environment variables.
 fn load_system_cfg(gitpath: ConfigGitPathOption) -> Result<Cfg, GitXetRepoError> {
     let no_smudge = no_smudge_from_env();
-    if no_smudge {
-        remove_no_smudge_from_env()
-    }
 
     let loader = create_config_loader(Some(gitpath))?;
     let mut resolved_cfg = loader.resolve_config(Level::ENV).map_err(Config)?;
 
-    resolved_cfg.smudge = Some(!no_smudge);
+    if let Some(value) = no_smudge {
+        resolved_cfg.smudge = Some(!value)
+    }
 
     Ok(resolved_cfg)
 }

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -565,6 +565,7 @@ fn load_system_cfg(gitpath: ConfigGitPathOption) -> Result<Cfg, GitXetRepoError>
     let loader = create_config_loader(Some(gitpath))?;
     let mut resolved_cfg = loader.resolve_config(Level::ENV).map_err(Config)?;
 
+    // Env config has the highest priority
     if let Some(value) = no_smudge {
         resolved_cfg.smudge = Some(!value)
     }


### PR DESCRIPTION
Fixes CLI-144 [->](https://linear.app/xethub/issue/CLI-144/xet-no-smudge-doesnt-work-with-git-xet-clone). 

Context:
When cloning a repo "no smudge" can be configured from three places in order of descending priority:
1. command line args: `git xet clone --lazy/--no-smudge`
2. env var `XET_NO_SMUDGE=1`
3. git-xet global config, e.g. `git xet config --global smudge false`.

The bug was that `XET_NO_SMUDGE` was dropped from the env var but the config not used by `git xet clone`. It was dropped in https://github.com/xetdata/xet-core/pull/87 to avoid a config parsing issue which was later fixed by https://github.com/xetdata/xet-core/pull/95, making it unnecessary to drop `XET_NO_SMUDGE`.

This PR fixes the XetConfig to make sure it picks up the corresponding global config and env var config, and makes sure "git xet clone" uses that.

Tests:
1. `XET_NO_SMUDGE=1 git clone`: no smudge
2. `XET_NO_SMUDGE=1 git xet clone`: no smudge
3. `git xet config --global smudge false && git xet clone`: no smudge