### PR TITLE
Adding simple summary diffs for twb and tds files

### DIFF
--- a/rust/gitxetcore/src/command/diff.rs
+++ b/rust/gitxetcore/src/command/diff.rs
@@ -141,23 +141,34 @@ fn run_diffs(
     after_summary: Option<&FileSummary>,
 ) -> Result<Vec<SummaryDiff>, DiffError> {
     let mut diffs = vec![];
+    let mut errs = vec![];
+    debug!("Summaries retrieved: \n\nBefore: {before_summary:?}\n\nAfter: {after_summary:?}");
 
     // csv diff
     let csv_proc = CsvSummaryDiffProcessor {};
-    let diff = csv_proc.get_diff(before_summary, after_summary)?;
-    diffs.push(diff);
+    _ = csv_proc.get_diff(before_summary, after_summary)
+        .map(|diff| diffs.push(diff))
+        .map_err(|e| errs.push(e));
 
     // twb diff
     let twb_proc = TwbSummaryDiffProcessor {};
-    let diff = twb_proc.get_diff(before_summary, after_summary)?;
-    diffs.push(diff);
+    _ = twb_proc.get_diff(before_summary, after_summary)
+        .map(|diff| diffs.push(diff))
+        .map_err(|e| errs.push(e));
 
     // tds diff
     let tds_proc = TdsSummaryDiffProcessor {};
-    let diff = tds_proc.get_diff(before_summary, after_summary)?;
-    diffs.push(diff);
+    _ = tds_proc.get_diff(before_summary, after_summary)
+        .map(|diff| diffs.push(diff))
+        .map_err(|e| errs.push(e));
 
-    Ok(diffs)
+    if !diffs.is_empty() {
+        Ok(diffs)
+    } else {
+        Err(errs.into_iter()
+            .find(|e| !matches!(e, DiffError::NoSummaries)) // find the first error that isn't NoSummaries
+            .unwrap_or(DiffError::NoSummaries))
+    }
 }
 
 #[cfg(test)]

--- a/rust/gitxetcore/src/command/diff.rs
+++ b/rust/gitxetcore/src/command/diff.rs
@@ -147,6 +147,16 @@ fn run_diffs(
     let diff = csv_proc.get_diff(before_summary, after_summary)?;
     diffs.push(diff);
 
+    // twb diff
+    let twb_proc = TwbSummaryDiffProcessor {};
+    let diff = twb_proc.get_diff(before_summary, after_summary)?;
+    diffs.push(diff);
+
+    // tds diff
+    let tds_proc = TdsSummaryDiffProcessor {};
+    let diff = tds_proc.get_diff(before_summary, after_summary)?;
+    diffs.push(diff);
+
     Ok(diffs)
 }
 

--- a/rust/gitxetcore/src/diff/mod.rs
+++ b/rust/gitxetcore/src/diff/mod.rs
@@ -4,8 +4,12 @@ mod fetcher;
 mod output;
 mod processor;
 mod util;
+mod twb;
+mod tds;
 
 pub use csv::CsvSummaryDiffProcessor;
+pub use twb::TwbSummaryDiffProcessor;
+pub use tds::TdsSummaryDiffProcessor;
 pub use error::*;
 pub use fetcher::SummaryFetcher;
 pub use output::{DiffOutput, SummaryDiff};

--- a/rust/gitxetcore/src/diff/output.rs
+++ b/rust/gitxetcore/src/diff/output.rs
@@ -3,6 +3,8 @@ use crate::diff::error::DiffError;
 use crate::summaries::summary_type::SummaryType;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use crate::diff::tds::TdsSummaryDiffContent;
+use crate::diff::twb::TwbSummaryDiffContent;
 
 /// The resulting struct to be output by the command.
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
@@ -33,6 +35,8 @@ pub struct SummaryDiff {
 #[serde(untagged)]
 pub enum SummaryDiffData {
     Csv(CsvSummaryDiffContent),
+    Twb(TwbSummaryDiffContent),
+    Tds(TdsSummaryDiffContent),
 }
 
 impl From<DiffError> for DiffOutput {

--- a/rust/gitxetcore/src/diff/tds.rs
+++ b/rust/gitxetcore/src/diff/tds.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use tableau_summary::tds::TdsSummary;
+use crate::diff::output::SummaryDiffData;
+use crate::diff::{DiffError, SummaryDiffProcessor};
+use crate::diff::output::SummaryDiffData::Tds;
+use crate::summaries::{FileSummary, SummaryType};
+
+/// Diff content for a Tds diff
+#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+pub struct TdsSummaryDiffContent {
+    pub before: Option<TdsSummary>,
+    pub after: Option<TdsSummary>,
+}
+
+/// Processes diffs of Tds Summaries, taking in [TdsSummary]s and producing a [TdsSummaryDiffContent]
+/// indicating the delta between them.
+///
+/// Currently, this will just provide the two summaries (before + after). In the future, we can
+/// change this to become more intelligent (actually identify what changed between the datasources).
+pub struct TdsSummaryDiffProcessor {}
+
+
+impl SummaryDiffProcessor for TdsSummaryDiffProcessor {
+    type SummaryData = TdsSummary;
+
+    fn get_type(&self) -> SummaryType {
+        SummaryType::Tds
+    }
+
+    fn get_version(&self) -> u8 {
+        1
+    }
+
+    fn get_data<'a>(&'a self, summary: &'a FileSummary) -> Option<&Self::SummaryData> {
+        summary.additional_summaries.as_ref()
+            .and_then(|ext|ext.tds.as_ref())
+    }
+
+    fn get_insert_diff(&self, summary: &TdsSummary) -> Result<SummaryDiffData, DiffError> {
+        Ok(Tds(TdsSummaryDiffContent {
+            before: None,
+            after: Some(summary.clone()),
+        }))
+    }
+
+    fn get_remove_diff(&self, summary: &TdsSummary) -> Result<SummaryDiffData, DiffError> {
+        Ok(Tds(TdsSummaryDiffContent {
+            before: Some(summary.clone()),
+            after: None,
+        }))
+    }
+
+    fn get_diff_impl(
+        &self,
+        before: &TdsSummary,
+        after: &TdsSummary,
+    ) -> Result<SummaryDiffData, DiffError> {
+        Ok(Tds(TdsSummaryDiffContent {
+            before: Some(before.clone()),
+            after: Some(after.clone()),
+        }))
+    }
+}

--- a/rust/gitxetcore/src/diff/twb.rs
+++ b/rust/gitxetcore/src/diff/twb.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use tableau_summary::twb::TwbSummary;
+use crate::diff::output::SummaryDiffData;
+use crate::diff::{DiffError, SummaryDiffProcessor};
+use crate::diff::output::SummaryDiffData::Twb;
+use crate::summaries::{FileSummary, SummaryType};
+
+/// Diff content for a Twb diff
+#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+pub struct TwbSummaryDiffContent {
+    pub before: Option<TwbSummary>,
+    pub after: Option<TwbSummary>,
+}
+
+/// Processes diffs of Twb Summaries, taking in [TwbSummary]s and producing a [TwbSummaryDiffContent]
+/// indicating the delta between them.
+///
+/// Currently, this will just provide the two summaries (before + after). In the future, we can
+/// change this to become more intelligent (actually identify what changed between the workbooks).
+pub struct TwbSummaryDiffProcessor {}
+
+
+impl SummaryDiffProcessor for TwbSummaryDiffProcessor {
+    type SummaryData = TwbSummary;
+
+    fn get_type(&self) -> SummaryType {
+        SummaryType::Twb
+    }
+
+    fn get_version(&self) -> u8 {
+        1
+    }
+
+    fn get_data<'a>(&'a self, summary: &'a FileSummary) -> Option<&Self::SummaryData> {
+        summary.additional_summaries.as_ref()
+            .and_then(|ext|ext.twb.as_ref())
+    }
+
+    fn get_insert_diff(&self, summary: &TwbSummary) -> Result<SummaryDiffData, DiffError> {
+        Ok(Twb(TwbSummaryDiffContent {
+            before: None,
+            after: Some(summary.clone()),
+        }))
+    }
+
+    fn get_remove_diff(&self, summary: &TwbSummary) -> Result<SummaryDiffData, DiffError> {
+        Ok(Twb(TwbSummaryDiffContent {
+            before: Some(summary.clone()),
+            after: None,
+        }))
+    }
+
+    fn get_diff_impl(
+        &self,
+        before: &TwbSummary,
+        after: &TwbSummary,
+    ) -> Result<SummaryDiffData, DiffError> {
+        Ok(Twb(TwbSummaryDiffContent {
+            before: Some(before.clone()),
+            after: Some(after.clone()),
+        }))
+    }
+}


### PR DESCRIPTION
Fixes: TAB-47

* Adds a summary diff processor for twb files that just provides the before/after summaries
* Adds a summary diff processor for tds files that just provides the before/after summaries