### PR TITLE
Upgrade blake3 for optimized Arm64 / M1 support.

### DIFF
--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -96,7 +96,7 @@ whoami = "1.4.1"
 tabled = "0.12.0"
 retry_strategy = { path = "../retry_strategy" }
 shellexpand = "1.0.0"
-blake3 = "1.0.0"
+blake3 = "1.5.1"
 uuid = { version = "1.8.0", features = ["std", "rng", "v6"] }
 
 # tracing

--- a/rust/merkledb/Cargo.toml
+++ b/rust/merkledb/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.36", features = ["full"] }
 futures = "0.3"
 lazy_static = "1.4.0"
 clap = { version = "3.1.6", features = ["derive"] }
-blake3 = "1.0.0"
+blake3 = "1.5.1"
 parutils = { path = "../parutils"}
 
 [dev-dependencies]

--- a/rust/merklehash/Cargo.toml
+++ b/rust/merklehash/Cargo.toml
@@ -11,7 +11,7 @@ rand_core = "0.6.3"
 rand_chacha = "0.3.1"
 structopt = "0.3.22"
 sha3 = "0.9.1"
-blake3 = "1.0.0"
+blake3 = "1.5.1"
 generic-array = "0.14.4"
 safe-transmute = "0.11.2"
 serde = { version = "1.0.129", features = ["derive"] }


### PR DESCRIPTION
As of version 1.4, blake3 now has optimized M1 / Neon support.  This PR upgrades our version to take advantage of those speedups.  