### PR TITLE
match cas/shard client hyper versions

### DIFF
--- a/rust/cas_client/Cargo.toml
+++ b/rust/cas_client/Cargo.toml
@@ -9,39 +9,39 @@ strict = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-common_constants = {path = "../common_constants"}
-error_printer = {path = "../error_printer"}
-utils = {path = "../utils"}
-merkledb = {path = "../merkledb"}
-merklehash = { path = "../merklehash" } 
-parutils = {path = "../parutils"}
-retry_strategy = {path = "../retry_strategy"}
-tonic = {version = "0.10.2", features = ["tls", "tls-roots", "transport"] }
+common_constants = { path = "../common_constants" }
+error_printer = { path = "../error_printer" }
+utils = { path = "../utils" }
+merkledb = { path = "../merkledb" }
+merklehash = { path = "../merklehash" }
+parutils = { path = "../parutils" }
+retry_strategy = { path = "../retry_strategy" }
+tonic = { version = "0.10.2", features = ["tls", "tls-roots", "transport"] }
 prost = "0.12.3"
 tokio = { version = "1.36", features = ["full"] }
 tokio-retry = "0.3.0"
-tower = {version = "0.4"}
+tower = { version = "0.4" }
 clap = "2.33"
 async-trait = "0.1.9"
 anyhow = "1"
-http = "0.2.5"
-xet_error = {path = "../xet_error"}
+http = "1.1.0"
+xet_error = { path = "../xet_error" }
 tempfile = "3"
-cache = {path = "../cache"}
-deadpool = {version = "0.9.4", features = ["managed", "rt_tokio_1"] }
-futures = {version = "0.3", default-features = false, features = ["alloc"]}
+cache = { path = "../cache" }
+deadpool = { version = "0.9.4", features = ["managed", "rt_tokio_1"] }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 tracing = "0.1.31"
 bincode = "1.3.3"
-uuid = {version = "1", features = ["v4", "fast-rng"]}
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 lazy_static = "1.4.0"
 # trace-propagation
 opentelemetry = { version = "0.17", features = ["trace", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 opentelemetry-http = "0.6.0"
 tracing-opentelemetry = "0.17.2"
-progress_reporting = {path = "../progress_reporting"}
+progress_reporting = { path = "../progress_reporting" }
 serde_json = "1.0"
-hyper = { version = "1.1.0", features = ["client", "http2"] }
+hyper = { version = "1.2.0", features = ["client", "http2"] }
 hyper-util = { version = "0.1.2", features = ["http2", "tokio", "client"] }
 http-body-util = "0.1.0"
 tokio-native-tls = "0.3.1"

--- a/rust/shard_client/Cargo.toml
+++ b/rust/shard_client/Cargo.toml
@@ -9,29 +9,29 @@ strict = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-utils = {path = "../utils"}
-merklehash = {path = "../merklehash"}
-retry_strategy = {path = "../retry_strategy"}
-tonic = {version = "0.10.2", features = ["tls", "tls-roots", "transport"] }
+utils = { path = "../utils" }
+merklehash = { path = "../merklehash" }
+retry_strategy = { path = "../retry_strategy" }
+tonic = { version = "0.10.2", features = ["tls", "tls-roots", "transport"] }
 prost = "0.12.3"
 tokio = { version = "1.36", features = ["full"] }
 tokio-retry = "0.3.0"
-tower = {version = "0.4"}
+tower = { version = "0.4" }
 clap = "2.33"
 async-trait = "0.1.9"
 anyhow = "1"
-http = "0.2.5"
-xet_error = {path = "../xet_error"}
+http = "1.1.0"
+xet_error = { path = "../xet_error" }
 tempfile = "3"
 tracing = "0.1.31"
 bincode = "1.3.3"
-uuid = {version = "1", features = ["v4", "fast-rng"]}
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 lazy_static = "1.4.0"
-cas_client = {path = "../cas_client"}
+cas_client = { path = "../cas_client" }
 serde_json = "1.0"
-mdb_shard = {path = "../mdb_shard"}
-merkledb = {path = "../merkledb"}
-progress_reporting = {path = "../progress_reporting"}
+mdb_shard = { path = "../mdb_shard" }
+merkledb = { path = "../merkledb" }
+progress_reporting = { path = "../progress_reporting" }
 heed = "0.11"
 
 # trace-propagation
@@ -43,7 +43,7 @@ tracing-opentelemetry = "0.17.2"
 
 
 # HTTP2 GET AND POST support
-hyper = "0.14.18"
+hyper = "1.2.0"
 bytes = "1"
 itertools = "0.10"
 


### PR DESCRIPTION
bump both cas_client & shard_client packages to have dependencies hyper v1.2.0 and http v1.1.0