### PR TITLE
Fixing Thumbnail extraction name from twb files

### DIFF
--- a/rust/tableau_summary/Cargo.toml
+++ b/rust/tableau_summary/Cargo.toml
@@ -13,6 +13,7 @@ itertools = "0.12.1"
 tracing = "0.1.40"
 regex = "1.10.3"
 once_cell = "1.19.0"
+url = "2.5.0"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/rust/tableau_summary/src/twb/raw/dashboard.rs
+++ b/rust/tableau_summary/src/twb/raw/dashboard.rs
@@ -4,7 +4,7 @@ use tracing::info;
 use crate::check_tag_or_default;
 
 use crate::twb::NAME_KEY;
-use crate::twb::raw::util::parse_formatted_text;
+use crate::twb::raw::util::{parse_formatted_text, repository_location_to_thumbnail_name};
 use crate::twb::raw::worksheet::table::View;
 use crate::xml::XmlExt;
 
@@ -32,7 +32,7 @@ impl<'a, 'b> From<Node<'a, 'b>> for RawDashboard {
             name: n.get_attr(NAME_KEY),
             title,
             thumbnail: n.get_tagged_child("repository-location")
-                .map(|ch|ch.get_attr("id")),
+                .map(repository_location_to_thumbnail_name),
             view: View::from(n),
             zones: n.get_tagged_child("zones")
                 .and_then(|ch|ch.get_tagged_child("zone"))

--- a/rust/tableau_summary/src/twb/raw/datasource/connection.rs
+++ b/rust/tableau_summary/src/twb/raw/datasource/connection.rs
@@ -375,7 +375,7 @@ impl<'a, 'b> From<Node<'a, 'b>> for MetadataRecords {
                     let name = get_text_from_child(c, "parent-name");
                     capabilities.insert(name, agg);
                 },
-                "column" => {
+                "column" | "measure" => {
                     let col = ColumnMetadata::from(c);
                     columns.insert(col.name.clone(), col);
                 },

--- a/rust/tableau_summary/src/twb/raw/util.rs
+++ b/rust/tableau_summary/src/twb/raw/util.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use roxmltree::Node;
+use url::Url;
 
 use crate::xml::XmlExt;
 
@@ -9,6 +10,18 @@ pub fn parse_formatted_text(n: Node) -> String {
         .map(Node::get_text)
         .join("")
 }
+
+pub fn repository_location_to_thumbnail_name(n: Node) -> String {
+    let id = n.get_attr("id");
+    let derived_from = n.get_attr("derived-from");
+    let view_name = Url::parse(&derived_from)
+        .map(|u| u.path_segments()
+            .and_then(|s| s.last())
+            .map(String::from)
+        ).unwrap_or(None);
+    view_name.unwrap_or(id)
+}
+
 
 pub mod macros {
     /// Macro to help wih validating a node's tag is correct for use in From<Node> implmementations.
@@ -24,4 +37,27 @@ pub mod macros {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    #[test]
+    fn test_repository_location_to_thumbnail() {
+        let s = "<repository-location derived-from='http://localhost:9100/t/xethubintegjoe/workbooks/Superstore?rev=1.2' id='Superstore' path='/t/xethubintegjoe/workbooks' revision='1.5' site='xethubintegjoe' />";
+        let document = roxmltree::Document::parse(s).unwrap();
+        let root = document.root().get_tagged_descendant("repository-location").unwrap();
+        let s = repository_location_to_thumbnail_name(root);
+        assert_eq!("Superstore", &s);
+    }
+
+    #[test]
+    fn test_repository_location_to_thumbnail_different_id() {
+        let s = "<repository-location derived-from='http://localhost:9100/t/xethubintegjoe/workbooks/BookSales/Sheet1?rev=' id='1352269' path='/t/xethubintegjoe/workbooks/BookSales' revision='' site='xethubintegjoe' />";
+        let document = roxmltree::Document::parse(s).unwrap();
+        let root = document.root().get_tagged_descendant("repository-location").unwrap();
+        let s = repository_location_to_thumbnail_name(root);
+        assert_eq!("Sheet1", &s);
+    }
+
+
+}

--- a/rust/tableau_summary/src/twb/raw/worksheet.rs
+++ b/rust/tableau_summary/src/twb/raw/worksheet.rs
@@ -6,6 +6,7 @@ use crate::check_tag_or_default;
 
 use crate::twb::NAME_KEY;
 use crate::twb::raw::util;
+use crate::twb::raw::util::repository_location_to_thumbnail_name;
 use crate::xml::XmlExt;
 
 pub mod table;
@@ -30,7 +31,7 @@ impl<'a, 'b> From<Node<'a, 'b>> for RawWorksheet {
             name: n.get_attr(NAME_KEY),
             title,
             thumbnail: n.get_tagged_child("repository-location")
-                .map(|ch|ch.get_attr("id")),
+                .map(repository_location_to_thumbnail_name),
             table: n.get_tagged_child("table")
                 .map(WorksheetTable::from)
                 .unwrap_or_default(),


### PR DESCRIPTION
Fixes: TAB-52

* Thumbnails are extracted using the last path element of the `derived-from` field of the `repository-location` node if that is different from the `id` column.
* Fixes an issue where `measure` classes in `metadata-records` were being ignored during parsing.