### PR TITLE
Remove automatic git path discovery when not in git repository.

### DIFF
--- a/rust/gitxetcore/src/config/git_path.rs
+++ b/rust/gitxetcore/src/config/git_path.rs
@@ -42,7 +42,7 @@ impl ConfigGitPathOption {
         })?;
 
         let remote_urls = if let Some(ref p) = maybe_git_path {
-            GitXetRepo::get_remote_urls(Some(p)).unwrap_or_else(|_| vec![])
+            GitXetRepo::get_remote_urls(p).unwrap_or_else(|_| vec![])
         } else {
             vec![]
         };

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -197,9 +197,12 @@ impl XetConfig {
     }
 
     /// Get the remote urls for the associated repo if present.
-    pub fn remote_repo_paths(&self) -> Vec<String> {
-        let maybe_path = self.repo_path_if_present.as_deref();
-        GitXetRepo::get_remote_urls(maybe_path).unwrap_or_else(|_| vec!["".to_string()])
+    pub fn known_remote_repo_paths(&self) -> Vec<String> {
+        let Some(repo_path) = self.repo_path_if_present.as_ref() else {
+            return vec!["".to_string()];
+        };
+
+        GitXetRepo::get_remote_urls(repo_path).unwrap_or_else(|_| vec!["".to_string()])
     }
 
     /// Builds an authenticated URL from a URL by injecting in

--- a/rust/gitxetcore/src/data/cas_interface.rs
+++ b/rust/gitxetcore/src/data/cas_interface.rs
@@ -2,7 +2,6 @@ use crate::config::XetConfig;
 use crate::constants::{GIT_XET_VERSION, LOCAL_CAS_SCHEME, MAX_CONCURRENT_DOWNLOADS};
 pub use crate::data::{FILTER_BYTES_CLEANED, FILTER_BYTES_SMUDGED, FILTER_CAS_BYTES_PRODUCED};
 use crate::errors::{GitXetRepoError, Result};
-use crate::git_integration::GitXetRepo;
 use cas_client::{
     new_staging_client, new_staging_client_with_progressbar, CachingClient, LocalClient,
     RemoteClient, Staging,
@@ -25,8 +24,7 @@ pub async fn create_cas_client(config: &XetConfig) -> Result<Arc<dyn Staging + S
     let endpoint = &config.cas.endpoint;
     let (user_id, _) = &config.user.get_user_id();
     let auth = &config.user.get_login_id();
-    let repo_paths = GitXetRepo::get_remote_urls(config.repo_path().ok().map(|x| x.as_path()))
-        .unwrap_or_else(|_| vec!["".to_string()]);
+    let repo_paths = config.known_remote_repo_paths();
 
     if let Some(fs_path) = endpoint.strip_prefix(LOCAL_CAS_SCHEME) {
         info!("Using local CAS with path: {:?}.", endpoint);

--- a/rust/gitxetcore/src/data/mdb.rs
+++ b/rust/gitxetcore/src/data/mdb.rs
@@ -273,13 +273,10 @@ fn sync_mdb_shards_meta_from_git(
     let mut shard_metas = MDBShardMetaCollection::default();
 
     // Walk the ref notes tree and deserialize all into a collection.
-    let repo = GitNotesWrapper::open(get_repo_path_from_config(config)?, config, notesref)
-        .map_err(|e| {
-            format!(
-                "sync_mdb_shards_meta_from_git: Unable to access git notes at {notesref:?}: {e:?}"
-            );
-            e
-        })?;
+    let repo = GitNotesWrapper::open(config.repo_path()?, config, notesref).map_err(|e| {
+        format!("sync_mdb_shards_meta_from_git: Unable to access git notes at {notesref:?}: {e:?}");
+        e
+    })?;
 
     for oid in repo
         .notes_name_iterator()
@@ -744,13 +741,10 @@ pub fn update_mdb_shards_to_git_notes(
     session_dir: &Path,
     notesref: &str,
 ) -> errors::Result<()> {
-    let repo = GitNotesWrapper::open(get_repo_path_from_config(config)?, config, notesref)
-        .map_err(|e| {
-            error!(
-                "update_mdb_shards_to_git_notes: Unable to access git notes at {notesref:?}: {e:?}"
-            );
-            e
-        })?;
+    let repo = GitNotesWrapper::open(config.repo_path()?, config, notesref).map_err(|e| {
+        error!("update_mdb_shards_to_git_notes: Unable to access git notes at {notesref:?}: {e:?}");
+        e
+    })?;
 
     if let Some(shard_note_data) = create_new_mdb_shard_note(session_dir)? {
         repo.add_note(shard_note_data).map_err(|e| {
@@ -809,7 +803,7 @@ pub fn get_mdb_version(repo_path: &Path, config: &XetConfig) -> errors::Result<S
         return Ok(ShardVersion::get_max());
     }
 
-    let Ok(repo) = open_libgit2_repo(Some(repo_path)).map_err(|e| {
+    let Ok(repo) = open_libgit2_repo(repo_path).map_err(|e| {
         info!("get_mdb_version: Repo path {repo_path:?} does note appear to be a repository ({e}); defaulting to ShardVersion::V2.");
         e
     }) else {

--- a/rust/gitxetcore/src/environment/axe.rs
+++ b/rust/gitxetcore/src/environment/axe.rs
@@ -1,6 +1,5 @@
 use crate::config::UserIdType;
 use crate::config::XetConfig;
-use crate::git_integration::GitXetRepo;
 use chrono::{NaiveDateTime, Utc};
 use prometheus_dict_encoder::DictEncoder;
 use reqwest::Client;
@@ -61,11 +60,7 @@ impl Axe {
                     .insert(k.to_string(), Value::String(v.to_string()));
             }
         }
-        for (i, xetea_url) in GitXetRepo::get_remote_urls(None)
-            .unwrap_or_else(|_| vec!["".to_string()])
-            .iter()
-            .enumerate()
-        {
+        for (i, xetea_url) in cfg.known_remote_repo_paths().iter().enumerate() {
             upload_body.properties.insert(
                 if i == 0 {
                     // common case
@@ -125,7 +120,7 @@ impl Axe {
         upload_body.properties.insert(
             "repo_paths".to_string(),
             Value::String(
-                serde_json::to_string(&cfg.remote_repo_paths())
+                serde_json::to_string(&cfg.known_remote_repo_paths())
                     .unwrap_or_else(|_| "[]".to_string()),
             ),
         );

--- a/rust/gitxetcore/src/git_integration/git_notes_wrapper.rs
+++ b/rust/gitxetcore/src/git_integration/git_notes_wrapper.rs
@@ -72,7 +72,7 @@ impl GitNotesWrapper {
         config: &XetConfig,
         notes_ref: &str,
     ) -> Result<GitNotesWrapper, git2::Error> {
-        let repo = open_libgit2_repo(Some(path.as_ref()))?;
+        let repo = open_libgit2_repo(path.as_ref())?;
         Self::from_repo(repo, config, notes_ref)
     }
 
@@ -84,7 +84,7 @@ impl GitNotesWrapper {
         Ok(GitNotesWrapper {
             repo: repo.clone(),
             notes_ref: notes_ref.into(),
-            write_signature: get_repo_signature(Some(config), None, Some(repo.clone())),
+            write_signature: get_repo_signature(Some(config), repo.clone()),
         })
     }
 

--- a/rust/gitxetcore/src/git_integration/git_repo_paths.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo_paths.rs
@@ -1,4 +1,3 @@
-use crate::config::XetConfig;
 use crate::errors::Result;
 use crate::git_integration::git_process_wrapping::run_git_captured;
 use std::path::PathBuf;
@@ -104,12 +103,4 @@ pub fn get_git_dir_from_repo_path(repo_path: &PathBuf) -> Result<PathBuf> {
     } else {
         repo_path.join(git_path)
     })
-}
-
-/// Obtains the repository path either from config or current directory
-pub fn get_repo_path_from_config(config: &XetConfig) -> Result<PathBuf> {
-    match config.repo_path() {
-        Ok(path) => Ok(path.clone()),
-        Err(_) => Ok(std::env::current_dir()?),
-    }
 }

--- a/rust/gitxetcore/src/git_integration/git_repo_salt.rs
+++ b/rust/gitxetcore/src/git_integration/git_repo_salt.rs
@@ -35,7 +35,7 @@ pub fn repo_salt_from_bytes(bytes: &[u8]) -> Result<RepoSalt> {
 }
 
 pub fn read_repo_salt_by_dir(git_dir: &Path, config: &XetConfig) -> Result<Option<RepoSalt>> {
-    let Ok(repo) = open_libgit2_repo(Some(git_dir)).map_err(|e| {
+    let Ok(repo) = open_libgit2_repo(git_dir).map_err(|e| {
         info!("Error opening {git_dir:?} as git repository; error = {e:?}.");
         e
     }) else {

--- a/rust/gitxetcore/src/git_integration/git_user_config.rs
+++ b/rust/gitxetcore/src/git_integration/git_user_config.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use git2::Repository;
 use tracing::info;
@@ -8,16 +8,12 @@ use crate::{
     constants::{XET_BACKUP_COMMIT_EMAIL, XET_BACKUP_COMMIT_NAME},
 };
 
-use super::open_libgit2_repo;
-
 // Returns the user name and email from available sources
 pub fn get_user_info_for_commit(
     config: Option<&XetConfig>,
-    path: Option<&Path>,
-    repo: Option<Arc<Repository>>,
+    repo: Arc<Repository>,
 ) -> (String, String) {
-    let repo = repo.or_else(|| open_libgit2_repo(path).ok());
-    let git_config = repo.and_then(|r| r.config().ok());
+    let git_config = repo.config().ok();
 
     let user_name = git_config
         .as_ref()
@@ -35,10 +31,9 @@ pub fn get_user_info_for_commit(
 
 pub fn get_repo_signature(
     config: Option<&XetConfig>,
-    path: Option<&Path>,
-    repo: Option<Arc<Repository>>,
+    repo: Arc<Repository>,
 ) -> git2::Signature<'static> {
-    let (name, email) = get_user_info_for_commit(config, path, repo);
+    let (name, email) = get_user_info_for_commit(config, repo);
 
     // Unwrap here only
     git2::Signature::now(&name, &email)

--- a/rust/gitxetcore/src/utils.rs
+++ b/rust/gitxetcore/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::config::XetConfig;
 use crate::errors::{self, GitXetRepoError};
-use crate::git_integration::{get_repo_path_from_config, open_libgit2_repo, GitNotesWrapper};
+use crate::git_integration::{open_libgit2_repo, GitNotesWrapper};
 
 use git2::Oid;
 use merklehash::{DataHashHexParseError, MerkleHash};
@@ -11,7 +11,7 @@ use tracing::error;
 
 /// Find the Oid a ref note references to.
 pub fn ref_to_oid(config: &XetConfig, notesref: &str) -> errors::Result<Option<Oid>> {
-    let repo = open_libgit2_repo(Some(&get_repo_path_from_config(config)?))?;
+    let repo = open_libgit2_repo(config.repo_path()?)?;
     let oid = repo.refname_to_id(notesref);
 
     match oid {

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -224,7 +224,7 @@ impl XetRepo {
         let remote = if let Some(repo_info) = repo_info.as_ref() {
             repo_info.repo.html_url.clone()
         } else {
-            let remotes = config.remote_repo_paths();
+            let remotes = config.known_remote_repo_paths();
             if remotes.is_empty() {
                 return Err(anyhow!("No remote defined"));
             }


### PR DESCRIPTION
Removes paths that automatically discover git remotes and config information from the current directory when config is not provided.  

Now, the repo path is set in XetConfig at the start, possibly from the current directory, but parts of the code that previously just defaulted to automatic discovery have been reworked. 