### PR TITLE
Hide git checkout command.

### DIFF
--- a/rust/gitxetcore/src/command/mod.rs
+++ b/rust/gitxetcore/src/command/mod.rs
@@ -72,7 +72,8 @@ mod visualization_dependencies;
 #[derive(Subcommand, Debug)]
 #[non_exhaustive]
 pub enum Command {
-    /// Hydrates all Xet objects converting Xet Pointer files to real files
+    /// Hydrates, Xet objects converting Xet Pointer files to real files
+    #[clap(hide(true))]
     Checkout(CheckoutArgs),
 
     /// Run the filter process.


### PR DESCRIPTION
Hides the slightly broken, poorly documented, and not really used `git xet checkout` command