### PR TITLE
Added additional rdev that creates a release binary but without lto

### DIFF
--- a/gitxet/Cargo.toml
+++ b/gitxet/Cargo.toml
@@ -34,6 +34,12 @@ opt-level = 3
 lto = true
 debug = "line-tables-only"
 
+[profile.rdev]
+inherits = "release"
+opt-level = 3
+lto = false
+debug = "full"
+
 [profile.opt-test]
 inherits = "dev"
 opt-level = 1


### PR DESCRIPTION
Compiling git-xet with lto, which is default in release mode, takes around 3 minutes to link.  This adds a local release dev profile invoked by 

`cargo build --profile=rdev` 

that builds the client in release mode but without lto.   This is substantially faster.