### PR TITLE
Fixes for git xet migrate 502 transport error.

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1440,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1748,6 +1761,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3870,6 +3893,7 @@ version = "0.13.4"
 dependencies = [
  "anyhow",
  "error_printer",
+ "imara-diff",
  "itertools 0.12.1",
  "once_cell",
  "regex",
@@ -4932,6 +4956,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/rust/gitxetcore/src/git_integration/repo_migration.rs
+++ b/rust/gitxetcore/src/git_integration/repo_migration.rs
@@ -29,7 +29,10 @@ struct RepoInitTracking {
     git_lfs_init_lock: Mutex<()>,
 }
 
-pub async fn migrate_repo(src_repo: impl AsRef<Path>, xet_repo: &GitXetRepo) -> Result<()> {
+pub async fn migrate_repo(
+    src_repo: impl AsRef<Path>,
+    xet_repo: &GitXetRepo,
+) -> Result<Vec<String>> {
     let repo_init_tracking = Arc::new(RepoInitTracking::default());
 
     // Open the source repo
@@ -471,6 +474,8 @@ pub async fn migrate_repo(src_repo: impl AsRef<Path>, xet_repo: &GitXetRepo) -> 
         }
     }
 
+    let mut branch_list = Vec::new();
+
     // Convert all the references.  Ignore any in xet (as this imports things in a new way).
     {
         // Add some logic to update HEAD at the end to one of these.
@@ -524,6 +529,7 @@ pub async fn migrate_repo(src_repo: impl AsRef<Path>, xet_repo: &GitXetRepo) -> 
                 if branch_name == "master" {
                     importing_master = true;
                 }
+                branch_list.push(branch_name.to_owned());
 
                 eprintln!("Set up branch {branch_name}");
             } else if reference.is_note() {
@@ -601,7 +607,7 @@ pub async fn migrate_repo(src_repo: impl AsRef<Path>, xet_repo: &GitXetRepo) -> 
         }
     }
 
-    Ok(())
+    Ok(branch_list)
 }
 
 /// Translate old blob contents into new blob contents.


### PR DESCRIPTION
This PR adds a fix for the 502 transport error for when it seems pushing all the branches gets 
```
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
send-pack: unexpected disconnect while reading sideband packet
fatal: the remote end hung up unexpectedly
```
This fixes one possible cause, but then as backup pushes each branch individually.