### PR TITLE
Adding tds diff v1

### DIFF
--- a/rust/gitxetcore/src/diff/output.rs
+++ b/rust/gitxetcore/src/diff/output.rs
@@ -1,9 +1,9 @@
 use crate::diff::csv::CsvSummaryDiffContent;
 use crate::diff::error::DiffError;
-use crate::diff::tds::TdsSummaryDiffContent;
 use crate::summaries::summary_type::SummaryType;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tableau_summary::tds::diff::schema::TdsSummaryDiffContent;
 use tableau_summary::twb::diff::schema::TwbSummaryDiffContent;
 
 /// The resulting struct to be output by the command.

--- a/rust/gitxetcore/src/diff/tds.rs
+++ b/rust/gitxetcore/src/diff/tds.rs
@@ -3,15 +3,9 @@ use crate::diff::output::SummaryDiffData;
 use crate::diff::output::SummaryDiffData::Tds;
 use crate::diff::{DiffError, SummaryDiffProcessor};
 use crate::summaries::{FileSummary, SummaryType};
-use serde::{Deserialize, Serialize};
+use tableau_summary::tds::diff::schema::TdsSummaryDiffContent;
 use tableau_summary::tds::TdsSummary;
-
-/// Diff content for a Tds diff
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
-pub struct TdsSummaryDiffContent {
-    pub before: Option<TdsSummary>,
-    pub after: Option<TdsSummary>,
-}
+use tableau_summary::twb::diff::util::DiffProducer;
 
 /// Processes diffs of Tds Summaries, taking in [TdsSummary]s and producing a [TdsSummaryDiffContent]
 /// indicating the delta between them.
@@ -40,17 +34,11 @@ impl SummaryDiffProcessor for TdsSummaryDiffProcessor {
     }
 
     fn get_insert_diff(&self, summary: &TdsSummary) -> Result<SummaryDiffData, DiffError> {
-        Ok(Tds(TdsSummaryDiffContent {
-            before: None,
-            after: Some(summary.clone()),
-        }))
+        Ok(Tds(TdsSummaryDiffContent::new_addition(summary)))
     }
 
     fn get_remove_diff(&self, summary: &TdsSummary) -> Result<SummaryDiffData, DiffError> {
-        Ok(Tds(TdsSummaryDiffContent {
-            before: Some(summary.clone()),
-            after: None,
-        }))
+        Ok(Tds(TdsSummaryDiffContent::new_deletion(summary)))
     }
 
     fn get_diff_impl(
@@ -58,9 +46,6 @@ impl SummaryDiffProcessor for TdsSummaryDiffProcessor {
         before: &TdsSummary,
         after: &TdsSummary,
     ) -> Result<SummaryDiffData, DiffError> {
-        Ok(Tds(TdsSummaryDiffContent {
-            before: Some(before.clone()),
-            after: Some(after.clone()),
-        }))
+        Ok(Tds(TdsSummaryDiffContent::new_diff(before, after)))
     }
 }

--- a/rust/tableau_summary/src/tds/diff/mod.rs
+++ b/rust/tableau_summary/src/tds/diff/mod.rs
@@ -1,0 +1,1 @@
+pub mod schema;

--- a/rust/tableau_summary/src/tds/diff/schema.rs
+++ b/rust/tableau_summary/src/tds/diff/schema.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+use crate::tds::diff::schema::TdsSummaryDiffContent::V1;
+use crate::tds::TdsSummary;
+use crate::twb::diff::datasource::DatasourceDiff;
+use crate::twb::diff::util::DiffProducer;
+
+/// Which schema of diffs to use.
+pub const DIFF_VERSION: usize = 1;
+
+/// Diff content for a Tds diff. Currently an enum of different schema versions.
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[serde(untagged)]
+pub enum TdsSummaryDiffContent {
+    V1(TdsSummaryDiffContentV1),
+    None,
+}
+
+impl DiffProducer<TdsSummary> for TdsSummaryDiffContent {
+    fn new_addition(item: &TdsSummary) -> Self {
+        match DIFF_VERSION {
+            1 => V1(TdsSummaryDiffContentV1::new_addition(item)),
+            _ => TdsSummaryDiffContent::None
+        }
+    }
+
+    fn new_deletion(item: &TdsSummary) -> Self {
+        match DIFF_VERSION {
+            1 => V1(TdsSummaryDiffContentV1::new_deletion(item)),
+            _ => TdsSummaryDiffContent::None
+        }
+    }
+
+    fn new_diff(before: &TdsSummary, after: &TdsSummary) -> Self {
+        match DIFF_VERSION {
+            1 => V1(TdsSummaryDiffContentV1::new_diff(before, after)),
+            _ => TdsSummaryDiffContent::None
+        }
+    }
+}
+
+/// V1 diff format: Detailed diffs for the datasources, worksheets, and dashboards.
+#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+pub struct TdsSummaryDiffContentV1 {
+    pub datasource: DatasourceDiff,
+}
+
+impl DiffProducer<TdsSummary> for TdsSummaryDiffContentV1 {
+    fn new_addition(summary: &TdsSummary) -> Self {
+        Self {
+            datasource: DatasourceDiff::new_addition(&summary.datasource),
+        }
+    }
+
+    fn new_deletion(summary: &TdsSummary) -> Self {
+        Self {
+            datasource: DatasourceDiff::new_deletion(&summary.datasource),
+        }
+    }
+
+    fn new_diff(before: &TdsSummary, after: &TdsSummary) -> Self {
+        Self {
+            datasource: DatasourceDiff::new_diff(&before.datasource, &after.datasource),
+        }
+    }
+}

--- a/rust/tableau_summary/src/tds/mod.rs
+++ b/rust/tableau_summary/src/tds/mod.rs
@@ -9,6 +9,7 @@ use crate::twb::summary::datasource::Datasource;
 use crate::xml::XmlExt;
 
 pub mod printer;
+pub mod diff;
 
 const PARSER_VERSION: u32 = 1;
 


### PR DESCRIPTION
Fixes: TAB-74

Changes the diffs for Tds files to provide more detailed information (i.e. the same as twb datasource diffs).

(Note: will need to apply changes to xdiff once merged).