### PR TITLE
Add RawDatasource dependency to View struct

### DIFF
--- a/rust/tableau_summary/src/twb/mod.rs
+++ b/rust/tableau_summary/src/twb/mod.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::mem;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use roxmltree::Node;
@@ -77,7 +79,15 @@ impl TwbAnalyzer {
             .ok_or(anyhow!("no workbook node"))?;
 
         // Build raw workbook model
-        let raw_workbook = TwbRaw::try_from(root)?;
+        let mut raw_workbook = TwbRaw::try_from(root)?;
+        let raw_ds_map = raw_workbook.datasources.iter()
+            .map(|ds| (ds.name.clone(), ds.clone()))
+            .collect::<HashMap<_, _>>();
+        let raw_ds_map = Arc::new(raw_ds_map);
+        raw_workbook.worksheets.iter_mut()
+            .for_each(|ws| ws.table.view.datasources = raw_ds_map.clone());
+        raw_workbook.dashboards.iter_mut()
+            .for_each(|dash| dash.view.datasources = raw_ds_map.clone());
 
         // Summarize from the raw workbook model
         let datasources = raw_workbook.datasources.iter()

--- a/rust/tableau_summary/src/twb/raw/datasource.rs
+++ b/rust/tableau_summary/src/twb/raw/datasource.rs
@@ -85,6 +85,10 @@ impl RawDatasource {
             .and_then(|conn| conn.metadata_records.capabilities.get(table).cloned())
     }
 
+    pub fn get_column(&self, name: &str) -> Option<&ColumnDep> {
+        self.column_set.columns.get(name)
+    }
+
     fn update_dependent_datasource_captions(&mut self, captions: &HashMap<String, String>) {
         self.dependencies.values_mut().for_each(|dep| {
             dep.caption = captions.get(&dep.name).cloned().unwrap_or_default();


### PR DESCRIPTION
Fixes: TAB-65

Sometimes, column resolution for Dashboards and Worksheets needs to use the Datasource's column listing. This change adds the dependency so that we can properly resolve columns.