### PR TITLE
Overwrite xetblob file on parse failure

### DIFF
--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -133,7 +133,7 @@ impl XetRepo {
                 config.permission.create_dir_all(&repo_path)?;
                 // check if there are already contents under the directory and
                 // if they represent the same repo as "remote" on server
-                Self::verify_repo_info(&repo_path, &repo_info, &raw_response)?;
+                Self::verify_repo_info(&repo_path, &repo_info, &raw_response, &config)?;
 
                 Self::open_v2_repo(Some(config), overrides, &repo_path, bbq_client, repo_info).await
             }
@@ -280,6 +280,7 @@ impl XetRepo {
         path: &Path,
         repo_info: &RepoInfo,
         raw_response: &[u8],
+        config: &XetConfig,
     ) -> anyhow::Result<()> {
         let xet_repo_info_file = path.join(XET_REPO_INFO_FILE);
 
@@ -302,7 +303,7 @@ impl XetRepo {
         // repo changed, delete all contents and write out the repo info
         if repo_changed {
             std::fs::remove_dir_all(path)?;
-            std::fs::create_dir_all(path)?;
+            config.permission.create_dir_all(path)?;
             write_all_file_safe(&path.join(XET_REPO_INFO_FILE), raw_response)?;
         }
 

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -286,10 +286,9 @@ impl XetRepo {
 
         // Try to parse a RepoInfo struct from maybe some bytes from a maybe existing metadata file.
         // Any failure leads to overwriting the file.
-        let saved_repo_info = std::fs::read(&xet_repo_info_file)
-            .map(|bytes| serde_json::de::from_slice::<RepoInfo>(&bytes).ok())
+        let saved_repo_info = std::fs::read(xet_repo_info_file)
             .ok()
-            .flatten();
+            .and_then(|bytes| serde_json::de::from_slice::<RepoInfo>(&bytes).ok());
 
         let repo_changed = match saved_repo_info {
             // Either:
@@ -1058,10 +1057,9 @@ mod tests {
         let dir = std::fs::read_dir(dirs::home_dir().unwrap().join(".xet").join("repos")).unwrap();
         for repo in dir.into_iter() {
             let xet_repo_info_file = repo.unwrap().path().join(XET_REPO_INFO_FILE);
-            let saved_repo_info = std::fs::read(&xet_repo_info_file)
-                .map(|bytes| serde_json::de::from_slice::<RepoInfo>(&bytes).ok())
+            let saved_repo_info = std::fs::read(xet_repo_info_file)
                 .ok()
-                .flatten();
+                .and_then(|bytes| serde_json::de::from_slice::<RepoInfo>(&bytes).ok());
 
             if let Some(repo_info) = saved_repo_info {
                 eprintln!("{}", repo_info.repo.html_url);


### PR DESCRIPTION
We added an extra field `cas` to the RepoInfo struct. `serde` parsing old saved info will fail. Tested locally that this will overwrite the repo metadata file on parse failure and then carry on operations correctly.