### PR TITLE
Allow bitmap zones

### DIFF
--- a/rust/tableau_summary/src/twb/summary/dashboard.rs
+++ b/rust/tableau_summary/src/twb/summary/dashboard.rs
@@ -108,7 +108,13 @@ fn get_name_type(z: &raw::dashboard::Zone, view: &View, title: &str) -> (String,
             } else {
                 "Filter".to_string()
             }
-        }
+        },
+        "bitmap" => {
+            z.param.as_ref()
+                .and_then(|p| p.split('/').last())
+                .unwrap_or("Image")
+                .to_string()
+        },
         "" => {
             ztype = "sheet".to_string();
             if let Some(ref zname) = z.name {


### PR DESCRIPTION
Fixes: TAB-114

Now when a user puts an image in their dashboard (type: `bitmap`), we extract the name of the image properly.