### PR TITLE
help message fixes

### DIFF
--- a/rust/gitxetcore/src/command/clone.rs
+++ b/rust/gitxetcore/src/command/clone.rs
@@ -8,15 +8,13 @@ use crate::errors::Result;
 /// to clone the repo.
 #[derive(Args, Debug)]
 pub struct CloneArgs {
-    /// If given, the repo is cloned without downloading the reference data blocks.   Data files will only show up as pointer files, and can later be downloaded using git xet checkout.
-    #[clap(long)]
-    no_smudge: bool,
-
-    #[clap(long)]
+    /// If given, the repo is cloned without downloading the reference data blocks.
+    /// Data files will only show up as pointer files, and can later be downloaded using git xet materialize.
+    #[clap(long, alias = "no-smudge")]
     lazy: bool,
 
     /// All remaining arguments are passed to git clone.
-    /// any arguments after '--' are unprocessed and passed through as is.
+    /// Any arguments after '--' are unprocessed and passed through as is.
     /// This is useful for instance in:
     ///
     /// > git xet clone https://xethub.com/user/repo -- --branch abranch
@@ -33,7 +31,7 @@ pub async fn clone_command(config: XetConfig, args: &CloneArgs) -> Result<()> {
         Some(&config),
         &arg_v[..],
         // config.force_no_smudge may come from env var `XET_NO_SMUDGE` or git-xet global config `smudge`
-        args.no_smudge || args.lazy || config.force_no_smudge,
+        args.lazy || config.force_no_smudge,
         None,
         true,
         true,

--- a/rust/gitxetcore/src/command/lazy.rs
+++ b/rust/gitxetcore/src/command/lazy.rs
@@ -18,7 +18,7 @@ enum LazyCommand {
     /// After editing a config file, apply changes to the
     /// working directory.
     Apply,
-    // Print the lazy config to stdout.
+    /// List files that are materialized in a lazy cloned repository.
     Show,
 }
 

--- a/rust/gitxetcore/src/command/mod.rs
+++ b/rust/gitxetcore/src/command/mod.rs
@@ -79,13 +79,17 @@ pub enum Command {
     Checkout(CheckoutArgs),
 
     /// Run the filter process.
+    #[clap(hide(true))]
     Filter,
 
+    #[clap(hide(true))]
     Pointer(PointerArgs),
 
+    #[clap(hide(true))]
     Smudge(SmudgeArgs),
 
     /// Manually push all staged cas information to a remote CAS.
+    #[clap(hide(true))]
     Push,
 
     /// Plumbing commands for merkledb integration.
@@ -95,9 +99,10 @@ pub enum Command {
     Cas(CasSubCommandShim),
 
     /// Plumbing commands for the git integration hooks.
+    #[clap(hide(true))]
     Hooks(HookCommandShim),
 
-    /// Clones an existing git xet repo, making sure the local configuration
+    /// Clones an existing git xet repo into a new directory.
     Clone(CloneArgs),
 
     /// Installs the git filter config.
@@ -116,12 +121,15 @@ pub enum Command {
 
     /// Computes and returns a file-level summary for a given file in the repo.
     /// Stores the result in git notes.
+    #[clap(hide(true))]
     Summary(SummaryArgs),
 
     /// Computes and returns a directory-level summary for all directories in the repo.
+    #[clap(hide(true))]
     DirSummary(DirSummaryArgs),
 
     /// Computes a summary-diff for a provided file between two commits.
+    #[clap(hide(true))]
     Diff(DiffArgs),
 
     /// Mounts a repository on a local path
@@ -139,11 +147,13 @@ pub enum Command {
 
     /// Computes and returns the data dependencies of custom visualizations,
     /// cached in git notes.
+    #[clap(hide(true))]
     VisualizationDependencies(VisualizationDependenciesArgs),
 
     /// Stores authentication information for Xethub
     Login(LoginArgs),
 
+    /// Auxiliary commands to manage the lazy config.
     Lazy(LazyCommandShim),
 
     /// Materialize files and add the list of file paths to the lazy config.


### PR DESCRIPTION
Fix a couple of issues regarding git-xet help messages, hides a couple of git xet commands that are only meant for internal usage and never exposed in public docs. Fix CLI-24, CLI-56, CLI-148

**Recommend to review with whitespaces hidden.**