### PR TITLE
Moved `git-xet migrate` to `git xet repo migrate`

### DIFF
--- a/rust/gitxetcore/src/command/mod.rs
+++ b/rust/gitxetcore/src/command/mod.rs
@@ -45,7 +45,7 @@ use crate::errors;
 use crate::git_integration::git_version_checks::perform_git_version_check;
 use crate::git_integration::hook_command_entry::{handle_hook_plumb_command, HookCommandShim};
 
-use self::migrate::{migrate_command, MigrateArgs};
+use self::repo::{repo_command, RepoCommandShim};
 
 mod cas_plumb;
 mod checkout;
@@ -62,10 +62,10 @@ mod lazy;
 pub mod login;
 mod materialize;
 mod merkledb;
-mod migrate;
 pub mod mount;
 mod pointer;
 mod push;
+mod repo;
 mod repo_size;
 mod s3config;
 mod smudge;
@@ -172,10 +172,8 @@ pub enum Command {
     /// Configure access to the XetHub S3 service.
     S3config(S3configArgs),
 
-    /// Migrate an external repository to a new XetHub repository. All commits, branches,
-    /// and other files are converted, history is fully preserved, and all data files stored
-    /// as LFS or Xet pointer files are imported.
-    Migrate(MigrateArgs),
+    /// Repo level actions such as migrating repos.
+    Repo(RepoCommandShim),
 }
 
 const GIT_VERSION: &str = git_version!(
@@ -300,7 +298,7 @@ impl Command {
             Command::Dematerialize(args) => dematerialize_command(cfg, args).await,
             Command::Cp(args) => cp_command(cfg, args).await,
             Command::S3config(args) => s3config_command(cfg, args),
-            Command::Migrate(args) => migrate_command(cfg, args).await,
+            Command::Repo(args) => repo_command(cfg, args).await,
         };
         if let Ok(mut axe) = axe {
             axe.command_complete().await;
@@ -337,7 +335,7 @@ impl Command {
             Command::Dematerialize(_) => true,
             Command::Cp(_) => true,
             Command::S3config(_) => true,
-            Command::Migrate(_) => true,
+            Command::Repo(_) => true,
         }
     }
 
@@ -370,7 +368,7 @@ impl Command {
             Command::Dematerialize(_) => "dematerialize".to_string(),
             Command::Cp(_) => "cp".to_string(),
             Command::S3config(_) => "s3config".to_string(),
-            Command::Migrate(_) => "migrate".to_string(),
+            Command::Repo(args) => format!("repo.{}", args.subcommand_name()),
         }
     }
     pub fn long_running(&self) -> bool {


### PR DESCRIPTION
In discussion with @erinys, change API of `git xet migrate` to `git xet repo migrate` in order to allow for more repo level commands in the future.  API is the same for the command itself.