### PR TITLE
Change zones to be allow multiple top-level Zone objects

### DIFF
--- a/rust/tableau_summary/src/twb/diff/dashboard.rs
+++ b/rust/tableau_summary/src/twb/diff/dashboard.rs
@@ -10,7 +10,7 @@ pub struct DashboardDiff {
     pub title: DiffItem<String>,
     pub thumbnail: DiffItem<Option<String>>,
     pub sheets: Vec<DiffItem<String>>,
-    pub zones: ZoneDiff,
+    pub zones: Vec<ZoneDiff>,
 }
 
 impl DashboardDiff {
@@ -19,7 +19,8 @@ impl DashboardDiff {
         self.changes.update(&self.title);
         self.changes.update_option(&self.thumbnail);
         self.changes.update_list(&self.sheets);
-        self.changes.merge(&self.zones.changes);
+        self.zones.iter()
+            .for_each(|z| self.changes.merge(&z.changes));
     }
 }
 
@@ -32,7 +33,7 @@ impl DiffProducer<Dashboard> for DashboardDiff {
             title: DiffItem::new_addition(&item.title),
             thumbnail: DiffItem::new_addition(&item.thumbnail),
             sheets: DiffItem::new_addition_list(&item.sheets),
-            zones: ZoneDiff::new_addition(&item.zones),
+            zones: ZoneDiff::new_addition_list(&item.zones),
         };
         diff.calculate_change_map();
         diff
@@ -46,7 +47,7 @@ impl DiffProducer<Dashboard> for DashboardDiff {
             title: DiffItem::new_deletion(&item.title),
             thumbnail: DiffItem::new_deletion(&item.thumbnail),
             sheets: DiffItem::new_deletion_list(&item.sheets),
-            zones: ZoneDiff::new_deletion(&item.zones),
+            zones: ZoneDiff::new_deletion_list(&item.zones),
         };
         diff.calculate_change_map();
         diff
@@ -60,7 +61,7 @@ impl DiffProducer<Dashboard> for DashboardDiff {
             title: DiffItem::new_diff(&before.title,&after.title),
             thumbnail: DiffItem::new_diff(&before.thumbnail,&after.thumbnail),
             sheets: DiffItem::new_diff_list(&before.sheets,&after.sheets),
-            zones: ZoneDiff::new_diff(&before.zones,&after.zones),
+            zones: ZoneDiff::new_diff_list(&before.zones,&after.zones),
         };
         diff.calculate_change_map();
         if diff.changes.is_empty() {

--- a/rust/tableau_summary/src/twb/raw/dashboard.rs
+++ b/rust/tableau_summary/src/twb/raw/dashboard.rs
@@ -17,7 +17,7 @@ pub struct RawDashboard {
     // PNG can be pulled using the ID in conjunction with a get_workbook call.
     pub thumbnail: Option<String>,
     pub view: View,
-    pub zones: Zone,
+    pub zones: Vec<Zone>,
 }
 
 impl<'a, 'b> From<Node<'a, 'b>> for RawDashboard {
@@ -27,6 +27,11 @@ impl<'a, 'b> From<Node<'a, 'b>> for RawDashboard {
             .and_then(|ch| ch.get_tagged_child("title"))
             .map(parse_formatted_text)
             .unwrap_or_default();
+        let zones = n.get_tagged_child("zones")
+            .iter()
+            .flat_map(|ch| ch.find_tagged_children("zone"))
+            .map(Zone::from)
+            .collect();
 
         Self {
             name: n.get_attr(NAME_KEY),
@@ -34,10 +39,7 @@ impl<'a, 'b> From<Node<'a, 'b>> for RawDashboard {
             thumbnail: n.get_tagged_child("repository-location")
                 .map(repository_location_to_thumbnail_name),
             view: View::from(n),
-            zones: n.get_tagged_child("zones")
-                .and_then(|ch|ch.get_tagged_child("zone"))
-                .map(Zone::from)
-                .unwrap_or_default(),
+            zones,
         }
     }
 }


### PR DESCRIPTION
Fixes: TAB-115

Since the `<zones>` tag might have multiple `<zone>` tags within, we need to change the Raw and Summary Dashboards to support this.

Note: this bumps up the schema version of the TwbSummary to 3 since this is a type change. We should make sure that the UI is able to accept these V3 schemas before merging.