### PR TITLE
Fixes significant slowdown when chunking huge buffers of constant data.

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1440,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1748,6 +1761,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+dependencies = [
+ "ahash 0.8.11",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3870,6 +3893,7 @@ version = "0.13.4"
 dependencies = [
  "anyhow",
  "error_printer",
+ "imara-diff",
  "itertools 0.12.1",
  "once_cell",
  "regex",
@@ -4932,6 +4956,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/rust/merkledb/src/async_chunk_iterator.rs
+++ b/rust/merkledb/src/async_chunk_iterator.rs
@@ -310,14 +310,20 @@ where
                             let mut consume_len;
                             let mut create_chunk = false;
                             // find a chunk boundary after minimum chunk
+
+                            // If we have a lot of data, don't read all the way to the end when we'll stop reading
+                            // at the maximum chunk boundary.
+                            let read_end =
+                                read_bytes.min(cur_pos + self.maximum_chunk - self.cur_chunk_len);
+
                             if let Some(boundary) = unsafe {
                                 (*self.cur_hasher.0)
-                                    .next_match(&readbuf[cur_pos..read_bytes], self.mask)
+                                    .next_match(&readbuf[cur_pos..read_end], self.mask)
                             } {
                                 consume_len = boundary;
                                 create_chunk = true;
                             } else {
-                                consume_len = read_bytes - cur_pos;
+                                consume_len = read_end - cur_pos;
                             }
 
                             // if we hit maximum chunk we must create a chunk


### PR DESCRIPTION
When using large buffers in the low variance chunking algorithm, the chunker will scan all the way to the end of the buffers even when it's way past the max_chunk_size.  This can cause near-quadratic behavior.  This PR limits the read to the max that can be part of the next chunk. 