### PR TITLE
Show server message nicely on mount

### DIFF
--- a/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
+++ b/rust/gitxetcore/src/git_integration/git_process_wrapping.rs
@@ -99,7 +99,7 @@ fn spawn_git_command(
 ///
 /// The command is run in the directory base_directory.  On nonzero exit status, an error is
 /// returned.
-#[tracing::instrument(skip_all, err, fields(command = command, ?args))]
+#[tracing::instrument(skip_all, fields(command = command, ?args))]
 pub fn run_git_captured_raw(
     base_directory: Option<&PathBuf>,
     command: &str,
@@ -145,7 +145,7 @@ pub fn run_git_captured_raw(
 ///
 /// The command is run in the directory base_directory.  On nonzero exit status, an error is
 /// returned.
-#[tracing::instrument(skip_all, err, fields(command = command, ?args))]
+#[tracing::instrument(skip_all, fields(command = command, ?args))]
 pub fn run_git_captured(
     base_directory: Option<&PathBuf>,
     command: &str,
@@ -189,7 +189,7 @@ pub fn run_git_captured(
 ///
 /// The command is run in the directory base_directory.  On nonzero exit status, an error is
 /// returned.
-#[tracing::instrument(skip_all, err, fields(command = command, ?args))]
+#[tracing::instrument(skip_all, fields(command = command, ?args))]
 pub fn run_git_passthrough(
     base_directory: Option<&PathBuf>,
     command: &str,


### PR DESCRIPTION
Fix Fun-89.

Test locally, note that only the server reply "repo.access_denied_free_trial%!(EXTRA string=http://localhost:3000///subscription/upgrade)" is printed.

- Mount
```
di@di-mbp ~/tt % git xet mount http://localhost:3000/seanses-local/pyxet.git
Mounting to "/Users/di/tt/pyxet"
repo.access_denied_free_trial%!(EXTRA string=http://localhost:3000///subscription/upgrade)
Error : failed to mount
```

- Writable Mount
```
di@di-mbp ~/tt % git xet mount http://localhost:3000/seanses-local/pyxet.git --writable
Writable mounts are currently an EXPERIMENTAL feature. Be warned. You might lose data!!
Known issues: Performance is poor.

Raw clone at "/Users/di/tt/pyxet_raw".
Mounting at "/Users/di/tt/pyxet".

You can access and make arbitrary modification in the mounted path and changes
will immediately reflect in the git state in the raw clone path.

Similarly you can perform git operations in the raw clone path and it will immediately
reflect in the mounted path. All git operations should work as expected.

If you use a git UI, point it to the raw path.

repo.access_denied_free_trial%!(EXTRA string=http://localhost:3000///subscription/upgrade)
Error : failed to mount
```

To compare, this is clone
```
di@di-mbp ~/tt % git xet clone http://localhost:3000/seanses-local/pyxet.git
Preparing to clone Xet repository.
Cloning into 'pyxet'...
remote: repo.access_denied_free_trial%!(EXTRA string=http://localhost:3000///subscription/upgrade)
fatal: unable to access 'http://localhost:3000/seanses-local/pyxet.git/': The requested URL returned error: 403
```