### PR TITLE
Allow templates to use table aggregation column

### DIFF
--- a/rust/tableau_summary/src/twb/raw/datasource/columns.rs
+++ b/rust/tableau_summary/src/twb/raw/datasource/columns.rs
@@ -202,15 +202,8 @@ pub struct TableType {
 impl<'a, 'b> From<Node<'a, 'b>> for TableType {
     fn from(n: Node) -> Self {
         check_tag_or_default!(n, TABLEAU_TABLE_TYPE_TAG);
-        let name = n.get_attr(NAME_KEY);
-        let ids = parse_identifiers(&name);
-        let name = if ids.len() != 2 {
-            name
-        } else {
-            ids[1].clone()
-        };
         Self {
-            name,
+            name: n.get_attr(NAME_KEY),
             caption: n.get_attr(CAPTION_KEY),
         }
     }

--- a/rust/tableau_summary/src/twb/raw/worksheet/table.rs
+++ b/rust/tableau_summary/src/twb/raw/worksheet/table.rs
@@ -118,7 +118,7 @@ impl View {
             ColumnDep::Column(c) => get_captioned(c.caption.as_str(), c.name.as_str()),
             ColumnDep::ColumnInstance(ci) => Cow::from(self.column_instance_caption(ci)),
             ColumnDep::Group(g) => get_captioned(g.caption.as_str(), g.name.as_str()),
-            ColumnDep::Table(_) => Cow::from("")
+            ColumnDep::Table(t) => get_captioned(t.caption.as_str(), t.name.as_str()),
         }
     }
 


### PR DESCRIPTION
Fixes: TAB-78

* Allows table aggregations to be correctly resolved in template strings by using the correct key name in the column map and using the caption when summarizing.

For example:
```
COUNT([pcto:cnt:Orders_6D2EF74F348B46BDA976A7AEEA6FB5C9:qk:1])
```
becomes:
```
COUNT(Orders)
```