### PR TITLE
Fix Zone change count 

### DIFF
--- a/rust/tableau_summary/src/twb/diff/dashboard.rs
+++ b/rust/tableau_summary/src/twb/diff/dashboard.rs
@@ -82,9 +82,7 @@ pub struct ZoneDiff {
 
 impl ZoneDiff {
     fn calculate_change_map(&mut self) {
-        self.changes.update(&self.name);
-        self.changes.update(&self.zone_type);
-        self.changes.update(&self.is_sheet);
+        self.changes.update_first(&[self.name.status, self.zone_type.status, self.is_sheet.status]);
         self.sub_zones.iter()
             .for_each(|z| self.changes.merge(&z.changes));
     }

--- a/rust/tableau_summary/src/twb/diff/util.rs
+++ b/rust/tableau_summary/src/twb/diff/util.rs
@@ -85,6 +85,12 @@ impl ChangeMap {
         self.increment_change(item.status)
     }
 
+    pub fn update_first(&mut self, items: &[ChangeState]) {
+        if let Some(&s) = items.iter().find(|&&i| (i != ChangeState::None)) {
+            self.increment_change(s)
+        }
+    }
+
     /// Update the map with the change encapsulated by the DiffItem of an Option.
     /// This differs from `update()` since a DiffItem<Option<T>> contains
     /// Option<Option<T>> for the before/after, so we want to consider the presence


### PR DESCRIPTION
Fixes: TAB-86

Changes the count of zone changes to only be 1 if any of the fields changes.