### PR TITLE
"merkledb extract-git" fetch no shard by default

### DIFF
--- a/rust/gitxetcore/src/command/merkledb.rs
+++ b/rust/gitxetcore/src/command/merkledb.rs
@@ -155,6 +155,9 @@ struct MerkleDBGitExtractArgs {
     output: Option<PathBuf>,
     #[clap(short, long, default_value = "refs/notes/xet/merkledb")]
     notesref: String,
+    /// For MerkleDB V2, also fetch all shards from remote.
+    #[clap(long)]
+    fetch_all_shards: bool,
 }
 
 /// Writes out a MerkleDB to git notes.
@@ -318,7 +321,7 @@ pub async fn handle_merkledb_plumb_command(
                         &cfg,
                         output,
                         GIT_NOTES_MERKLEDB_V2_REF_NAME,
-                        true, // with Shard client we can disable this in the future
+                        args.fetch_all_shards, // false by default
                     )
                     .await
                 } else {
@@ -326,7 +329,7 @@ pub async fn handle_merkledb_plumb_command(
                         &cfg,
                         &cfg.merkledb_v2_cache,
                         GIT_NOTES_MERKLEDB_V2_REF_NAME,
-                        true, // with Shard client we can disable this in the future
+                        args.fetch_all_shards, // false by default
                     )
                     .await
                 }


### PR DESCRIPTION
Xetea [GetXetDirSummary](https://github.com/xetdata/xethub/blob/13542f1cdb7a7d6c4de38e1b1b0827c51dc70194/golang/xetea/modules/context/xet.go#L83) and [GetDiff](https://github.com/xetdata/xethub/blob/13542f1cdb7a7d6c4de38e1b1b0827c51dc70194/golang/xetea/services/gitdiff/gitdiff.go#L1274) call `merkledb extract-git` for MDBV1 compatibility. This PR disables fetching all shards by default for V2 repos so there's less burden on Xetea. Fix [CLI-224](https://linear.app/xethub/issue/CLI-224/merkledb-extract-git-takes-long-time-when-rendering-pr-for-the-real)