### PR TITLE
Limit clean task memory usage

### DIFF
--- a/rust/gitxetcore/src/constants.rs
+++ b/rust/gitxetcore/src/constants.rs
@@ -56,3 +56,7 @@ pub const XET_BACKUP_COMMIT_EMAIL: &str = "system@xethub.com";
 
 // Approximately 4 MB min spacing between global dedup queries.  Calculated by 4MB / TARGET_CHUNK_SIZE
 pub const MIN_SPACING_BETWEEN_GLOBAL_DEDUP_QUERIES: usize = 256;
+
+// Concurrent cleaning tasks use at most 8 GB memory. Further increasing
+// the limit is unlikely to help due to chunking being a bottleneck.
+pub const CLEAN_TASK_MEMORY_LIMIT: usize = 8 * 1024 * 1024 * 1024;

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -32,7 +32,7 @@ use merkledb::aggregate_hashes::{cas_node_hash, file_node_hash};
 use merkledb::constants::TARGET_CAS_BLOCK_SIZE;
 use merkledb::*;
 use merklehash::MerkleHash;
-use parutils::{BatchedAsyncIterator, BufferedAsyncIterator};
+use parutils::{BatchedAsyncIterator, BufferedAsyncIterator, GlobalMemoryLimit};
 use progress_reporting::DataProgressReporter;
 use tableau_summary::tds::TdsAnalyzer;
 use tableau_summary::twb::TwbAnalyzer;
@@ -339,11 +339,18 @@ impl PointerFileTranslatorV2 {
         };
 
         // Now, start chunking.
-        let raw_data_iter =
-            BufferedAsyncIterator::new_with_starting_data(starting_data, reader, None);
+        let raw_data_iter = BufferedAsyncIterator::new_with_starting_data(
+            starting_data,
+            reader,
+            None,
+            Some(GlobalMemoryLimit::entry_only(&MEMORY_LIMIT)),
+        );
 
-        let mut generator =
-            BufferedAsyncIterator::new(async_chunk_target_default(raw_data_iter), Some(4096));
+        let mut generator = BufferedAsyncIterator::new(
+            async_chunk_target_default(raw_data_iter),
+            Some(4096),
+            Some(GlobalMemoryLimit::exit_only(&MEMORY_LIMIT)),
+        );
         let mut bytes_cleaned: usize = 0;
 
         // TODO: This span isn't quite accurate as we hold it across `await` calls.

--- a/rust/parutils/src/async_iterator.rs
+++ b/rust/parutils/src/async_iterator.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
 
+use crate::memory_limit::Lengthed;
+
 #[async_trait]
 pub trait AsyncIterator<E: Send + Sync + 'static>: Send + Sync {
-    type Item: Send + Sync;
+    type Item: Send + Sync + Lengthed;
 
     /// The traditional next method for iterators, with a Result and Error
     /// type.  Returns None when everything is done.

--- a/rust/parutils/src/buffered_async_iterator.rs
+++ b/rust/parutils/src/buffered_async_iterator.rs
@@ -152,7 +152,7 @@ impl<It: AsyncIterator<E> + 'static, E: Send + Sync + 'static> BufferedAsyncIter
             data_queue,
             completion_flag,
             background_handle,
-            global_memory_limit: global_memory_limit,
+            global_memory_limit,
             _marker: Default::default(),
         }
     }

--- a/rust/parutils/src/buffered_async_iterator.rs
+++ b/rust/parutils/src/buffered_async_iterator.rs
@@ -291,20 +291,18 @@ impl<It: AsyncIterator<E>, E: Send + Sync + 'static> BatchedAsyncIterator<E>
 }
 
 #[cfg(test)]
-mod tests {
-
-    use super::*;
+pub mod test_utils {
+    use crate::{AsyncIterator, Lengthed};
     use async_trait::async_trait;
-    use more_asserts::*;
     use std::{collections::VecDeque, mem::size_of};
 
-    struct VecIterator {
-        data: VecDeque<u64>,
-        id: u64,
+    pub struct VecIterator {
+        pub data: VecDeque<u64>,
+        pub id: u64,
     }
 
     impl VecIterator {
-        fn new(id: u64, data: Vec<u64>) -> Self {
+        pub fn new(id: u64, data: Vec<u64>) -> Self {
             VecIterator {
                 data: VecDeque::from(data),
                 id,
@@ -326,6 +324,13 @@ mod tests {
             size_of::<u64>()
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use self::test_utils::VecIterator;
+    use super::*;
+    use more_asserts::*;
 
     async fn make_batch_iterator(
         id: u64,

--- a/rust/parutils/src/lib.rs
+++ b/rust/parutils/src/lib.rs
@@ -8,3 +8,6 @@ pub use async_iterator::*;
 
 mod buffered_async_iterator;
 pub use buffered_async_iterator::*;
+
+mod memory_limit;
+pub use memory_limit::*;

--- a/rust/parutils/src/memory_limit.rs
+++ b/rust/parutils/src/memory_limit.rs
@@ -107,6 +107,7 @@ impl GlobalMemoryLimit {
 }
 
 /// Defines that a struct has a known length in bytes.
+#[allow(clippy::len_without_is_empty)]
 pub trait Lengthed {
     fn len(&self) -> usize;
 }

--- a/rust/parutils/src/memory_limit.rs
+++ b/rust/parutils/src/memory_limit.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+use tokio::sync::{AcquireError, Semaphore};
+
+#[derive(Clone)]
+pub struct MemoryLimit {
+    inner: Arc<Semaphore>,
+}
+
+impl MemoryLimit {
+    pub fn new(nbytes: usize) -> Self {
+        Self {
+            inner: Arc::new(Semaphore::new(nbytes)),
+        }
+    }
+}
+
+/// Suppose a graph of resource dependents that share a common limit,
+/// i.e. they in total cannot hold more than N resources,
+///              limit region
+///         |---------------------|
+///         |    A1 - ... - Z1    |
+///         |  /      \ /      \  |
+/// input - |  - .. - ... - .. -  |output
+///         |  \      / \      /  |
+///         |    An - ... - Zn    |
+///         |---------------------|
+/// and executors that move resources from one dependent to the next
+/// (likely with some computation) that work in parallel, only the
+/// executors that move resources from input to entry nodes Ai can
+/// acquire tokens and executors that move resources from exits Zi to
+/// output can release tokens. Otherwise deadlock may happen when any
+/// participant grabs all tokens.
+///                                                e1     e2     e3
+/// For example with the most simple case, "input ---- A ---- B ---- output" with
+/// executors e1, e2, e3 running in parallel.
+/// Suppose at one point A holds all tokens (e.g. e1 being super fast or e2 delayed).
+/// Now e2 removes one resource from A and releases a token, but before e2 finishing
+/// processing this resource and can acquire a token to move it into B, e1 managed to
+/// acquire this token. This now becomes a deadlock situation because e2 and e3 can no
+/// longer make progress to move resource out of the limit region.
+#[derive(Clone)]
+pub struct GlobalMemoryLimit {
+    inner: MemoryLimit,
+    is_entry: bool,
+    is_exit: bool,
+}
+
+impl GlobalMemoryLimit {
+    /// For any memory resource dependent that only takes data
+    /// into a region that limits memory usage.
+    pub fn entry_only(limit: &MemoryLimit) -> Self {
+        Self {
+            inner: limit.clone(),
+            is_entry: true,
+            is_exit: false,
+        }
+    }
+
+    /// For any memory resource dependent that only takes data
+    /// out of a region that limits memory usage.
+    pub fn exit_only(limit: &MemoryLimit) -> Self {
+        Self {
+            inner: limit.clone(),
+            is_entry: false,
+            is_exit: true,
+        }
+    }
+
+    /// For any memory resource dependent that both takes data
+    /// into and out of a region that limits memory usage.
+    pub fn entry_and_exit(limit: &MemoryLimit) -> Self {
+        Self {
+            inner: limit.clone(),
+            is_entry: true,
+            is_exit: true,
+        }
+    }
+
+    /// Acquire nbytes resource from this global limit.
+    pub async fn acquire(&self, nbytes: impl TryInto<u32>) -> Result<(), AcquireError> {
+        if self.is_entry {
+            let permit = self
+                .inner
+                .inner
+                // This function takes a u32, if a single size exceeds 4 GB, just acquire 4 GB.
+                // Unfortuantely, breaking a size that is greater than 4 GB into chunks and
+                // trying to acquire them in a loop will also lead to a potential deadlock,
+                // if there are multiple global entries in the same limit region.
+                // This will not lead to memory explotion as long as the same size is released as is.
+                .acquire_many(nbytes.try_into().unwrap_or(u32::MAX))
+                .await?;
+            permit.forget();
+        }
+
+        Ok(())
+    }
+
+    /// Release nbytes resource to this global limit.
+    pub fn release(&self, nbytes: impl TryInto<u32>) {
+        if self.is_exit {
+            self.inner
+                .inner
+                // If a single size exceeds 4 GB, just release 4 GB.
+                .add_permits(nbytes.try_into().unwrap_or(u32::MAX) as usize);
+        }
+    }
+}
+
+/// Defines that a struct has a known length in bytes.
+pub trait Lengthed {
+    fn len(&self) -> usize;
+}
+
+// Impl this trait for Item types used in AsyncIterators.
+impl Lengthed for Vec<u8> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T: Sized> Lengthed for (T, Vec<u8>) {
+    fn len(&self) -> usize {
+        std::mem::size_of::<T>() + self.1.len()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{BufferedAsyncIterator, GlobalMemoryLimit, MemoryLimit};
+
+    #[test]
+    fn demonstrate_deadlock() {
+        let limit = MemoryLimit::new(5);
+
+        let input = vec![0u8; 100];
+    }
+}


### PR DESCRIPTION
Fix CLI-190

Given the fact that 
1. Git and PyXet send data in different block size to xet-core to clean,
2. PyXet can clean multiple files in parallel,
3. Different files have different clean speed,

it's difficult to tune memory usage for each clean task. Instead, clean tasks can share a common memory limit (8 GB) and grab resource as fast as they can for efficiency.

Tested locally uploading two files each of 40 GB and maintain memory usage < 8 GB:
```
(.env) di@di-mbp ~/xetdata/pyxet/python/pyxet % xet cp ~/tt/zz* xet://localhost:3000:seanses-local/empty/main
copy /Users/di/tt/zz0, /Users/di/tt/zzx... to xet://localhost:3000:seanses-local/empty/main: (2 / 2), 80 GiB | 1.19 GiB/s, done.
```