### PR TITLE
Report xorb compression size

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "libc",
  "libmagic",
  "lru",
+ "lz4",
  "mdb_shard",
  "merkledb",
  "merklehash",

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -98,6 +98,7 @@ retry_strategy = { path = "../retry_strategy" }
 shellexpand = "1.0.0"
 blake3 = "1.0.0"
 uuid = { version = "1.8.0", features = ["std", "rng", "v6"] }
+lz4 = "1.24.0"
 
 # tracing
 tracing-futures = "0.2"

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -832,7 +832,7 @@ impl PointerFileTranslatorV2 {
                 .await?;
         }
 
-        FILTER_CAS_BYTES_PRODUCED.inc_by(running_sum as u64);
+        FILTER_CAS_BYTES_PRODUCED.inc_by(compressed_bytes_len as u64);
 
         cas_data.data.clear();
         cas_data.chunks.clear();

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use error_printer::ErrorPrinter;
 use futures::prelude::stream::*;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
@@ -759,8 +760,26 @@ impl PointerFileTranslatorV2 {
 
     async fn register_new_cas_block(&self, cas_data: &mut CASDataAggregator) -> Result<MerkleHash> {
         let cas_hash = cas_node_hash(&cas_data.chunks[..])?;
-        let metadata =
-            CASChunkSequenceHeader::new(cas_hash, cas_data.chunks.len(), cas_data.data.len());
+
+        let raw_bytes_len = cas_data.data.len();
+        // We now assume that the server will compress Xorbs using lz4,
+        // without actually compressing the data client-side.
+        // The accounting logic will be moved to server-side in the future.
+        let compressed_bytes_len = lz4::block::compress(
+            &cas_data.data,
+            Some(lz4::block::CompressionMode::DEFAULT),
+            false,
+        )
+        .log_error("LZ4 compression error")
+        .map(|out| out.len())
+        .unwrap_or(raw_bytes_len);
+
+        let metadata = CASChunkSequenceHeader::new_with_compression(
+            cas_hash,
+            cas_data.chunks.len(),
+            raw_bytes_len,
+            compressed_bytes_len,
+        );
 
         let mut pos = 0;
         let chunks: Vec<_> = cas_data

--- a/rust/gitxetcore/src/data/mdb.rs
+++ b/rust/gitxetcore/src/data/mdb.rs
@@ -906,7 +906,9 @@ pub async fn cas_stat_git(config: &XetConfig) -> errors::Result<()> {
     }
 
     println!("{{");
-    println!("\"total_compressed_cas_bytes\" : {stored_bytes_on_disk},");
+    if stored_bytes_on_disk != stored_bytes {
+        println!("\"total_compressed_cas_bytes\" : {stored_bytes_on_disk},");
+    }
     println!("\"total_cas_bytes\" : {stored_bytes},");
     println!("\"total_file_bytes\" : {materialized_bytes}");
     println!("}}");

--- a/rust/mdb_shard/src/set_operations.rs
+++ b/rust/mdb_shard/src/set_operations.rs
@@ -190,6 +190,7 @@ fn set_operation<R: Read + Seek, W: Write>(
                 match action[i] {
                     NextAction::CopyToOut => {
                         let fh = cas_data_header[i].as_ref().unwrap();
+                        footer.stored_bytes_on_disk += fh.num_bytes_on_disk as u64;
                         footer.stored_bytes += fh.num_bytes_in_cas as u64;
 
                         out_offset += fh.serialize(out)? as u64;

--- a/rust/mdb_shard/src/shard_format.rs
+++ b/rust/mdb_shard/src/shard_format.rs
@@ -238,13 +238,8 @@ impl MDBShardInfo {
         reader.rewind()?;
         obj.header = MDBShardFileHeader::deserialize(reader)?;
 
-        // Move cursor to the end of shard file minus sizeof(u64) to
-        // read footer_offset. Then seek to that position to read
-        // MDBShardFileFooter.
-        //
-        reader.seek(SeekFrom::End(-(size_of::<u64>() as i64)))?;
-        let footer_offset = read_u64(reader)?;
-        reader.seek(SeekFrom::Start(footer_offset))?;
+        // Move cursor to end of shard file minus footer size.
+        reader.seek(SeekFrom::End(-MDB_SHARD_FOOTER_SIZE))?;
         obj.metadata = MDBShardFileFooter::deserialize(reader)?;
 
         Ok(obj)

--- a/rust/mdb_shard/src/shard_format.rs
+++ b/rust/mdb_shard/src/shard_format.rs
@@ -93,7 +93,8 @@ pub struct MDBShardFileFooter {
     pub intershard_reference_offset: u64,
 
     // More locations to stick in here if needed.
-    _buffer: [u64; 7],
+    _buffer: [u64; 6],
+    pub stored_bytes_on_disk: u64,
     pub materialized_bytes: u64,
     pub stored_bytes: u64,
     pub footer_offset: u64, // Always last.
@@ -112,7 +113,8 @@ impl Default for MDBShardFileFooter {
             chunk_lookup_offset: 0,
             chunk_lookup_num_entry: 0,
             intershard_reference_offset: 0,
-            _buffer: [0u64; 7],
+            _buffer: [0u64; 6],
+            stored_bytes_on_disk: 0,
             materialized_bytes: 0,
             stored_bytes: 0,
             footer_offset: 0,
@@ -133,6 +135,7 @@ impl MDBShardFileFooter {
         write_u64(writer, self.chunk_lookup_num_entry)?;
         write_u64(writer, self.intershard_reference_offset)?;
         write_u64s(writer, &self._buffer)?;
+        write_u64(writer, self.stored_bytes_on_disk)?;
         write_u64(writer, self.materialized_bytes)?;
         write_u64(writer, self.stored_bytes)?;
         write_u64(writer, self.footer_offset)?;
@@ -155,6 +158,7 @@ impl MDBShardFileFooter {
             ..Default::default()
         };
         read_u64s(reader, &mut obj._buffer)?;
+        obj.stored_bytes_on_disk = read_u64(reader)?;
         obj.materialized_bytes = read_u64(reader)?;
         obj.stored_bytes = read_u64(reader)?;
         obj.footer_offset = read_u64(reader)?;
@@ -234,8 +238,13 @@ impl MDBShardInfo {
         reader.rewind()?;
         obj.header = MDBShardFileHeader::deserialize(reader)?;
 
-        // Move cursor to end of shard file minus footer size.
-        reader.seek(SeekFrom::End(-MDB_SHARD_FOOTER_SIZE))?;
+        // Move cursor to the end of shard file minus sizeof(u64) to
+        // read footer_offset. Then seek to that position to read
+        // MDBShardFileFooter.
+        //
+        reader.seek(SeekFrom::End(-(size_of::<u64>() as i64)))?;
+        let footer_offset = read_u64(reader)?;
+        reader.seek(SeekFrom::Start(footer_offset))?;
         obj.metadata = MDBShardFileFooter::deserialize(reader)?;
 
         Ok(obj)
@@ -324,6 +333,7 @@ impl MDBShardInfo {
         }
 
         // Update repo size information.
+        shard.metadata.stored_bytes_on_disk = mdb.stored_bytes_on_disk();
         shard.metadata.materialized_bytes = mdb.materialized_bytes();
         shard.metadata.stored_bytes = mdb.stored_bytes();
 
@@ -796,6 +806,10 @@ impl MDBShardInfo {
     /// Returns the number of bytes in the shard
     pub fn num_bytes(&self) -> u64 {
         self.metadata.footer_offset + size_of::<MDBShardFileFooter>() as u64
+    }
+
+    pub fn stored_bytes_on_disk(&self) -> u64 {
+        self.metadata.stored_bytes_on_disk
     }
 
     pub fn materialized_bytes(&self) -> u64 {

--- a/rust/mdb_shard/src/shard_in_memory.rs
+++ b/rust/mdb_shard/src/shard_in_memory.rs
@@ -275,6 +275,12 @@ impl MDBInMemoryShard {
         self.file_content.len()
     }
 
+    pub fn stored_bytes_on_disk(&self) -> u64 {
+        self.cas_content.iter().fold(0u64, |acc, (_, cas)| {
+            acc + cas.metadata.num_bytes_on_disk as u64
+        })
+    }
+
     pub fn materialized_bytes(&self) -> u64 {
         self.file_content.iter().fold(0u64, |acc, (_, file)| {
             acc + file


### PR DESCRIPTION
Fix BAC-162

Tests:
1. Under a repo with history before this, add a csv file of 373909 bytes
```
di@di-mbp ~/tt/pyxet-build % git xet merkledb cas-stat
{
"total_cas_bytes" : 559694603,
"total_file_bytes" : 559917404
}
di@di-mbp ~/tt/pyxet-build % ls -l
total 1062232
-rw-r--r--@ 1 di  staff     373909 May  6 14:22 Stocks_data (1).csv
-rw-r--r--  1 di  staff  527042656 May  6 14:22 rpyxet.abi3.so
-rw-r--r--  1 di  staff   16437430 May  6 14:22 xet-linux-arm64.tar.gz
di@di-mbp ~/tt/pyxet-build % git add .
Git-Xet 0.13.4: Processing data: 16.03 MiB | 16.03 MiB/s, done.
16.03 MiB added, stored 110.65 KiB (99.3% reduction)
di@di-mbp ~/tt/pyxet-build % git commit -m "add stock data"
[main e73a7fc] add stock data
 1 file changed, 3 insertions(+)
 create mode 100644 Stocks_data (1).csv
di@di-mbp ~/tt/pyxet-build % git push >/dev/null 2>&1
di@di-mbp ~/tt/pyxet-build % git xet merkledb cas-stat
{
"total_compressed_cas_bytes" : 559807907,
"total_cas_bytes" : 560068512,
"total_file_bytes" : 560291313
}
```
2. Under a new repo that commits a csv file of 76775041 bytes after this
```
di@di-mbp ~/tt/comp % ls -l
total 149952
-rw-r--r--  1 di  staff  76775041 May  6 13:56 sometrain.csv
di@di-mbp ~/tt/comp % git add sometrain.csv
Git-Xet 0.13.4: Processing data: 73.22 MiB | 29.15 MiB/s, done.
73.22 MiB added, stored 14.82 MiB (79.8% reduction)
di@di-mbp ~/tt/comp % git commit -m "add a csv"
[main 0887633] add a csv
 1 file changed, 3 insertions(+)
 create mode 100644 sometrain.csv
di@di-mbp ~/tt/comp % git push
di@di-mbp ~/tt/comp % git xet merkledb cas-stat
{
"total_compressed_cas_bytes" : 15544790,
"total_cas_bytes" : 76775041,
"total_file_bytes" : 76775041
}
``` 