### PR TITLE
Better list diffs for Twb/Tds summaries

### DIFF
--- a/rust/tableau_summary/Cargo.toml
+++ b/rust/tableau_summary/Cargo.toml
@@ -14,6 +14,7 @@ tracing = "0.1.40"
 regex = "1.10.3"
 once_cell = "1.19.0"
 url = "2.5.0"
+imara-diff = "0.1.5"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/rust/tableau_summary/src/tds/mod.rs
+++ b/rust/tableau_summary/src/tds/mod.rs
@@ -23,7 +23,7 @@ pub struct TdsAnalyzer {
 }
 
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 #[repr(u32)]
 pub enum TdsSummaryVersioner {
     #[default]
@@ -46,7 +46,7 @@ impl TdsSummary {
 
 /// A summary of a Tableau Datasource File (*.tds) providing the
 /// schema.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TdsSummaryV2 {
     pub datasource: Datasource,
 }
@@ -62,7 +62,7 @@ impl From<&TdsSummaryV1> for TdsSummaryV2 {
 
 /// A summary of a Tableau Datasource File (*.tds) providing the
 /// schema.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TdsSummaryV1 {
     pub datasource: DatasourceV1,
 }

--- a/rust/tableau_summary/src/twb/diff/dashboard.rs
+++ b/rust/tableau_summary/src/twb/diff/dashboard.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use crate::twb::diff::util::{ChangeMap, ChangeState, DiffItem, DiffProducer};
 use crate::twb::summary::dashboard::{Dashboard, Zone};
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct DashboardDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,
@@ -70,7 +70,7 @@ impl DiffProducer<Dashboard> for DashboardDiff {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct ZoneDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,

--- a/rust/tableau_summary/src/twb/diff/datasource.rs
+++ b/rust/tableau_summary/src/twb/diff/datasource.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use crate::twb::diff::util::{ChangeMap, ChangeState, DiffItem, DiffProducer};
 use crate::twb::summary::datasource::{Column, Datasource, Table, TableRelationship};
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct DatasourceDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,
@@ -79,7 +79,7 @@ impl DiffProducer<Datasource> for DatasourceDiff {
 }
 
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TableDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,
@@ -140,7 +140,7 @@ impl DiffProducer<Table> for TableDiff {
 }
 
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct ColumnDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,

--- a/rust/tableau_summary/src/twb/diff/schema.rs
+++ b/rust/tableau_summary/src/twb/diff/schema.rs
@@ -10,7 +10,7 @@ use crate::twb::TwbSummary;
 pub const DIFF_VERSION: usize = 1;
 
 /// Diff content for a Twb diff. Currently an enum of different schema versions.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
 #[serde(untagged)]
 pub enum TwbSummaryDiffContent {
     V0(TwbSummaryDiffContentV0),
@@ -45,7 +45,7 @@ impl DiffProducer<TwbSummary> for TwbSummaryDiffContent {
 }
 
 /// V0 diff format: A before/after of the entire summary.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TwbSummaryDiffContentV0 {
     pub before: Option<TwbSummary>,
     pub after: Option<TwbSummary>,
@@ -75,7 +75,7 @@ impl DiffProducer<TwbSummary> for TwbSummaryDiffContentV0 {
 }
 
 /// V1 diff format: Detailed diffs for the datasources, worksheets, and dashboards.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TwbSummaryDiffContentV1 {
     pub wb_version: DiffItem<String>,
     pub datasources: Vec<DatasourceDiff>,

--- a/rust/tableau_summary/src/twb/diff/worksheet.rs
+++ b/rust/tableau_summary/src/twb/diff/worksheet.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use crate::twb::diff::util::{ChangeMap, ChangeState, DiffItem, DiffProducer};
 use crate::twb::summary::worksheet::{Filter, Item, Mark, Table, Worksheet};
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct WorksheetDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,
@@ -66,7 +66,7 @@ impl DiffProducer<Worksheet> for WorksheetDiff {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TableDiff {
     pub status: ChangeState,
     pub changes: ChangeMap,

--- a/rust/tableau_summary/src/twb/mod.rs
+++ b/rust/tableau_summary/src/twb/mod.rs
@@ -37,7 +37,7 @@ pub struct TwbAnalyzer {
     content_buffer: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 #[repr(u32)]
 pub enum TwbSummaryVersioner {
     #[default]
@@ -61,7 +61,7 @@ impl TwbSummary {
 /// A summary of a Tableau Workbook File (*.twb) providing the
 /// key components of a workbook.
 /// V2 adds in Datasource relations.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TwbSummaryV2 {
     pub wb_version: String,
     pub datasources: Vec<Datasource>,
@@ -84,7 +84,7 @@ impl From<&TwbSummaryV1> for TwbSummaryV2 {
 /// key components of a workbook.
 ///
 /// repository-location indicates the views of the workbook
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TwbSummaryV1 {
     pub wb_version: String,
     pub datasources: Vec<DatasourceV1>,

--- a/rust/tableau_summary/src/twb/summary/dashboard.rs
+++ b/rust/tableau_summary/src/twb/summary/dashboard.rs
@@ -6,7 +6,7 @@ use crate::twb::raw::datasource::substituter;
 use crate::twb::raw::worksheet::table::View;
 use crate::twb::summary::worksheet::get_name_discrete;
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Dashboard {
     pub name: String,
     pub title: String,
@@ -15,7 +15,7 @@ pub struct Dashboard {
     pub zones: Zone,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Zone {
     pub zone_type: String,
     pub name: String,

--- a/rust/tableau_summary/src/twb/summary/datasource.rs
+++ b/rust/tableau_summary/src/twb/summary/datasource.rs
@@ -10,7 +10,7 @@ use crate::twb::raw::datasource::object_graph::{Relationship, TableauObject};
 use crate::twb::raw::datasource::substituter::ColumnFinder;
 use crate::twb::summary::util;
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct DatasourceV1 {
     pub name: String,
     pub version: String,
@@ -18,7 +18,7 @@ pub struct DatasourceV1 {
     pub added_columns: Option<Table>,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Datasource {
     pub name: String,
     pub version: String,
@@ -27,14 +27,14 @@ pub struct Datasource {
     pub relations: Vec<TableRelationship>,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Table {
     pub name: String,
     pub dimensions: Vec<Column>,
     pub measures: Vec<Column>,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Column {
     pub name: String,
     pub datatype: String,
@@ -92,7 +92,7 @@ impl From<&DatasourceV1> for Datasource {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct TableRelationship {
     pub table1: String,
     pub table2: String,

--- a/rust/tableau_summary/src/twb/summary/worksheet.rs
+++ b/rust/tableau_summary/src/twb/summary/worksheet.rs
@@ -5,7 +5,7 @@ use crate::twb::raw::worksheet::RawWorksheet;
 use crate::twb::raw::worksheet::table::{Encoding, MEASURE_NAMES_COL_NAME, View};
 use crate::twb::summary::util::{strip_brackets, strip_quotes};
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Worksheet {
     pub name: String,
     pub title: String,
@@ -26,7 +26,7 @@ impl From<&RawWorksheet> for Worksheet {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Table {
     pub rows: Vec<Item>,
     pub cols: Vec<Item>,
@@ -37,20 +37,20 @@ pub struct Table {
     pub tooltip: String,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Filter {
     pub item: Item,
     pub range: Option<(String, String)>,
     // TODO: we might want to show more info, like the sort order or categorical filtering.
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Mark {
     pub class: String,
     pub item: Item,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Item {
     pub name: String,
     pub is_discrete: bool,


### PR DESCRIPTION
Fixes: TAB-87

Switches diffs to use the Myers diff algorithm implemented using the [imara-diff](https://github.com/pascalkuthe/imara-diff) crate, allowing for minimal diffs between two lists of items.

* Summary/Diff structs  need to have `Eq + Hash` traits defined.
* Adds a `DiffTokenSource` to provide tokens from a list of some T to the diff algorithm.
* Adds a `DiffSync` to process "hunks" of changes that the diff algorithm produces (e.g. `before[1..3]` and `after[2..4]` differ).