### PR TITLE
ssh to https url

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -572,6 +572,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1047,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1273,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git-url-parse"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b037f7449dd4a8b711e660301ff1ff28aa00eea09698421fb2d78db51a7b7a72"
+dependencies = [
+ "color-eyre",
+ "regex",
+ "strum",
+ "strum_macros",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1367,7 @@ dependencies = [
  "filetime",
  "futures",
  "futures-core",
+ "git-url-parse",
  "git-version",
  "git2",
  "glob",
@@ -1772,6 +1824,12 @@ dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -2536,6 +2594,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "page_size"
@@ -3810,6 +3874,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,6 +4404,16 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/libxet/Cargo.lock
+++ b/libxet/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "cas_client"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "chunkpipe"
-version = "0.13.4"
+version = "0.14.1"
 
 [[package]]
 name = "clap"
@@ -546,6 +546,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colored"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "common_constants"
-version = "0.13.4"
+version = "0.14.1"
 
 [[package]]
 name = "compare"
@@ -813,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "data_analysis"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "approx",
  "cxx",
@@ -976,9 +1003,19 @@ dependencies = [
 
 [[package]]
 name = "error_printer"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "tracing",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1188,6 +1225,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git-url-parse"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b037f7449dd4a8b711e660301ff1ff28aa00eea09698421fb2d78db51a7b7a72"
+dependencies = [
+ "color-eyre",
+ "regex",
+ "strum",
+ "strum_macros",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "gitxetcore"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1249,6 +1300,7 @@ dependencies = [
  "filetime",
  "futures",
  "futures-core",
+ "git-url-parse",
  "git-version",
  "git2",
  "glob",
@@ -1704,6 +1756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "lazy"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -1866,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "libmagic"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "phf",
@@ -1889,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "libxet"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "gitxetcore",
  "progress_reporting",
@@ -2001,7 +2059,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mdb_shard"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2031,7 +2089,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "merkledb"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2061,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "merklehash"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2450,6 +2508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "parutils"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2778,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "progress_reporting"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "atty",
  "crossterm",
@@ -2805,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus_dict_encoder"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "memchr",
  "prometheus",
@@ -3098,7 +3162,7 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry_strategy"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "tokio-retry",
 ]
@@ -3464,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "shard_client"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3673,6 +3737,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "tableau_summary"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "error_printer",
@@ -4174,6 +4257,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4768,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "xet_config"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "config",
  "dirs 4.0.0",
@@ -4780,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "xet_error"
-version = "0.13.4"
+version = "0.14.1"
 dependencies = [
  "lazy_static",
  "xet-error-impl",

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -99,6 +99,7 @@ shellexpand = "1.0.0"
 blake3 = "1.5.1"
 uuid = { version = "1.8.0", features = ["std", "rng", "v6"] }
 lz4 = "1.24.0"
+git-url-parse = "0.4.4"
 
 # tracing
 tracing-futures = "0.2"


### PR DESCRIPTION
Fix CLI-199. On cas endpoint probing, if a repo is using an SSH remote url, we translate it to an HTTPS url.

Test:
```
di@di-mbp ~/tt/flyte-data % git remote -v
origin	xet@xethub.com:seanses/flyte-data.git (fetch)
origin	xet@xethub.com:seanses/flyte-data.git (push)
di@di-mbp ~/tt/flyte-data % git show HEAD:owid-covid-data.csv
# xet version 0
filesize = 93509074
hash = '0aa378d80cc13e4dce00dc1150aae14c25af2c273c63df789117c6cdcae5b86b'
di@di-mbp ~/tt/flyte-data % git xet merkledb query . 0aa378d80cc13e4dce00dc1150aae14c25af2c273c63df789117c6cdcae5b86b
MDBFileInfo { metadata: FileDataSequenceHeader { file_hash: 0aa378d80cc13e4dce00dc1150aae14c25af2c273c63df789117c6cdcae5b86b, file_flags: 0, num_entries: 6, _unused: 0 }, segments: [FileDataSequenceEntry { cas_hash: 4289d0425ac5e7de6c30e28440d19498c98774edda1e0418d35e8d106721c60f, cas_flags: 0, unpacked_segment_bytes: 15737191, chunk_byte_range_start: 0, chunk_byte_range_end: 15737191 }, FileDataSequenceEntry { cas_hash: b7a8855e4144963467f512ee5bdb47d8a9a92f3f05b6385fd140bc180d0f2f93, cas_flags: 0, unpacked_segment_bytes: 15740702, chunk_byte_range_start: 0, chunk_byte_range_end: 15740702 }, FileDataSequenceEntry { cas_hash: 8c751ae77ff9bb49c3e34cd3b29833efcddb073e66ad814ecc09ad4bce0f5491, cas_flags: 0, unpacked_segment_bytes: 15735658, chunk_byte_range_start: 0, chunk_byte_range_end: 15735658 }, FileDataSequenceEntry { cas_hash: b06898a3dbcf6a705a20c5cc26d57ea6cad87e2e393932d1026787c4b6bdbb3c, cas_flags: 0, unpacked_segment_bytes: 15735373, chunk_byte_range_start: 0, chunk_byte_range_end: 15735373 }, FileDataSequenceEntry { cas_hash: 7430a17e0f1db70d33dcebdeb4211ca28d973346b3f04a67a9398e558326a634, cas_flags: 0, unpacked_segment_bytes: 15738198, chunk_byte_range_start: 0, chunk_byte_range_end: 15738198 }, FileDataSequenceEntry { cas_hash: 3782ec0ab1615337ffcd1dc5b228541f1fbf97dba3dd2fb4a642f69778ffe34e, cas_flags: 0, unpacked_segment_bytes: 14821952, chunk_byte_range_start: 0, chunk_byte_range_end: 14821952 }] }
di@di-mbp ~/tt/flyte-data % git xet cas probe 4289d0425ac5e7de6c30e28440d19498c98774edda1e0418d35e8d106721c60f
Probing for hash 4289d0425ac5e7de6c30e28440d19498c98774edda1e0418d35e8d106721c60f ...
Staging:
	◯ Not available

Remote:
	√ Available
	File Size: 15.01 MiB
```