### PR TITLE
s3config replace login for xs3 auth UX flow

### DIFF
--- a/rust/gitxetcore/src/command/login.rs
+++ b/rust/gitxetcore/src/command/login.rs
@@ -31,10 +31,6 @@ pub struct LoginArgs {
     /// Do not overwrite credentials if they already exist
     #[clap(long)]
     pub no_overwrite: bool,
-
-    /// Configures aws-cli for xethub S3 access
-    #[clap(long)]
-    pub s3: bool,
 }
 
 /// applies config from LoginArgs onto a cfg

--- a/rust/gitxetcore/src/command/mod.rs
+++ b/rust/gitxetcore/src/command/mod.rs
@@ -25,6 +25,7 @@ use openssl_probe;
 use pointer::{pointer_command, PointerArgs};
 use push::push_command;
 use repo_size::{repo_size_command, RepoSizeArgs};
+use s3config::{s3config_command, S3configArgs};
 use smudge::{smudge_command, SmudgeArgs};
 use summary::{summary_command, SummaryArgs};
 use uninit::{uninit_command, UninitArgs};
@@ -63,6 +64,7 @@ pub mod mount;
 mod pointer;
 mod push;
 mod repo_size;
+mod s3config;
 mod smudge;
 mod summary;
 pub mod uninit;
@@ -152,6 +154,9 @@ pub enum Command {
     /// Copy files to/from a xet remote.  
     #[clap(hide(true))]
     Cp(CpArgs),
+
+    /// Configure access to the XetHub S3 service.
+    S3config(S3configArgs),
 }
 
 const GIT_VERSION: &str = git_version!(
@@ -275,6 +280,7 @@ impl Command {
             Command::Materialize(args) => materialize_command(cfg, args).await,
             Command::Dematerialize(args) => dematerialize_command(cfg, args).await,
             Command::Cp(args) => cp_command(cfg, args).await,
+            Command::S3config(args) => s3config_command(cfg, args),
         };
         if let Ok(mut axe) = axe {
             axe.command_complete().await;
@@ -310,6 +316,7 @@ impl Command {
             Command::Materialize(_) => true,
             Command::Dematerialize(_) => true,
             Command::Cp(_) => true,
+            Command::S3config(_) => true,
         }
     }
 
@@ -341,6 +348,7 @@ impl Command {
             Command::Materialize(_) => "materialize".to_string(),
             Command::Dematerialize(_) => "dematerialize".to_string(),
             Command::Cp(_) => "cp".to_string(),
+            Command::S3config(_) => "s3config".to_string(),
         }
     }
     pub fn long_running(&self) -> bool {

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -69,9 +69,9 @@ fn print_help_message(s3config_path: &Path) {
 
 1. To get started, source the corresponding env file. This is usually done by
 running one of the following (note the leading DOT):
-. "{}"                            # For sh/bash/zsh/ash/dash/pdksh
+. {:<32}    # For sh/bash/zsh/ash/dash/pdksh
         "#,
-        path_str,
+        format!("\"{path_str}\"")
     );
     #[cfg(windows)]
     eprintln!(
@@ -79,9 +79,9 @@ running one of the following (note the leading DOT):
 
 1. To get started, source the corresponding env file. This can be done by running
 the following:
-"{}"                              # For cmd
+{:<32}    # For cmd
         "#,
-        path_str,
+        format!("\"{path_str}\""),
     );
     eprintln!(
         r#"2. To see the repos you have access to via XetHub S3, run: 

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -83,7 +83,7 @@ running one of the following (note the leading DOT):
 . "{}"                            # For git-bash/Cygwin/PowerShell
 "{}"                              # For cmd
         "#,
-        path_str, path_str, path_str,
+        path_str, path_str,
     );
     eprintln!(
         r#"2. To see the repos you have access to via XetHub S3, run: 

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -78,12 +78,11 @@ source "{}"                       # For fish
     eprintln!(
         r#"1. Profile for the XetHub S3 Service is configured now. Great!
 
-To get started source the corresponding env file. This is usually done by
-running one of the following (note the leading DOT):
-. "{}"                            # For git-bash/Cygwin/PowerShell
+To get started source the corresponding env file. This can be done by running
+the following:
 "{}"                              # For cmd
         "#,
-        path_str, path_str,
+        path_str,
     );
     eprintln!(
         r#"2. To see the repos you have access to via XetHub S3, run: 

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -49,7 +49,7 @@ pub fn s3config_command(config: XetConfig, args: &S3configArgs) -> Result<()> {
             Ok(())
         }
         Err(GitXetRepoError::InvalidOperation(_)) => {
-            print_service_unavailable_message();
+            print_service_unavailable_message(&args.host);
             Ok(())
         }
         Err(e) => Err(e),
@@ -95,10 +95,11 @@ fn print_auth_error_message(host: &str) {
     eprintln!(
         r#"No authentication information found.
 
-Please go to https://xethub.com/user/settings/pat to create a token and 
+Please go to https://{}/user/settings/pat to create a token and 
 run `git xet login -u <user_name> -e <email> -p <PAT>{}` to login. 
 
 After that, re-run this command."#,
+        host,
         if host == "xethub.com" {
             "".to_owned()
         } else {
@@ -107,17 +108,18 @@ After that, re-run this command."#,
     );
 }
 
-fn print_service_unavailable_message() {
+fn print_service_unavailable_message(host: &str) {
     eprintln!(
         r#"A XetHub S3 service is not available for this XetHub deployment.
 
 If you believe this is a mistake, try re-run `git xet login` with your credentials
 to pick up configuration changes. If you lost your personal access token, you can 
-go to https://xethub.com/user/settings/pat to create a new one.
+go to https://{}/user/settings/pat to create a new one.
 
 After that, re-run this command.
 
-If this still happens, contact XetHub support or your administrator."#
+If this still happens, contact XetHub support or your administrator."#,
+        host
     );
 }
 

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -67,18 +67,17 @@ fn print_help_message(s3config_path: &Path) {
     eprintln!(
         r#"Profile for the XetHub S3 Service is configured now. Great!
 
-1. To get started source the corresponding env file. This is usually done by
+1. To get started, source the corresponding env file. This is usually done by
 running one of the following (note the leading DOT):
 . "{}"                            # For sh/bash/zsh/ash/dash/pdksh
-source "{}"                       # For fish
         "#,
-        path_str, path_str,
+        path_str,
     );
     #[cfg(windows)]
     eprintln!(
-        r#"1. Profile for the XetHub S3 Service is configured now. Great!
+        r#"Profile for the XetHub S3 Service is configured now. Great!
 
-To get started source the corresponding env file. This can be done by running
+1. To get started, source the corresponding env file. This can be done by running
 the following:
 "{}"                              # For cmd
         "#,

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -65,26 +65,22 @@ fn print_help_message(s3config_path: &Path) {
     let path_str = s3config_path.to_str().unwrap_or(&default_path_str);
     #[cfg(unix)]
     eprintln!(
-        r#"Profile for the XetHub S3 Service is configured now. Great!
+        r#"XetHub S3 service profile configuration complete.
 
-1. To get started, source the corresponding env file. This is usually done by
-running one of the following (note the leading DOT):
-. {:<32}    # For sh/bash/zsh/ash/dash/pdksh
-        "#,
-        format!("\"{path_str}\"")
+Source the environment file to initialize:
+. "{path_str}"
+        "#
     );
     #[cfg(windows)]
     eprintln!(
-        r#"Profile for the XetHub S3 Service is configured now. Great!
+        r#"XetHub S3 service profile configuration complete.
 
-1. To get started, source the corresponding env file. This can be done by running
-the following:
-{:<32}    # For cmd
-        "#,
-        format!("\"{path_str}\""),
+Source the environment file to initialize (in cmd):
+"{path_str}"
+        "#
     );
     eprintln!(
-        r#"2. To see the repos you have access to via XetHub S3, run: 
+        r#"Confirm success by listing the XetHub repositories you can access:
 aws s3 ls
 "#
     );
@@ -92,32 +88,24 @@ aws s3 ls
 
 fn print_auth_error_message(host: &str) {
     eprintln!(
-        r#"No authentication information found.
+        r#"No XetHub authentication found.
 
-Please go to https://{}/user/settings/pat to create a token and 
-run `git xet login -u <user_name> -e <email> -p <PAT>{}` to login. 
+Create a new personal access token at https://{}/user/settings/pat
+and run the displayed `git xet login` command to authenticate.
 
-After that, re-run this command."#,
-        host,
-        if host == "xethub.com" {
-            "".to_owned()
-        } else {
-            format!(" --host {host}")
-        }
+Re-try your s3config command after logging in."#,
+        host
     );
 }
 
 fn print_service_unavailable_message(host: &str) {
     eprintln!(
-        r#"A XetHub S3 service is not available for this XetHub deployment.
+        r#"No XetHub S3 service was found for this deployment.
 
-If you believe this is a mistake, try re-run `git xet login` with your credentials
-to pick up configuration changes. If you lost your personal access token, you can 
-go to https://{}/user/settings/pat to create a new one.
+If you believe this to be an error, create a new token at https://{}/user/settings/pat
+and run the displayed `git xet login` command to authenticate. Then re-run your original command.
 
-After that, re-run this command.
-
-If this still happens, contact XetHub support or your administrator."#,
+Still getting this error? Reach out to contact@xethub.com or your administrator for support."#,
         host
     );
 }

--- a/rust/gitxetcore/src/command/s3config.rs
+++ b/rust/gitxetcore/src/command/s3config.rs
@@ -1,0 +1,159 @@
+use crate::config::{get_global_config, XetConfig};
+use crate::errors::{GitXetRepoError, Result};
+use anyhow::anyhow;
+use clap::Args;
+use std::path::{Path, PathBuf};
+use xet_config::{Cfg, DEFAULT_XET_HOME};
+
+#[cfg(unix)]
+const S3_CONFIG_FILE_NAME: &str = "s3env";
+#[cfg(windows)]
+const S3_CONFIG_FILE_NAME: &str = "s3env.bat";
+
+#[derive(Args, Debug)]
+pub struct S3configArgs {
+    /// The domain for Xet S3 service
+    #[clap(long, default_value = "xethub.com")]
+    pub host: String,
+}
+
+pub fn s3config_command(config: XetConfig, args: &S3configArgs) -> Result<()> {
+    // login always write auth info into the global config.
+    let global_config = get_global_config()?;
+    let cfg = Cfg::from_file(&global_config).unwrap_or_default();
+
+    let mut config_ret = Err(GitXetRepoError::AuthError(anyhow!("No match profile")));
+
+    if args.host.is_empty() || args.host == "xethub.com" {
+        // this goes into the root profile
+        config_ret = write_xs3_config(&config, &cfg);
+    } else {
+        // search in the sub-profiles
+        for (_, v) in &cfg.profiles {
+            if let Some(e) = &v.endpoint {
+                if e == &args.host {
+                    config_ret = write_xs3_config(&config, v);
+                    break;
+                }
+            }
+        }
+    }
+
+    match config_ret {
+        Ok(path) => Ok(print_help_message(&path)),
+        Err(GitXetRepoError::AuthError(_)) => Ok(print_auth_error_message(&args.host)),
+        Err(GitXetRepoError::InvalidOperation(_)) => Ok(print_service_unavailable_message()),
+        Err(e) => Err(e),
+    }
+}
+
+fn print_help_message(s3config_path: &Path) {
+    #[cfg(unix)]
+    let default_path_str = format!("$HOME/{DEFAULT_XET_HOME}/{S3_CONFIG_FILE_NAME}");
+    #[cfg(windows)]
+    let default_path_str =
+        format!("%HOMEDRIVE%%HOMEPATH%\\{DEFAULT_XET_HOME}\\{S3_CONFIG_FILE_NAME}");
+    let path_str = s3config_path.to_str().unwrap_or(&default_path_str);
+    #[cfg(unix)]
+    eprintln!(
+        r#"Profile for the XetHub S3 Service is configured now. Great!
+
+1. To get started source the corresponding env file. This is usually done by
+running one of the following (note the leading DOT):
+. "{}"                            # For sh/bash/zsh/ash/dash/pdksh
+source "{}"                       # For fish
+        "#,
+        path_str, path_str,
+    );
+    #[cfg(windows)]
+    eprintln!(
+        r#"1. Profile for the XetHub S3 Service is configured now. Great!
+
+To get started source the corresponding env file. This is usually done by
+running one of the following (note the leading DOT):
+. "{}"                            # For git-bash/Cygwin/PowerShell
+"{}"                              # For cmd
+        "#,
+        path_str, path_str, path_str,
+    );
+    eprintln!(
+        r#"2. To see the repos you have access to via XetHub S3, run: 
+aws s3 ls
+"#
+    );
+}
+
+fn print_auth_error_message(host: &str) {
+    eprintln!(
+        r#"No authentication information found.
+
+Please go to https://xethub.com/user/settings/pat to create a token and 
+run `git xet login -u <user_name> -e <email> -p <PAT>{}` to login. 
+
+After that, re-run this command."#,
+        if host == "xethub.com" {
+            "".to_owned()
+        } else {
+            format!(" --host {host}")
+        }
+    );
+}
+
+fn print_service_unavailable_message() {
+    eprintln!(
+        r#"A XetHub S3 service is not available for this XetHub deployment.
+
+If you believe this is a mistake, try re-run `git xet login` with your credentials
+to pick up configuration changes. If you lost your personal access token, you can 
+go to https://xethub.com/user/settings/pat to create a new one.
+
+After that, re-run this command.
+
+If this still happens, contact XetHub support or your administrator."#
+    );
+}
+
+fn write_xs3_config(xet_config: &XetConfig, cfg: &Cfg) -> Result<PathBuf> {
+    let no_login_info_err = || GitXetRepoError::AuthError(anyhow!("Not authenticated"));
+    let service_unavailable_err =
+        || GitXetRepoError::InvalidOperation("XS3 service not available".to_owned());
+
+    let user = cfg.user.as_ref().ok_or_else(no_login_info_err)?;
+    let aws_access_key = user.aws_access_key.as_ref().ok_or_else(no_login_info_err)?;
+    let aws_secret_key = user.aws_secret_key.as_ref().ok_or_else(no_login_info_err)?;
+    let xs3 = cfg.xs3.as_ref().ok_or_else(service_unavailable_err)?;
+    let xs3_server = xs3.server.as_ref().ok_or_else(service_unavailable_err)?;
+
+    write_xs3_config_script_file(xet_config, (aws_access_key, aws_secret_key), &xs3_server)
+}
+
+fn write_xs3_config_script_file(
+    xet_config: &XetConfig,
+    (aws_access_key, aws_secret_key): (&str, &str),
+    host: &str,
+) -> Result<PathBuf> {
+    #[cfg(unix)]
+    let script = format!(
+        r#"export AWS_ACCESS_KEY_ID={}
+export AWS_SECRET_ACCESS_KEY={}
+export AWS_ENDPOINT_URL={}
+        "#,
+        aws_access_key, aws_secret_key, host
+    );
+    #[cfg(windows)]
+    let script = format!(
+        r#"set AWS_ACCESS_KEY_ID={}
+set AWS_SECRET_ACCESS_KEY={}
+set AWS_ENDPOINT_URL={}
+        "#,
+        aws_access_key, aws_secret_key, host
+    );
+
+    let config_file = xet_config.xet_home.join(S3_CONFIG_FILE_NAME);
+
+    xet_config.permission.create_file(&config_file)?;
+
+    std::fs::write(&config_file, &script)?;
+
+    Ok(config_file)
+}

--- a/rust/gitxetcore/src/config/authentication.rs
+++ b/rust/gitxetcore/src/config/authentication.rs
@@ -30,6 +30,8 @@ pub struct XeteaLoginProbe {
     pub login_id: Option<String>,
     /// storage endpoint
     pub cas: Option<String>,
+    /// s3 service endpoint
+    pub xs3: Option<String>,
     /// monitoring endpoint
     pub axe_key: Option<String>,
     /// AWS Access Key

--- a/rust/xet_config/src/cfg.rs
+++ b/rust/xet_config/src/cfg.rs
@@ -53,6 +53,7 @@ pub struct Cfg {
     pub endpoint: Option<String>,
     pub smudge: Option<bool>,
     pub cas: Option<Cas>,
+    pub xs3: Option<Xs3>,
     pub cache: Option<Cache>,
     pub log: Option<Log>,
     pub user: Option<User>,
@@ -130,6 +131,7 @@ impl Cfg {
                 prefix: None,
                 sizethreshold: None,
             }),
+            xs3: None,
             cache: Some(Cache {
                 path: Some(default_cache_path),
                 size: Some(DEFAULT_CACHE_SIZE),
@@ -218,6 +220,7 @@ impl Default for Cfg {
             endpoint: None,
             smudge: None,
             cas: None,
+            xs3: None,
             cache: None,
             log: None,
             user: None,
@@ -248,6 +251,13 @@ pub struct Cas {
     /// Setting this to 0 will cause all files to be treated as pointer files.
     /// The threshold has to be <= SMALL_FILE_THRESHOLD
     pub sizethreshold: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+#[serde(default)]
+pub struct Xs3 {
+    /// address to the xs3 server.
+    pub server: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
@@ -305,7 +315,7 @@ pub struct Axe {
 
 #[cfg(test)]
 mod serialization_tests {
-    use crate::cfg::{Axe, Cache, Cas, Cfg, Log, User, CURRENT_VERSION};
+    use crate::cfg::{Axe, Cache, Cas, Cfg, Log, User, Xs3, CURRENT_VERSION};
     use std::collections::HashMap;
 
     #[test]
@@ -351,6 +361,9 @@ mod serialization_tests {
                 prefix: Some("test_prefix".to_string()),
                 sizethreshold: Some(1234),
             }),
+            xs3: Some(Xs3 {
+                server: Some("localhost:5003".to_string()),
+            }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),
                 size: Some(2000),
@@ -389,6 +402,9 @@ server = "localhost:40000"
 prefix = "test_prefix"
 sizethreshold = 1234
 
+[xs3]
+server = "localhost:5003"
+
 [cache]
 path = "/tmp/xet.log"
 size = 2000
@@ -421,6 +437,7 @@ axe_code = "5454"
             endpoint: None,
             smudge: Some(false),
             cas: None,
+            xs3: None,
             cache: None,
             log: None,
             user: Some(User {
@@ -468,6 +485,7 @@ token = "abc123"
             endpoint: None,
             smudge: Some(false),
             cas: None,
+            xs3: None,
             cache: None,
             log: None,
             user: Some(User {
@@ -519,6 +537,9 @@ token = "abc123"
                 prefix: Some("test_prefix2".to_string()),
                 sizethreshold: Some(5723),
             }),
+            xs3: Some(Xs3 {
+                server: Some("localhost:5002".to_string()),
+            }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),
                 size: Some(4356),
@@ -555,6 +576,9 @@ smudge = true
 server = "localhost:40000"
 prefix = "test_prefix2"
 sizethreshold = 5723
+
+[xs3]
+server = "localhost:5002"
 
 [cache]
 path = "/tmp/xet.log"
@@ -617,6 +641,9 @@ pth = "localhost"
                 prefix: Some("test_prefix2".to_string()),
                 sizethreshold: None,
             }),
+            xs3: Some(Xs3 {
+                server: Some("localhost:5003".to_string()),
+            }),
             cache: Some(Cache {
                 path: Some("/tmp/xet.log".into()),
                 size: Some(4356),
@@ -652,6 +679,7 @@ pth = "localhost"
             endpoint: Some("xethub.com".to_string()),
             smudge: None,
             cas: None,
+            xs3: None,
             cache: None,
             log: Some(Log {
                 path: Some("/tmp/cache2".into()),
@@ -686,6 +714,9 @@ smudge = true
 [cas]
 server = "localhost:40000"
 prefix = "test_prefix2"
+
+[xs3]
+server = "localhost:5003"
 
 [cache]
 path = "/tmp/xet.log"

--- a/rust/xet_config/src/lib.rs
+++ b/rust/xet_config/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 mod level;
 mod loader;
 
-pub use cfg::{Axe, Cache, Cas, Cfg, Log, User};
+pub use cfg::{Axe, Cache, Cas, Cfg, Log, User, Xs3};
 pub use cfg::{
     DEFAULT_CACHE_PATH_UNDER_HOME, DEFAULT_CAS_PREFIX, DEFAULT_XET_HOME, PROD_AXE_CODE,
     PROD_CAS_ENDPOINT,

--- a/rust/xet_config/src/loader.rs
+++ b/rust/xet_config/src/loader.rs
@@ -261,6 +261,7 @@ mod tests {
                 prefix: Some("test".to_string()),
                 ..Default::default()
             }),
+            xs3: None,
             cache: Some(Cache {
                 path: Default::default(),
                 size: Some(4_294_967_296),


### PR DESCRIPTION
Fix CLI-164.

Run `git xet s3config [--host ..]` to pick up login information from ~/.xetconfig to create a env file for AWS CLI. Users will source this env file to pick up `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_ENDPOINT_URL`. After that users can directly run `aws s3 ...` to operate with XS3.

- **If no access_key or secret_key found in the .xetconfig corresponding profile, print**

```
No XetHub authentication found.

Create a new personal access token at https://xethub.com/user/settings/pat
and run the displayed `git xet login` command to authenticate.

Re-try your s3config command after logging in.
```

- **If no xs3 server address found in the .xetconfig corresponding profile ( this can happen if either**
          **1. XS3 service is not available for this XetHub deployment;**
          **2. People who logged in previously but didn't have the xs3 server endpoint returned from Xetea and stored in the .xetconfig),** 
**print**

```
No XetHub S3 service was found for this deployment.

If you believe this to be an error, create a new token at https://xethub.com/user/settings/pat
and run the displayed `git xet login` command to authenticate. Then re-run your original command.

Still getting this error? Reach out to contact@xethub.com or your administrator for support.
```

- **If everything finishes correctly, print**

```
XetHub S3 service profile configuration complete.

Source the environment file to initialize:
. "/Users/di/.xet/s3env"

Confirm success by listing the XetHub repositories you can access:
aws s3 ls
```

Depends on https://github.com/xetdata/xethub/pull/5875