### PR TITLE
Fix counting for changes to table columns

### DIFF
--- a/rust/tableau_summary/src/twb/diff/datasource.rs
+++ b/rust/tableau_summary/src/twb/diff/datasource.rs
@@ -156,15 +156,17 @@ pub struct ColumnDiff {
 
 impl ColumnDiff {
     fn calculate_change_map(&mut self) {
-        self.changes.update(&self.name);
-        self.changes.update(&self.datatype);
-        self.changes.update(&self.generated);
-        self.changes.update_option(&self.formula);
-        self.changes.update_option(&self.value);
+        let mut c = ChangeMap::default();
+        c.update(&self.name);
+        c.update(&self.datatype);
+        c.update(&self.generated);
+        c.update_option(&self.formula);
+        c.update_option(&self.value);
+        c.update(&self.is_dimension);
+        c.update_option(&self.table);
+        self.changes.increment_change(c.get_most_changes());
         self.drilldown.iter()
             .for_each(|t| self.changes.merge(&t.changes));
-        self.changes.update_option(&self.table);
-        self.changes.update(&self.is_dimension);
     }
 }
 

--- a/rust/tableau_summary/src/twb/diff/util.rs
+++ b/rust/tableau_summary/src/twb/diff/util.rs
@@ -133,6 +133,13 @@ impl ChangeMap {
     pub fn get(&self, state: ChangeState) -> usize {
         self.0.get(&state).copied().unwrap_or_default()
     }
+
+    pub fn get_most_changes(&self) -> ChangeState {
+        self.0.iter()
+            .max_by(|(_, a), (_,b)| a.cmp(b))
+            .map(|(k, _)| *k)
+            .unwrap_or_default()
+    }
 }
 
 


### PR DESCRIPTION
Instead of counting each individual piece of the column as a change (e.g. name, type, calculation, ...), we instead only count a change if any item has changed.