### PR TITLE
Fix compression reporting bug

### DIFF
--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -772,7 +772,8 @@ impl PointerFileTranslatorV2 {
         )
         .log_error("LZ4 compression error")
         .map(|out| out.len())
-        .unwrap_or(raw_bytes_len);
+        .unwrap_or(raw_bytes_len)
+        .min(raw_bytes_len);
 
         let metadata = CASChunkSequenceHeader::new_with_compression(
             cas_hash,


### PR DESCRIPTION
lz4 compressed size can be larger than the original size. For example, I added `10/` and `11/` under https://xethub.com/XetHub/Flickr30k/src/branch/main/flickr30k_images and got:
```
di@di-mbp ~/tt/int64 % git add .
Git-Xet 0.13.4: Processing data: 76.37 MiB | 23.10 MiB/s, done.
76.37 MiB added, stored 76.63 MiB (-0.3% reduction)
```