### PR TITLE
Update gitxet/Cargo.toml version string

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "cas_client"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "chunkpipe"
-version = "0.1.0"
+version = "0.13.4"
 
 [[package]]
 name = "clap"
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "common_constants"
-version = "0.13.3"
+version = "0.13.4"
 
 [[package]]
 name = "compare"
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "data_analysis"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "approx",
  "cxx",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "error_printer"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "tracing",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "gitxet"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "gitxetcore"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "lazy"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "libmagic"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "phf",
@@ -2049,7 +2049,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mdb_shard"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2079,7 +2079,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "merkledb"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "merklehash"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "parutils"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "progress_reporting"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "atty",
  "crossterm",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus_dict_encoder"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "memchr",
  "prometheus",
@@ -3166,7 +3166,7 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry_strategy"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "tokio-retry",
 ]
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "shard_client"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "tableau_summary"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "error_printer",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "xet_config"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "config",
  "dirs 4.0.0",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "xet_error"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "lazy_static",
  "xet-error-impl",

--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "libxet"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "gitxetcore",
 ]

--- a/gitxet/Cargo.toml
+++ b/gitxet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitxet"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 resolver = "2"
 

--- a/libxet/Cargo.toml
+++ b/libxet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxet"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
The executable in gitxet/ did not get the version string properly updated.  This PR fixes this.  