### PR TITLE
Drop some info statements to debug.

### DIFF
--- a/rust/cache/src/disk/cache.rs
+++ b/rust/cache/src/disk/cache.rs
@@ -76,7 +76,7 @@ impl DiskCache {
         //       order that they're read in, which isn't technically correct for LRU.
         //       We may want to consider loading the files in order of accessed_time
         //       (as long as the cache FS was mounted with accessed_time metadata).
-        info!(
+        debug!(
             "Successfully initialized cache dir at {:?} , loading existing files into cache",
             self.disk_manager.get_root_dir()
         );
@@ -90,7 +90,11 @@ impl DiskCache {
             error!("Error loading files from root dir into the cache: {:?}", e);
             return Err(e);
         }
-        info!("Loaded {} files from cache dir into Disk Cache", num_files);
+        info!(
+            "Loaded {} files from cache dir at {:?} into disk cache",
+            num_files,
+            self.disk_manager.get_root_dir()
+        );
         Ok(())
     }
 }

--- a/rust/cache/src/disk/cache.rs
+++ b/rust/cache/src/disk/cache.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::disk::size_bound::{CacheValue, SizeBoundCache};
 use crate::disk::storage::DiskManager;
@@ -90,7 +90,7 @@ impl DiskCache {
             error!("Error loading files from root dir into the cache: {:?}", e);
             return Err(e);
         }
-        info!(
+        debug!(
             "Loaded {} files from cache dir at {:?} into disk cache",
             num_files,
             self.disk_manager.get_root_dir()

--- a/rust/cas_client/src/caching_client.rs
+++ b/rust/cas_client/src/caching_client.rs
@@ -43,11 +43,6 @@ impl<T: Client + Debug + Sync + Send + 'static> CachingClient<T> {
         let client_remote_arc: Arc<dyn Remote> =
             Arc::new(ClientRemoteAdapter::new(arcclient.clone()));
 
-        info!(
-            "Creating CachingClient {:?} with capacity {} blocksize {:?}",
-            cache_path, capacity_bytes, blocksize
-        );
-
         let cache = cache::from_config::<CasClientError>(
             cache::CacheConfig {
                 cache_dir: canonical_string_path.to_string(),
@@ -56,6 +51,11 @@ impl<T: Client + Debug + Sync + Send + 'static> CachingClient<T> {
             },
             client_remote_arc,
         )?;
+
+        info!(
+            "Creating CachingClient, path={:?}, byte capacity={}, blocksize={:?}",
+            cache_path, capacity_bytes, blocksize
+        );
 
         Ok(CachingClient {
             client: arcclient,

--- a/rust/cas_client/src/data_transport.rs
+++ b/rust/cas_client/src/data_transport.rs
@@ -32,7 +32,7 @@ use retry_strategy::RetryStrategy;
 use rustls_pemfile::Item;
 use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::CertificateDer;
-use tracing::{debug, error, info, info_span, warn, Instrument, Span};
+use tracing::{debug, error, info_span, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use xet_error::Error;
 
@@ -106,7 +106,7 @@ fn retry_http_status_code(stat: &hyper::StatusCode) -> bool {
 fn is_status_retriable_and_print(err: &RetryError) -> bool {
     let ret = is_status_retriable(err);
     if ret {
-        info!("{}. Retrying...", err);
+        debug!("{}. Retrying...", err);
     }
     ret
 }
@@ -284,7 +284,7 @@ impl DataTransport {
             .to_vec();
         let payload_size = bytes.len();
         let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-        info!(
+        debug!(
             "GET; encoding: ({}), uncompressed size: ({}), payload ({})  prefix: ({}), hash: ({})",
             encoding.as_str_name(),
             uncompressed_size.unwrap_or_default(),
@@ -346,7 +346,7 @@ impl DataTransport {
                         .to_vec();
                     let payload_size = bytes.len();
                     let bytes = maybe_decode(bytes.as_slice(), encoding, uncompressed_size)?;
-                    info!("GET RANGE; encoding: ({}), uncompressed size: ({}), payload ({}) prefix: ({}), hash: ({})", encoding.as_str_name(), uncompressed_size.unwrap_or_default(), payload_size, prefix, hash);
+                    debug!("GET RANGE; encoding: ({}), uncompressed size: ({}), payload ({}) prefix: ({}), hash: ({})", encoding.as_str_name(), uncompressed_size.unwrap_or_default(), payload_size, prefix, hash);
                     Ok(bytes.to_vec())
                 },
                 is_status_retriable_and_print,
@@ -367,7 +367,7 @@ impl DataTransport {
     ) -> Result<()> {
         let full_size = data.len();
         let data = maybe_encode(data, encoding)?;
-        info!(
+        debug!(
             "PUT; encoding: ({}), uncompressed size: ({}), payload: ({}), prefix: ({}), hash: ({})",
             encoding.as_str_name(),
             full_size,

--- a/rust/cas_client/src/grpc.rs
+++ b/rust/cas_client/src/grpc.rs
@@ -52,7 +52,7 @@ lazy_static::lazy_static! {
 }
 
 async fn get_channel(endpoint: &str, root_ca: &Option<Arc<String>>) -> Result<Channel> {
-    info!("server name: {}", endpoint);
+    debug!("server name: {}", endpoint);
     let mut server_uri: Uri = endpoint
         .parse()
         .map_err(|e| CasClientError::ConfigurationError(format!("Error parsing endpoint: {e}.")))?;
@@ -71,7 +71,7 @@ async fn get_channel(endpoint: &str, root_ca: &Option<Arc<String>>) -> Result<Ch
         server_uri = format!("{scheme}://{endpoint}").parse().unwrap();
     }
 
-    info!("Server URI: {}", server_uri);
+    debug!("Connecting to URI: {}", server_uri);
 
     let mut builder = Channel::builder(server_uri);
     if let Some(root_ca) = root_ca {
@@ -352,7 +352,7 @@ impl GrpcClient {
         );
 
         if !response.into_inner().was_inserted {
-            info!(
+            debug!(
                 "GrpcClient Req {}: XORB {}/{} not inserted; already present.",
                 get_request_id(),
                 prefix,

--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -293,7 +293,7 @@ If you believe this to be an error, reach out to contact@xethub.com or your admi
             }
         }
 
-        tracing::info!("CAS endpoint: {}", cas);
+        tracing::debug!("Config: CAS endpoint set to: {cas}");
 
         Ok(cas.clone())
     }

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -304,7 +304,7 @@ impl PointerFileTranslatorV2 {
         };
 
         let Some(shard_hash) = shard_hash_opt else {
-            info!("get_hinted_shard_list_for_file: file reconstruction found in non-permanent shard, ignoring.");
+            debug!("get_hinted_shard_list_for_file: file reconstruction found in non-permanent shard, ignoring.");
             return Ok(<_>::default());
         };
 
@@ -377,12 +377,12 @@ impl PointerFileTranslatorV2 {
             analyzers_active = true;
         }
         if path.extension() == Some(OsStr::new("twb")) {
-            info!("Including TWB analyzer (file extension .twb)");
+            debug!("Including TWB analyzer (file extension .twb)");
             analyzers.twb = Some(TwbAnalyzer::new());
             analyzers_active = true;
         }
         if path.extension() == Some(OsStr::new("tds")) {
-            info!("Including TDS analyzer (file extension .tds)");
+            debug!("Including TDS analyzer (file extension .tds)");
             analyzers.tds = Some(TdsAnalyzer::new());
             analyzers_active = true;
         }
@@ -503,7 +503,7 @@ impl PointerFileTranslatorV2 {
 
                             global_dedup_queries.spawn(async move {
                                 let Ok(query_result) = remote_shards.query_dedup_shard_by_chunk(&query_chunk, &salt).await.map_err(|e| {
-                                    warn!("Error encountered attempting to query global dedup table: {e:?}; ignoring.");
+                                    debug!("Error encountered attempting to query global dedup table: {e:?}; ignoring.");
                                     e
                                 })
                                     else { return false; };
@@ -521,7 +521,7 @@ impl PointerFileTranslatorV2 {
                                 })
                                     else { return false; };
 
-                                info!("global dedup: New shard {shard_hash:?} can be used for deduplication of {path:?}; reprocessing file.");
+                                debug!("global dedup: New shard {shard_hash:?} can be used for deduplication of {path:?}; reprocessing file.");
 
                                 true
                             });
@@ -545,7 +545,7 @@ impl PointerFileTranslatorV2 {
                 if !has_new_shards {
                     break;
                 } else {
-                    info!("New shard(s) available for dedup on {path:?}; reprocessing chunks.");
+                    debug!("New shard(s) available for dedup on {path:?}; reprocessing chunks.");
                 }
             }
 
@@ -965,7 +965,7 @@ impl PointerFileTranslatorV2 {
         passthrough: bool,
         range: Option<(usize, usize)>,
     ) -> Result<()> {
-        info!("Smudging file {:?}", &path);
+        debug!("Smudging file {:?}", &path);
 
         let (fi, data) =
             pointer_file_from_reader(path, &mut reader, self.cfg.force_no_smudge).await?;
@@ -991,7 +991,7 @@ impl PointerFileTranslatorV2 {
         } else {
             // Now, the file gets passed through.
             if passthrough {
-                info!("{:?} is not a valid pointer file. Passing through", path);
+                debug!("{:?} is not a valid pointer file. Passing through", path);
             } else {
                 error!("Invalid Pointer File");
                 return Err(GitXetRepoError::Other("Invalid Pointer File".into()));

--- a/rust/gitxetcore/src/data/mdb.rs
+++ b/rust/gitxetcore/src/data/mdb.rs
@@ -252,7 +252,7 @@ fn sync_mdb_shards_meta_from_git(
     cache_head: &Path,
     notesref: &str,
 ) -> errors::Result<Option<Oid>> {
-    info!("Sync shards meta from git");
+    debug!("Sync shards meta from git");
     let ref_notes_head = ref_to_oid(config, notesref)?;
 
     if ref_notes_head.is_none() {
@@ -313,7 +313,7 @@ async fn sync_mdb_shards_from_cas(
     cache_meta: &Path,
     cache_dir: &Path,
 ) -> errors::Result<()> {
-    info!("Sync shards from CAS");
+    debug!("Sync shards from CAS");
 
     let metas = MDBShardMetaCollection::open(cache_meta)?;
 
@@ -389,7 +389,7 @@ pub async fn download_shard(
         );
         return Ok((dest_file, 0));
     } else {
-        info!(
+        debug!(
             "download_shard: shard file {shard_name:?} does not exist in local cache, downloading from cas."
         );
     }
@@ -647,7 +647,7 @@ pub async fn sync_session_shards_to_remote(
             // 1. Upload directly to CAS.
             // 2. Sync to server.
 
-            info!(
+            debug!(
                 "Uploading shard {shard_prefix_ref}/{:?} from staging area to CAS.",
                 &si.shard_hash
             );
@@ -662,7 +662,7 @@ pub async fn sync_session_shards_to_remote(
             )
             .await?;
 
-            info!(
+            debug!(
                 "Registering shard {shard_prefix_ref}/{:?} with shard server.",
                 &si.shard_hash
             );
@@ -673,7 +673,7 @@ pub async fn sync_session_shards_to_remote(
                 .await?;
 
             info!(
-                "Shard {shard_prefix_ref}/{:?} upload + sync successful.",
+                "Shard {shard_prefix_ref}/{:?} upload + sync completed successfully.",
                 &si.shard_hash
             );
 
@@ -804,7 +804,7 @@ pub fn get_mdb_version(repo_path: &Path, config: &XetConfig) -> errors::Result<S
     }
 
     let Ok(repo) = open_libgit2_repo(repo_path).map_err(|e| {
-        info!("get_mdb_version: Repo path {repo_path:?} does note appear to be a repository ({e}); defaulting to ShardVersion::V2.");
+        info!("get_mdb_version: Repo path {repo_path:?} does not appear to be a repository ({e}); defaulting to ShardVersion::V2.");
         e
     }) else {
         return Ok(ShardVersion::V2);

--- a/rust/gitxetcore/src/data/remote_shard_interface.rs
+++ b/rust/gitxetcore/src/data/remote_shard_interface.rs
@@ -139,11 +139,11 @@ impl RemoteShardInterface {
         repo_salt: Option<RepoSalt>,
     ) -> Result<Arc<Self>> {
         let cas_endpoint = config.cas_endpoint().await?;
-        info!("data_processing: Cas endpoint = {:?}", cas_endpoint);
+        debug!("data_processing: Cas endpoint = {:?}", cas_endpoint);
 
         let shard_client = {
             if config.smudge_query_policy != SmudgeQueryPolicy::LocalOnly {
-                info!("data_processing: Setting up file reconstructor to query shard server.");
+                debug!("data_processing: Setting up file reconstructor to query shard server.");
                 let (user_id, _) = config.user.get_user_id();
 
                 let shard_file_config = shard_client::ShardConnectionConfig {

--- a/rust/gitxetcore/src/xetblob/bbq_queries.rs
+++ b/rust/gitxetcore/src/xetblob/bbq_queries.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{debug, info};
+use tracing::debug;
 use url::Url;
 
 const NUM_RETRIES: usize = 5;
@@ -79,7 +79,7 @@ impl BbqClient {
             format!("/api/xet/repos{base_path}/bbq/{query_type}/{branch}/{filename}")
         };
         let mut bbq_url = remote_base_url;
-        info!("Querying {bbq_path}, type = {query_type}");
+        debug!("Querying {bbq_path}");
         bbq_url.set_path(&bbq_path);
 
         // build the query and ask for the contents
@@ -117,7 +117,7 @@ impl BbqClient {
         let api_path = format!("/api/xet/repos{base_path}/{op}");
         let api_path = api_path.trim_end_matches('/');
         let mut api_url = remote_base_url.clone();
-        info!("Querying {}", api_path);
+        debug!("Querying {api_path}");
         api_url.set_path(api_path);
         if http_command != "get"
             && http_command != "post"

--- a/rust/gitxetcore/src/xetblob/bbq_queries.rs
+++ b/rust/gitxetcore/src/xetblob/bbq_queries.rs
@@ -79,7 +79,7 @@ impl BbqClient {
             format!("/api/xet/repos{base_path}/bbq/{query_type}/{branch}/{filename}")
         };
         let mut bbq_url = remote_base_url;
-        info!("Querying {}", bbq_path);
+        info!("Querying {bbq_path}, type = {query_type}");
         bbq_url.set_path(&bbq_path);
 
         // build the query and ask for the contents

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -18,6 +18,7 @@ use cas::gitbaretools::{Action, JSONCommand};
 use cas::safeio::write_all_file_safe;
 use core::panic;
 use git_repo_salt::repo_salt_from_bytes;
+use lazy_static::lazy_static;
 use mdb_shard::constants::MDB_SHARD_MIN_TARGET_SIZE;
 use mdb_shard::session_directory::consolidate_shards_in_directory;
 use mdb_shard::shard_version::ShardVersion;
@@ -28,6 +29,7 @@ use remote_shard_interface::GlobalDedupPolicy;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use tempdir::TempDir;
 use tokio::sync::Mutex;
@@ -79,6 +81,18 @@ pub struct XetRepoWriteTransaction {
 
     #[allow(dead_code)]
     shard_session_dir: TempDir,
+
+    // For tracking which transactions complete and which do not
+    #[allow(dead_code)]
+    transaction_tag: usize,
+}
+
+lazy_static! {
+    static ref REPO_WRITE_TRANSACTION_TAG_COUNTER: AtomicUsize = AtomicUsize::new(0);
+}
+
+fn new_transaction_tag() -> usize {
+    REPO_WRITE_TRANSACTION_TAG_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 impl XetRepo {
@@ -512,6 +526,9 @@ impl XetRepo {
             }),
             PFTRouter::V2(_) => XRWTMdbSwitch::MdbV2(XRWTMdbInfoV2 {}),
         };
+        let transaction_tag = new_transaction_tag();
+
+        info!("Transaction {transaction_tag}: Start.");
 
         // we make a new translator
         Ok(XetRepoWriteTransaction {
@@ -528,6 +545,7 @@ impl XetRepo {
             mdb,
             translator,
             shard_session_dir,
+            transaction_tag,
         })
     }
 
@@ -647,6 +665,10 @@ impl XetRepoWriteTransaction {
     /// Opens a file a for write, returning a XetWFileObject
     /// which provides file write capability
     pub async fn open_for_write(&mut self, filename: &str) -> anyhow::Result<Arc<XetWFileObject>> {
+        info!(
+            "Transaction {}: open_for_write: {filename}",
+            self.transaction_tag
+        );
         let ret = Arc::new(XetWFileObject::new(filename, self.translator.clone()));
         self.files
             .insert(filename.to_string(), NewFileSource::NewFile(ret.clone()));
@@ -718,6 +740,7 @@ impl XetRepoWriteTransaction {
             }
         }
         self.translator.finalize_cleaning().await?;
+        info!("Transaction {} canceled.", self.transaction_tag);
         Ok(())
     }
 
@@ -726,6 +749,10 @@ impl XetRepoWriteTransaction {
     /// is in the config if not provided.
     /// If neither config or parameter is available, an error is thrown.
     pub async fn commit(mut self, commit_message: &str) -> anyhow::Result<()> {
+        info!(
+            "Committing transaction {} ({commit_message})",
+            self.transaction_tag
+        );
         for i in self.files.iter() {
             if let NewFileSource::NewFile(ref f) = i.1 {
                 f.close().await?;
@@ -752,6 +779,7 @@ impl XetRepoWriteTransaction {
             .await?;
 
         self.invalidate_bbq_cache().await;
+        info!("Transaction {} committed.", self.transaction_tag);
         Ok(())
     }
 
@@ -1012,13 +1040,14 @@ impl XetRepoWriteTransaction {
             };
             let git_object_commit_command = serde_json::to_string(&command)
                 .map_err(|_| anyhow!("Unexpected serialization error for {:?}", command))?;
-            info!("{git_object_commit_command}");
+            debug!("Commiting git object: {git_object_commit_command}");
 
             let remote_base_url = self.remote_base_url.clone();
 
             // TODO: If this really slow, then it can easily be parallelized.  For now, do it
             // sequentially
             perform_atomic_commit_query(remote_base_url, &git_object_commit_command).await?;
+            debug!("Commit of git object completed: {git_object_commit_command}.");
         }
 
         Ok(())

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -1020,6 +1020,14 @@ impl XetRepoWriteTransaction {
 
         commit_boundaries.push(actions.len());
 
+        info!(
+            "Transaction {}: Committing {} operations ({} new files) in {} commits.",
+            self.transaction_tag,
+            actions.len(),
+            self.files.len(),
+            commit_boundaries.len() - 1
+        );
+
         for (lb_i, ub_i) in commit_boundaries[..(commit_boundaries.len() - 1)]
             .iter()
             .zip(&commit_boundaries[1..])

--- a/rust/mdb_shard/src/shard_file_handle.rs
+++ b/rust/mdb_shard/src/shard_file_handle.rs
@@ -7,7 +7,7 @@ use crate::{shard_format::MDBShardInfo, utils::parse_shard_filename};
 use merklehash::{compute_data_hash, HashedWrite, MerkleHash};
 use std::io::{BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
-use tracing::{error, info, warn};
+use tracing::{error, debug, warn};
 
 /// When a specific implementation of the  
 ///
@@ -93,13 +93,13 @@ impl MDBShardFile {
                     if let Some(h) = parse_shard_filename(file_name) {
                         shards.push((h, std::fs::canonicalize(entry.path())?));
                     }
-                    info!("Found shard file '{file_name:?}'.");
+                    debug!("Found shard file '{file_name:?}'.");
                 }
             }
         } else if let Some(file_name) = path.to_str() {
             if let Some(h) = parse_shard_filename(file_name) {
                 shards.push((h, std::fs::canonicalize(path)?));
-                info!("Registerd shard file '{file_name:?}'.");
+                debug!("Registerd shard file '{file_name:?}'.");
             } else {
                 return Err(MDBShardError::BadFilename(format!(
                     "Filename {file_name} not valid shard file name."
@@ -126,6 +126,7 @@ impl MDBShardFile {
                 s.verify_shard_integrity_debug_only();
             }
         }
+
         Ok(ret)
     }
 
@@ -200,10 +201,10 @@ impl MDBShardFile {
     }
 
     pub fn verify_shard_integrity(&self) {
-        info!("Verifying shard integrity for shard {:?}", &self.path);
+        debug!("Verifying shard integrity for shard {:?}", &self.path);
 
-        info!("Header : {:?}", self.shard.header);
-        info!("Metadata : {:?}", self.shard.metadata);
+        debug!("Header : {:?}", self.shard.header);
+        debug!("Metadata : {:?}", self.shard.metadata);
 
         let mut reader = self
             .get_reader()
@@ -246,7 +247,7 @@ impl MDBShardFile {
             .unwrap();
 
         debug_assert_eq!(fir.len() as u64, self.shard.metadata.file_lookup_num_entry);
-        info!("Integrity test passed for shard {:?}", &self.path);
+        debug!("Integrity test passed for shard {:?}", &self.path);
 
         // TODO: More parts; but this will at least succeed on the server end.
     }

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -218,12 +218,14 @@ impl ShardFileManager {
             }
         }
 
-        info!(
-            "Registered {} new shards, for {} shards total. Chunk pre-lookup now has {} chunks.",
-            num_shards,
-            shards_lg.shard_list.len(),
-            shards_lg.chunk_lookup.len()
-        );
+        if num_shards != 0 {
+            info!(
+                "Registered {} new shards, for {} shards total. Chunk pre-lookup now has {} chunks.",
+                num_shards,
+                shards_lg.shard_list.len(),
+                shards_lg.chunk_lookup.len()
+            );
+        }
 
         Ok(())
     }

--- a/rust/mdb_shard/src/shard_file_manager.rs
+++ b/rust/mdb_shard/src/shard_file_manager.rs
@@ -424,7 +424,7 @@ impl MDBShardFlushGuard {
 
             Ok(Some(path))
         } else {
-            info!("Shard manager in ephemeral mode; skipping flush to disk.");
+            debug!("Shard manager in ephemeral mode; skipping flush to disk.");
             Ok(None)
         }
     }

--- a/rust/mdb_shard/src/shard_format.rs
+++ b/rust/mdb_shard/src/shard_format.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, debug};
 
 use crate::cas_structs::*;
 use crate::file_structs::*;
@@ -503,7 +503,7 @@ impl MDBShardInfo {
         // Chunk lookup hashes are Ok to have (many) collisions,
         // we will use a subset of collisions to do dedup.
         if num_indices == dest_indices.len() {
-            info!(
+            debug!(
                 "Found {:?} or more collisions when searching for truncated hash {:?}",
                 dest_indices.len(),
                 truncate_hash(chunk_hash)

--- a/rust/mdb_shard/src/shard_in_memory.rs
+++ b/rust/mdb_shard/src/shard_in_memory.rs
@@ -11,7 +11,7 @@ use std::{
 use merkledb::MerkleMemDB;
 use merkledb::{aggregate_hashes::with_salt, prelude_v2::MerkleDBReconstruction};
 use merklehash::{HashedWrite, MerkleHash};
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::{
     cas_structs::*,
@@ -353,7 +353,7 @@ impl MDBInMemoryShard {
 
         std::fs::rename(&temp_file_name, &full_file_name)?;
 
-        info!("Wrote out in-memory shard to {full_file_name:?}.");
+        debug!("Wrote out in-memory shard to {full_file_name:?}.");
 
         Ok(full_file_name)
     }

--- a/rust/shard_client/src/shard_client.rs
+++ b/rust/shard_client/src/shard_client.rs
@@ -57,7 +57,7 @@ lazy_static::lazy_static! {
 }
 
 async fn get_channel(endpoint: &str) -> anyhow::Result<Channel> {
-    info!("server name: {}", endpoint);
+    debug!("shard client get_channel: server name: {}", endpoint);
     let mut server_uri: Uri = endpoint.parse()?;
 
     // supports an absolute URI (above) or just the host:port (below)
@@ -74,7 +74,7 @@ async fn get_channel(endpoint: &str) -> anyhow::Result<Channel> {
         server_uri = format!("{scheme}://{endpoint}").parse().unwrap();
     }
 
-    info!("Server URI: {}", server_uri);
+    debug!("Server URI: {}", server_uri);
 
     let channel = Channel::builder(server_uri)
         .keep_alive_timeout(Duration::new(HTTP2_KEEPALIVE_TIMEOUT_SEC, 0))

--- a/rust/shard_client/src/shard_client.rs
+++ b/rust/shard_client/src/shard_client.rs
@@ -305,7 +305,7 @@ impl RegistrationClient for GrpcShardClient {
         force: bool,
         salt: &[u8; 32],
     ) -> Result<()> {
-        info!("Registering shard {prefix}/{hash} with salt {salt:x?}");
+        info!("Registering shard {prefix}/{hash} (w/ salt)");
         inc_request_id();
         Span::current().record("request_id", &get_request_id());
         debug!(


### PR DESCRIPTION
info! is too verbose for a lot of things that have been stable for a while, so this drops many of these to debug to make info! more informative.  This also adds some summary info! commands that pull together larger blocks of statements with more aggregation. 
Also, for tracking transactions, this PR adds a tag field so that reporting on transactions can be traced. 