### PR TITLE
Run cargo fmt

### DIFF
--- a/rust/chunkpipe/src/lib.rs
+++ b/rust/chunkpipe/src/lib.rs
@@ -36,7 +36,9 @@ pub struct PipeWrite {
 impl Write for PipeWrite {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let size = buf.len();
-        self.send.send(buf.to_vec()).map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))?;
+        self.send
+            .send(buf.to_vec())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))?;
         Ok(size)
     }
 
@@ -46,21 +48,19 @@ impl Write for PipeWrite {
 }
 
 pub fn pipe() -> (PipeWrite, PipeRead) {
-    let (send, recv)= channel();
+    let (send, recv) = channel();
     let read = PipeRead {
         recv,
         buf: Vec::new(),
     };
-    let write = PipeWrite {
-        send,
-    };
+    let write = PipeWrite { send };
     (write, read)
 }
 
 #[cfg(test)]
 mod test {
-    use std::io::{Read, Write};
     use crate::pipe;
+    use std::io::{Read, Write};
 
     #[test]
     fn test_pipe() {
@@ -81,8 +81,8 @@ mod test {
         let (mut w, mut r) = pipe();
 
         let handle = std::thread::spawn(move || {
-        w.write_all("abcdefghijklmnop".as_bytes()).unwrap();
-        w.write_all("qrstuvwxyz".as_bytes()).unwrap();
+            w.write_all("abcdefghijklmnop".as_bytes()).unwrap();
+            w.write_all("qrstuvwxyz".as_bytes()).unwrap();
         });
         let mut buf = Vec::with_capacity("abcdefghijklmnopqrstuvwxyz".len());
         let s = r.read_to_end(&mut buf).unwrap();
@@ -92,8 +92,4 @@ mod test {
         assert_eq!(s, "abcdefghijklmnopqrstuvwxyz".len());
         assert_eq!(buf.as_slice(), "abcdefghijklmnopqrstuvwxyz".as_bytes());
     }
-
 }
-
-
-

--- a/rust/gitxetcore/src/command/diff.rs
+++ b/rust/gitxetcore/src/command/diff.rs
@@ -146,26 +146,30 @@ fn run_diffs(
 
     // csv diff
     let csv_proc = CsvSummaryDiffProcessor {};
-    _ = csv_proc.get_diff(before_summary, after_summary)
+    _ = csv_proc
+        .get_diff(before_summary, after_summary)
         .map(|diff| diffs.push(diff))
         .map_err(|e| errs.push(e));
 
     // twb diff
     let twb_proc = TwbSummaryDiffProcessor {};
-    _ = twb_proc.get_diff(before_summary, after_summary)
+    _ = twb_proc
+        .get_diff(before_summary, after_summary)
         .map(|diff| diffs.push(diff))
         .map_err(|e| errs.push(e));
 
     // tds diff
     let tds_proc = TdsSummaryDiffProcessor {};
-    _ = tds_proc.get_diff(before_summary, after_summary)
+    _ = tds_proc
+        .get_diff(before_summary, after_summary)
         .map(|diff| diffs.push(diff))
         .map_err(|e| errs.push(e));
 
     if !diffs.is_empty() {
         Ok(diffs)
     } else {
-        Err(errs.into_iter()
+        Err(errs
+            .into_iter()
             .find(|e| !matches!(e, DiffError::NoSummaries)) // find the first error that isn't NoSummaries
             .unwrap_or(DiffError::NoSummaries))
     }

--- a/rust/gitxetcore/src/command/summary.rs
+++ b/rust/gitxetcore/src/command/summary.rs
@@ -1,8 +1,8 @@
+use std::io::stdin;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use std::io::stdin;
 
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -16,19 +16,19 @@ use tableau_summary::tds::TdsSummary;
 use tableau_summary::twb::printer::{print_twb_summary, print_twb_summary_from_reader};
 use tableau_summary::twb::TwbSummary;
 
+use crate::data::{PointerFile, PointerFileTranslator};
+use crate::summaries::csv::CsvDelimiter;
 use crate::{config::XetConfig, errors::GitXetRepoError, utils};
 use crate::{
     constants::{GIT_NOTES_SUMMARIES_REF_NAME, POINTER_FILE_LIMIT},
     errors,
     git_integration::GitXetRepo,
-    summaries::{summaries_dump, summaries_list_git, summaries_query, WholeRepoSummary},
     summaries::csv::print_csv_summary,
     summaries::csv::print_csv_summary_from_reader,
     summaries::libmagic::print_libmagic_summary,
     summaries::summary_type::SummaryType,
+    summaries::{summaries_dump, summaries_list_git, summaries_query, WholeRepoSummary},
 };
-use crate::data::{PointerFile, PointerFileTranslator};
-use crate::summaries::csv::CsvDelimiter;
 
 #[derive(Args, Debug)]
 pub struct SummaryArgs {
@@ -98,8 +98,8 @@ pub enum SummarySubCommand {
 }
 
 fn print_stored_summary_impl<T: Serialize>(t: &Option<T>) -> errors::Result<()>
-    where
-        T: Default,
+where
+    T: Default,
 {
     match t {
         Some(item) => {
@@ -126,13 +126,12 @@ async fn print_summary_from_db(
         &config.summarydb,
         GIT_NOTES_SUMMARIES_REF_NAME,
     )
-        .await?;
+    .await?;
     let summary = summarydb.get(pointer_file.hash_string()).ok_or_else(|| {
-        GitXetRepoError::SummaryDBNotFoundError(
-            format!(
-                "could not find summary for pointer file with hash {}",
-                pointer_file.hash_string()
-            ))
+        GitXetRepoError::SummaryDBNotFoundError(format!(
+            "could not find summary for pointer file with hash {}",
+            pointer_file.hash_string()
+        ))
     })?;
     match summary_type {
         SummaryType::Libmagic => print_stored_summary_impl(&summary.libmagic),
@@ -172,13 +171,12 @@ async fn print_summary(
     }
     // fall through. Non-pointer.
     match summary_type {
-        SummaryType::Libmagic => print_libmagic_summary(file_path)
-            .map_err(|e| GitXetRepoError::Other(e.to_string())),
+        SummaryType::Libmagic => {
+            print_libmagic_summary(file_path).map_err(|e| GitXetRepoError::Other(e.to_string()))
+        }
         SummaryType::Csv => print_csv_summary(file_path),
-        SummaryType::Twb => print_twb_summary(file_path)
-            .map_err(GitXetRepoError::from),
-        SummaryType::Tds => print_tds_summary(file_path)
-            .map_err(GitXetRepoError::from),
+        SummaryType::Twb => print_twb_summary(file_path).map_err(GitXetRepoError::from),
+        SummaryType::Tds => print_tds_summary(file_path).map_err(GitXetRepoError::from),
     }
 }
 
@@ -201,12 +199,24 @@ async fn print_summary_from_blobid(
         let pointer_file = PointerFile::init_from_string(content_str, "");
         if pointer_file.is_valid() {
             if force_compute {
-                return print_summary_from_hash(config, summary_type, pointer_file.hash_string(), csv_delimiter).await;
+                return print_summary_from_hash(
+                    config,
+                    summary_type,
+                    pointer_file.hash_string(),
+                    csv_delimiter,
+                )
+                .await;
             }
             let res = print_summary_from_db(config, &pointer_file, summary_type).await;
             if let Err(GitXetRepoError::SummaryDBNotFoundError(_)) = res {
                 // not in summary db, expected that we have to recompute
-                return print_summary_from_hash(config, summary_type, pointer_file.hash_string(), csv_delimiter).await;
+                return print_summary_from_hash(
+                    config,
+                    summary_type,
+                    pointer_file.hash_string(),
+                    csv_delimiter,
+                )
+                .await;
             }
             return res;
         }
@@ -230,34 +240,41 @@ async fn print_summary_from_hash(
 
     let (mut w, mut r) = pipe();
 
-    let smudge_handle = tokio::spawn(async move {
-        pft.smudge_file_from_hash(None, &hash, &mut w, None).await
-    });
+    let smudge_handle =
+        tokio::spawn(async move { pft.smudge_file_from_hash(None, &hash, &mut w, None).await });
 
-    let res = print_summary_from_reader(&mut r, summary_type, csv_delimiter).log_error("error summarizing: ");
-    let (smudge_res, ) = tokio::join!(smudge_handle);
+    let res = print_summary_from_reader(&mut r, summary_type, csv_delimiter)
+        .log_error("error summarizing: ");
+    let (smudge_res,) = tokio::join!(smudge_handle);
     smudge_res?.log_error("error from smudging?: ")?;
     res
 }
 
-async fn print_summary_from_stdin(_xet_config: &XetConfig, summary_type: &SummaryType, csv_delimiter: Option<CsvDelimiter>) -> errors::Result<()> {
+async fn print_summary_from_stdin(
+    _xet_config: &XetConfig,
+    summary_type: &SummaryType,
+    csv_delimiter: Option<CsvDelimiter>,
+) -> errors::Result<()> {
     let mut r = stdin();
     print_summary_from_reader(&mut r, summary_type, csv_delimiter)
 }
 
-fn print_summary_from_reader<T: std::io::Read>(reader: &mut T, summary_type: &SummaryType, csv_delimiter: Option<CsvDelimiter>) -> errors::Result<()> {
+fn print_summary_from_reader<T: std::io::Read>(
+    reader: &mut T,
+    summary_type: &SummaryType,
+    csv_delimiter: Option<CsvDelimiter>,
+) -> errors::Result<()> {
     match summary_type {
         SummaryType::Libmagic => Err(GitXetRepoError::InvalidOperation(
             "file type summarization from contents not supported".to_string(),
         )),
-        SummaryType::Twb => print_twb_summary_from_reader(reader)
-            .map_err(GitXetRepoError::from),
-        SummaryType::Tds => print_tds_summary_from_reader(reader)
-            .map_err(GitXetRepoError::from),
-        SummaryType::Csv => print_csv_summary_from_reader(reader, csv_delimiter.unwrap_or_default().into()),
+        SummaryType::Twb => print_twb_summary_from_reader(reader).map_err(GitXetRepoError::from),
+        SummaryType::Tds => print_tds_summary_from_reader(reader).map_err(GitXetRepoError::from),
+        SummaryType::Csv => {
+            print_csv_summary_from_reader(reader, csv_delimiter.unwrap_or_default().into())
+        }
     }
 }
-
 
 pub async fn summary_command(config: XetConfig, args: &SummaryArgs) -> errors::Result<()> {
     match &args.command {
@@ -269,14 +286,30 @@ pub async fn summary_command(config: XetConfig, args: &SummaryArgs) -> errors::R
             blobid,
             csv_delimiter,
             force_compute,
-        } => print_summary_from_blobid(&config, summary_type, blobid, *csv_delimiter, *force_compute).await,
+        } => {
+            print_summary_from_blobid(
+                &config,
+                summary_type,
+                blobid,
+                *csv_delimiter,
+                *force_compute,
+            )
+            .await
+        }
         SummarySubCommand::ListGit => summaries_list_git(config).await,
         SummarySubCommand::MergeGit { base, head } => {
             utils::merge_git_notes(base, head, GIT_NOTES_SUMMARIES_REF_NAME, &config).await
         }
         SummarySubCommand::Query { merklehash } => summaries_query(config, merklehash).await,
         SummarySubCommand::Dump => summaries_dump(config).await,
-        SummarySubCommand::ComputeFromHash { summary_type, hash, csv_delimiter } => print_summary_from_hash(&config, summary_type, hash, *csv_delimiter).await,
-        SummarySubCommand::ComputeFromStdin { summary_type, csv_delimiter } => print_summary_from_stdin(&config, summary_type, *csv_delimiter).await,
+        SummarySubCommand::ComputeFromHash {
+            summary_type,
+            hash,
+            csv_delimiter,
+        } => print_summary_from_hash(&config, summary_type, hash, *csv_delimiter).await,
+        SummarySubCommand::ComputeFromStdin {
+            summary_type,
+            csv_delimiter,
+        } => print_summary_from_stdin(&config, summary_type, *csv_delimiter).await,
     }
 }

--- a/rust/gitxetcore/src/data/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data/data_processing_v1.rs
@@ -18,13 +18,13 @@ use merkledb::*;
 use merklehash::MerkleHash;
 use parutils::{AsyncIterator, BufferedAsyncIterator};
 use progress_reporting::DataProgressReporter;
+use tableau_summary::tds::TdsAnalyzer;
+use tableau_summary::twb::TwbAnalyzer;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, info_span};
 use tracing_futures::Instrument;
-use tableau_summary::tds::TdsAnalyzer;
-use tableau_summary::twb::TwbAnalyzer;
 
 use super::data_processing::{FILTER_BYTES_CLEANED, FILTER_CAS_BYTES_PRODUCED};
 

--- a/rust/gitxetcore/src/diff/fetcher.rs
+++ b/rust/gitxetcore/src/diff/fetcher.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use git2::{ErrorCode, Repository};
 
-use ::libmagic::libmagic::{LibmagicSummary, summarize_libmagic};
+use ::libmagic::libmagic::{summarize_libmagic, LibmagicSummary};
 use error_printer::ErrorPrinter;
 use tableau_summary::tds::printer::summarize_tds_from_reader;
 use tableau_summary::twb::printer::summarize_twb_from_reader;
@@ -17,8 +17,8 @@ use crate::diff::error::DiffError;
 use crate::diff::error::DiffError::{FailedSummaryCalculation, NoSummaries, NotInRepoDir};
 use crate::diff::util::RefOrT;
 use crate::git_integration::GitXetRepo;
-use crate::summaries::*;
 use crate::summaries::analysis::SummaryExt;
+use crate::summaries::*;
 
 /// Fetches FileSummaries for hashes or blob_ids.
 ///
@@ -44,9 +44,9 @@ impl SummaryFetcher {
             &config.summarydb,
             GIT_NOTES_SUMMARIES_REF_NAME,
         )
-            .await
-            .log_error("Error loading git notes")
-            .map_err(|_| NoSummaries)
+        .await
+        .log_error("Error loading git notes")
+        .map_err(|_| NoSummaries)
     }
 
     fn load_repo(config: XetConfig) -> Result<Arc<Repository>, DiffError> {

--- a/rust/gitxetcore/src/diff/mod.rs
+++ b/rust/gitxetcore/src/diff/mod.rs
@@ -3,14 +3,14 @@ mod error;
 mod fetcher;
 mod output;
 mod processor;
-mod util;
-mod twb;
 mod tds;
+mod twb;
+mod util;
 
 pub use csv::CsvSummaryDiffProcessor;
-pub use twb::TwbSummaryDiffProcessor;
-pub use tds::TdsSummaryDiffProcessor;
 pub use error::*;
 pub use fetcher::SummaryFetcher;
 pub use output::{DiffOutput, SummaryDiff};
 pub use processor::SummaryDiffProcessor;
+pub use tds::TdsSummaryDiffProcessor;
+pub use twb::TwbSummaryDiffProcessor;

--- a/rust/gitxetcore/src/diff/output.rs
+++ b/rust/gitxetcore/src/diff/output.rs
@@ -1,10 +1,10 @@
 use crate::diff::csv::CsvSummaryDiffContent;
 use crate::diff::error::DiffError;
+use crate::diff::tds::TdsSummaryDiffContent;
 use crate::summaries::summary_type::SummaryType;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use tableau_summary::twb::diff::schema::TwbSummaryDiffContent;
-use crate::diff::tds::TdsSummaryDiffContent;
 
 /// The resulting struct to be output by the command.
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/rust/gitxetcore/src/diff/tds.rs
+++ b/rust/gitxetcore/src/diff/tds.rs
@@ -1,9 +1,9 @@
+use crate::diff::output::SummaryDiffData;
+use crate::diff::output::SummaryDiffData::Tds;
+use crate::diff::{DiffError, SummaryDiffProcessor};
+use crate::summaries::{FileSummary, SummaryType};
 use serde::{Deserialize, Serialize};
 use tableau_summary::tds::TdsSummary;
-use crate::diff::output::SummaryDiffData;
-use crate::diff::{DiffError, SummaryDiffProcessor};
-use crate::diff::output::SummaryDiffData::Tds;
-use crate::summaries::{FileSummary, SummaryType};
 
 /// Diff content for a Tds diff
 #[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
@@ -19,7 +19,6 @@ pub struct TdsSummaryDiffContent {
 /// change this to become more intelligent (actually identify what changed between the datasources).
 pub struct TdsSummaryDiffProcessor {}
 
-
 impl SummaryDiffProcessor for TdsSummaryDiffProcessor {
     type SummaryData = TdsSummary;
 
@@ -32,8 +31,10 @@ impl SummaryDiffProcessor for TdsSummaryDiffProcessor {
     }
 
     fn get_data<'a>(&'a self, summary: &'a FileSummary) -> Option<&Self::SummaryData> {
-        summary.additional_summaries.as_ref()
-            .and_then(|ext|ext.tds.as_ref())
+        summary
+            .additional_summaries
+            .as_ref()
+            .and_then(|ext| ext.tds.as_ref())
     }
 
     fn get_insert_diff(&self, summary: &TdsSummary) -> Result<SummaryDiffData, DiffError> {

--- a/rust/gitxetcore/src/diff/twb.rs
+++ b/rust/gitxetcore/src/diff/twb.rs
@@ -2,9 +2,9 @@ use tableau_summary::twb::diff::schema::TwbSummaryDiffContent;
 use tableau_summary::twb::diff::util::DiffProducer;
 use tableau_summary::twb::TwbSummary;
 
-use crate::diff::{DiffError, SummaryDiffProcessor};
 use crate::diff::output::SummaryDiffData;
 use crate::diff::output::SummaryDiffData::Twb;
+use crate::diff::{DiffError, SummaryDiffProcessor};
 use crate::summaries::{FileSummary, SummaryType};
 
 /// Processes diffs of Twb Summaries, taking in [TwbSummary]s and producing a [TwbSummaryDiffContent]
@@ -26,7 +26,9 @@ impl SummaryDiffProcessor for TwbSummaryDiffProcessor {
     }
 
     fn get_data<'a>(&'a self, summary: &'a FileSummary) -> Option<&Self::SummaryData> {
-        summary.additional_summaries.as_ref()
+        summary
+            .additional_summaries
+            .as_ref()
             .and_then(|ext| ext.twb.as_ref())
     }
 

--- a/rust/gitxetcore/src/git_integration/git_url.rs
+++ b/rust/gitxetcore/src/git_integration/git_url.rs
@@ -89,14 +89,17 @@ impl XetPathInfo {
             })?;
         }
 
-        // closure to split out domain and port, returns Err if port is an invalid u16. 
+        // closure to split out domain and port, returns Err if port is an invalid u16.
         let split_out_port = |domain: &str| -> Result<(String, Option<u16>)> {
             let host_port_split = domain.split(':').collect::<Vec<_>>();
             if host_port_split.len() == 2 {
                 Ok((
                     host_port_split[0].to_string(),
                     Some(host_port_split[1].parse::<u16>().map_err(|_| {
-                        GitXetRepoError::InvalidRemote(format!("Invalid port {}", host_port_split[1]))
+                        GitXetRepoError::InvalidRemote(format!(
+                            "Invalid port {}",
+                            host_port_split[1]
+                        ))
                     })?),
                 ))
             } else {
@@ -111,7 +114,7 @@ impl XetPathInfo {
         let domain;
         if domain_split.len() == 2 {
             scheme = domain_split[0].to_owned();
-            (domain, port) = split_out_port(domain_split[1])?; 
+            (domain, port) = split_out_port(domain_split[1])?;
         } else {
             (domain, port) = split_out_port(force_domain)?;
         }
@@ -179,7 +182,7 @@ impl XetPathInfo {
         // we leave url with the first 3 components. i.e. "/user/repo"
         let replacement_parse_path = components[..3].join("/");
 
-        let port_string; 
+        let port_string;
         if let Some(parsed_port) = parse.port() {
             port_string = format!(":{}", parsed_port)
         } else {
@@ -189,7 +192,8 @@ impl XetPathInfo {
         let ret = XetPathInfo {
             remote_url: format!(
                 "{scheme}://{}{}{replacement_parse_path}",
-                parse.host().unwrap(), port_string, 
+                parse.host().unwrap(),
+                port_string,
             ),
             branch,
             path,

--- a/rust/gitxetcore/src/summaries/analysis.rs
+++ b/rust/gitxetcore/src/summaries/analysis.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
-use tracing::{error, warn};
 use tableau_summary::tds::{TdsAnalyzer, TdsSummary};
 use tableau_summary::twb::{TwbAnalyzer, TwbSummary};
+use tracing::{error, warn};
 
 #[derive(Default)]
 pub struct FileAnalyzers {
@@ -162,7 +162,10 @@ impl FileSummary {
         }
 
         if self.additional_summaries != other.additional_summaries {
-            match (self.additional_summaries.as_ref(), other.additional_summaries.as_ref()) {
+            match (
+                self.additional_summaries.as_ref(),
+                other.additional_summaries.as_ref(),
+            ) {
                 (_, None) => ret.additional_summaries = None,
                 (Some(a), Some(b)) => {
                     let mut ret_sum = SummaryExt::default();
@@ -176,7 +179,7 @@ impl FileSummary {
                         ret_sum.tds = b.tds.clone();
                     }
                     ret.additional_summaries = Some(ret_sum);
-                },
+                }
                 (None, x) => {
                     ret.additional_summaries = x.cloned();
                 }
@@ -212,6 +215,4 @@ impl SummaryExt {
             ..Default::default()
         }
     }
-
-
 }

--- a/rust/gitxetcore/src/summaries/csv.rs
+++ b/rust/gitxetcore/src/summaries/csv.rs
@@ -1,8 +1,8 @@
-use std::ffi::OsStr;
-use std::{borrow::Cow, fs::File, io::Read, mem::take, path::Path};
-use std::str::FromStr;
 use anyhow::anyhow;
 use clap::ArgEnum;
+use std::ffi::OsStr;
+use std::str::FromStr;
+use std::{borrow::Cow, fs::File, io::Read, mem::take, path::Path};
 
 use super::constants::*;
 use crate::errors::Result;
@@ -27,7 +27,7 @@ impl FromStr for CsvDelimiter {
         match s {
             "comma" | "," => Ok(CsvDelimiter::Comma),
             "tab" | "\t" => Ok(CsvDelimiter::Tab),
-            _ => Err(anyhow!("unrecognized csv delimiter str"))
+            _ => Err(anyhow!("unrecognized csv delimiter str")),
         }
     }
 }

--- a/rust/gitxetcore/src/summaries/summaries_plumb.rs
+++ b/rust/gitxetcore/src/summaries/summaries_plumb.rs
@@ -1,4 +1,5 @@
 use futures::prelude::stream::*;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{hash_map::Entry, HashMap},
     fs::File,
@@ -6,7 +7,6 @@ use std::{
     mem::swap,
     path::{Path, PathBuf},
 };
-use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, warn};
 
 use crate::{config::XetConfig, errors::GitXetRepoError};

--- a/rust/gitxetcore/src/xetblob/file_operations/cp_operations.rs
+++ b/rust/gitxetcore/src/xetblob/file_operations/cp_operations.rs
@@ -84,8 +84,8 @@ async fn build_cp_operation_list(
             // src_root_dir should be blah/blah/blah here
             let src_root_dir = src_fs.parent(src.as_str());
             let src_file_name = src_fs.file_name(src.as_str());
-            
-            if src_root_dir.is_some_and(|d| d.contains('*'))   {
+
+            if src_root_dir.is_some_and(|d| d.contains('*')) {
                 return Err(GitXetRepoError::InvalidOperation(format!(
                     "Invalid glob {src}. Wildcards can only appear in the last position",
                 )));
@@ -95,8 +95,11 @@ async fn build_cp_operation_list(
             dest_path = dest_base_path.to_owned();
             dest_dir = dest_path.clone();
             file_filter_pattern = if !src_file_name.is_empty() {
-                Some(Pattern::new(src_file_name).
-                    map_err(|e| GitXetRepoError::InvalidOperation(format!("Error in glob pattern {src_file_name}: {e:?}")))?)
+                Some(Pattern::new(src_file_name).map_err(|e| {
+                    GitXetRepoError::InvalidOperation(format!(
+                        "Error in glob pattern {src_file_name}: {e:?}"
+                    ))
+                })?)
             } else {
                 None
             };
@@ -107,7 +110,7 @@ async fn build_cp_operation_list(
                 ));
             };
             src_size = src_info.size;
-            
+
             if src.ends_with('/') {
                 src_path = src.strip_suffix('/').unwrap_or(src.as_str()).to_owned();
 
@@ -164,7 +167,7 @@ async fn build_cp_operation_list(
                         dest_path = dest_base_path.to_owned();
                     }
                 }
-            }; 
+            };
         }
 
         // Now, we should have all the variables -- src_is_directory, src_path, dest_path, dest_dir, and file_filter_pattern
@@ -184,7 +187,8 @@ async fn build_cp_operation_list(
                         size: 0,
                     });
                 } else {
-                    cp_ops.extend(src_fs.listdir(&src_path, true).await?.into_iter().
+                    cp_ops.extend(
+                        src_fs.listdir(&src_path, true).await?.into_iter().
                         // filter files under dir that do not match glob pattern if the input src uses wildcard
                         filter(|entry| {
                             if let Some(filter) = file_filter_pattern.as_ref() {
@@ -210,7 +214,8 @@ async fn build_cp_operation_list(
                                 size: entry.size,
                             }
                         },
-                    ));
+                    ),
+                    );
                 }
             } else {
                 return Err(GitXetRepoError::InvalidOperation(format!(
@@ -559,8 +564,8 @@ mod tests {
             dest_dir_path.to_str().unwrap().to_owned(),
             true,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let dest_file_path = dest_dir_path.join("file.txt");
         assert!(dest_dir_path.exists());
@@ -578,7 +583,7 @@ mod tests {
             &source_dir,
             &[("subdir", None), ("subdir/file.txt", Some(b"Hello"))],
         )
-            .unwrap();
+        .unwrap();
 
         let wildcard_source_dir = source_dir.join("*");
         perform_copy_wrapper(
@@ -586,8 +591,8 @@ mod tests {
             temp_dir.path().to_str().unwrap().to_owned(),
             true,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let copied_file_path = temp_dir.path().join("subdir/file.txt");
         assert!(copied_file_path.exists());
@@ -607,7 +612,7 @@ mod tests {
             &source_dir,
             &[("subdir", None), ("subdir/file.txt", Some(b"Hello"))],
         )
-            .unwrap();
+        .unwrap();
 
         let wildcard_source_dir = source_dir.join("*");
         perform_copy_wrapper(
@@ -615,8 +620,8 @@ mod tests {
             dest_dir.as_path().to_str().unwrap().to_owned(),
             true,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let dest_file_path = dest_dir.join("subdir/file.txt");
         assert!(dest_file_path.exists());

--- a/rust/utils/src/compression.rs
+++ b/rust/utils/src/compression.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
-use anyhow::anyhow;
 use crate::common::CompressionScheme;
+use anyhow::anyhow;
+use std::str::FromStr;
 
 pub const CAS_CONTENT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
 pub const CAS_ACCEPT_ENCODING_HEADER: &str = "xet-cas-content-encoding";
@@ -32,13 +32,14 @@ impl FromStr for CompressionScheme {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            return Ok(CompressionScheme::None)
+            return Ok(CompressionScheme::None);
         }
-        Self::from_str_name(s.to_uppercase().as_str()).ok_or_else(|| anyhow!("could not convert &str to CompressionScheme"))
+        Self::from_str_name(s.to_uppercase().as_str())
+            .ok_or_else(|| anyhow!("could not convert &str to CompressionScheme"))
     }
 }
 
-// in the header value, we will consider 
+// in the header value, we will consider
 pub fn multiple_accepted_encoding_header_value(list: Vec<CompressionScheme>) -> String {
     let as_strs: Vec<&str> = list.iter().map(Into::into).collect();
     as_strs.join(";").to_string()
@@ -46,16 +47,31 @@ pub fn multiple_accepted_encoding_header_value(list: Vec<CompressionScheme>) -> 
 
 #[cfg(test)]
 mod tests {
+    use crate::compression::{multiple_accepted_encoding_header_value, CompressionScheme};
     use std::str::FromStr;
-    use crate::compression::{CompressionScheme, multiple_accepted_encoding_header_value};
 
     #[test]
     fn test_from_str() {
-        assert_eq!(CompressionScheme::from_str("LZ4").unwrap(), CompressionScheme::Lz4);
-        assert_eq!(CompressionScheme::from_str("NONE").unwrap(), CompressionScheme::None);
-        assert_eq!(CompressionScheme::from_str("NoNE").unwrap(), CompressionScheme::None);
-        assert_eq!(CompressionScheme::from_str("none").unwrap(), CompressionScheme::None);
-        assert_eq!(CompressionScheme::from_str("").unwrap(), CompressionScheme::None);
+        assert_eq!(
+            CompressionScheme::from_str("LZ4").unwrap(),
+            CompressionScheme::Lz4
+        );
+        assert_eq!(
+            CompressionScheme::from_str("NONE").unwrap(),
+            CompressionScheme::None
+        );
+        assert_eq!(
+            CompressionScheme::from_str("NoNE").unwrap(),
+            CompressionScheme::None
+        );
+        assert_eq!(
+            CompressionScheme::from_str("none").unwrap(),
+            CompressionScheme::None
+        );
+        assert_eq!(
+            CompressionScheme::from_str("").unwrap(),
+            CompressionScheme::None
+        );
         assert!(CompressionScheme::from_str("not-scheme").is_err());
     }
 
@@ -68,9 +84,15 @@ mod tests {
     #[test]
     fn test_multiple_accepted_encoding_header_value() {
         let multi = vec![CompressionScheme::Lz4, CompressionScheme::None];
-        assert_eq!(multiple_accepted_encoding_header_value(multi), "LZ4;NONE".to_string());
+        assert_eq!(
+            multiple_accepted_encoding_header_value(multi),
+            "LZ4;NONE".to_string()
+        );
 
         let singular = vec![CompressionScheme::Lz4];
-        assert_eq!(multiple_accepted_encoding_header_value(singular), "LZ4".to_string());
+        assert_eq!(
+            multiple_accepted_encoding_header_value(singular),
+            "LZ4".to_string()
+        );
     }
 }

--- a/rust/utils/src/lib.rs
+++ b/rust/utils/src/lib.rs
@@ -31,9 +31,9 @@ pub mod shard {
     tonic::include_proto!("shard");
 }
 
+pub mod compression;
 pub mod consistenthash;
 pub mod constants;
-pub mod compression;
 pub mod errors;
 pub mod gitbaretools;
 pub mod key;
@@ -43,8 +43,8 @@ pub mod version;
 
 mod output_bytes;
 
-pub use output_bytes::output_bytes;
 use crate::common::{CompressionScheme, InitiateResponse};
+pub use output_bytes::output_bytes;
 
 impl TryFrom<cas::Range> for Range<u64> {
     type Error = Status;
@@ -94,7 +94,10 @@ impl std::fmt::Display for common::EndpointConfig {
 
 impl InitiateResponse {
     pub fn get_accepted_encodings_parsed(&self) -> Vec<CompressionScheme> {
-        self.accepted_encodings.iter().filter_map(|i| CompressionScheme::try_from(*i).ok()).collect()
+        self.accepted_encodings
+            .iter()
+            .filter_map(|i| CompressionScheme::try_from(*i).ok())
+            .collect()
     }
 }
 


### PR DESCRIPTION
A bunch of code has crept in that has not had cargo format properly run on it, which results in PRs with a lot of formatting changes when editors that automatically do run cargo fmt touch a file.  

This PR updates a big chunk of these format changes (the rest are in active development, so will hold off on those). 