### PR TITLE
Resolve column names in titles

### DIFF
--- a/rust/tableau_summary/src/twb/summary/dashboard.rs
+++ b/rust/tableau_summary/src/twb/summary/dashboard.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use crate::twb::raw::dashboard::RawDashboard;
 use crate::twb::raw;
+use crate::twb::raw::datasource::substituter;
 use crate::twb::raw::worksheet::table::View;
 use crate::twb::summary::worksheet::get_name_discrete;
 
@@ -26,9 +27,11 @@ pub struct Zone {
 impl From<&RawDashboard> for Dashboard {
     fn from(dashboard: &RawDashboard) -> Self {
         let (sheets, zones) = build_zones(dashboard);
+        let view = &dashboard.view;
+        let (maybe_title, _) = substituter::substitute_columns(view, &dashboard.title);
         Self {
             name: dashboard.name.clone(),
-            title: dashboard.title.clone(),
+            title: maybe_title.unwrap_or_else(|| dashboard.title.clone()),
             thumbnail: dashboard.thumbnail.clone(),
             sheets,
             zones,

--- a/rust/tableau_summary/src/twb/summary/worksheet.rs
+++ b/rust/tableau_summary/src/twb/summary/worksheet.rs
@@ -15,9 +15,11 @@ pub struct Worksheet {
 
 impl From<&RawWorksheet> for Worksheet {
     fn from(raw_wks: &RawWorksheet) -> Self {
+        let view = &raw_wks.table.view;
+        let (maybe_title, _) = substituter::substitute_columns(view, &raw_wks.title);
         Self {
             name: raw_wks.name.clone(),
-            title: raw_wks.title.clone(),
+            title: maybe_title.unwrap_or_else(||raw_wks.title.clone()),
             thumbnail: raw_wks.thumbnail.clone(),
             table: table_from_worksheet(raw_wks),
         }


### PR DESCRIPTION
Fixes: TAB-77

* Titles in Twb worksheets and dashboards that reference a Column/ColumnInstance will be properly templated to their correct column name: