### PR TITLE
cas endpoint query without auth

### DIFF
--- a/rust/gitxetcore/src/config/xet.rs
+++ b/rust/gitxetcore/src/config/xet.rs
@@ -286,8 +286,9 @@ impl XetConfig {
             if cas.is_empty() {
                 eprintln!("A CAS server endpoint is not specified. 
 
-Did you run `git xet login` with your credentials? If not, create a new token on XetHub and 
-run the displayed `git xet login` command to authenticate. Then re-run your original command.
+Did you run `git xet login` with your credentials? If not, create a new token from your 
+\"Account Settings -> Personal Access Tokens\" and run the displayed `git xet login` command
+to authenticate. Then re-run your original command.
                 
 If this is not a repository on a XetHub managed deployment, please use git-xet command line
 override '--cas' to provide a URL, or export '{XET_CAS_SERVER_ENV_VAR}'=<URL> in your terminal.

--- a/rust/gitxetcore/src/xetblob/remote_repo_info.rs
+++ b/rust/gitxetcore/src/xetblob/remote_repo_info.rs
@@ -66,7 +66,7 @@ pub async fn get_cas_endpoint_from_git_remote(
     let bbq_client = BbqClient::new().map_err(|_| anyhow!("Unable to create network client."))?;
 
     // first try the cas endpoint query route that doesn't need auth
-    let url = git_remote_to_base_url(&remote)?;
+    let url = git_remote_to_base_url(remote)?;
     if let Ok(cas) = get_cas_endpoint(&url, &bbq_client).await {
         return Ok(cas);
     }


### PR DESCRIPTION
Depends on https://github.com/xetdata/xethub/pull/6117. Fix CLI-229, CLI-232.
First query `/api/xet/cas`, on failure query `api/xet/repos/...`.

Test:
1. Against Prod that doesn't have `/api/xet/cas` route yet.
```
di@di-mbp ~/tt/bsf13 % git remote -v
origin	https://seanses:[masked]@xethub.com/seanses/bsf13 (fetch)
origin	https://seanses:[masked]@xethub.com/seanses/bsf13 (push)
di@di-mbp ~/tt/bsf13 % XET_LOG_LEVEL=debug git xet cas probe d760aaf4beb07581956e24c847c47f1abd2e419166aa68259035bc412232e9da 2>&1 | grep "Config: CAS endpoint set to:"
{"timestamp":"2024-06-07T22:01:32.919316Z","level":"DEBUG","fields":{"message":"Config: CAS endpoint set to: cas-lb.xethub.com:443"},"filename":"/Users/di/xetdata/xet-core/rust/gitxetcore/src/config/xet.rs","line_number":301,"span":{"command":"cas.probe","name":"gitxet"},"spans":[{"command":"cas.probe","name":"gitxet"}]}
{"timestamp":"2024-06-07T22:01:33.032034Z","level":"DEBUG","fields":{"message":"Config: CAS endpoint set to: cas-lb.xethub.com:443"},"filename":"/Users/di/xetdata/xet-core/rust/gitxetcore/src/config/xet.rs","line_number":301,"span":{"command":"cas.probe","name":"gitxet"},"spans":[{"command":"cas.probe","name":"gitxet"}]}
```
2. Against dev that has `/api/xet/cas` deployed.
```
di@di-mbp ~/tt/aa % git remote -v
origin	https://hub.xetsvc.com/seanses-dev/some-private-repo.git (fetch)
origin	https://hub.xetsvc.com/seanses-dev/some-private-repo.git (push)
di@di-mbp ~/tt/aa % XET_LOG_LEVEL=debug git xet cas probe d760aaf4beb07581956e24c847c47f1abd2e419166aa68259035bc412232e9da 2>&1 | grep "Config: CAS endpoint set to:"
{"timestamp":"2024-06-07T22:16:24.760857Z","level":"DEBUG","fields":{"message":"Config: CAS endpoint set to: cas-lb.xetsvc.com:443"},"filename":"/Users/di/xetdata/xet-core/rust/gitxetcore/src/config/xet.rs","line_number":302,"span":{"command":"cas.probe","name":"gitxet"},"spans":[{"command":"cas.probe","name":"gitxet"}]}
{"timestamp":"2024-06-07T22:16:24.802306Z","level":"DEBUG","fields":{"message":"Config: CAS endpoint set to: cas-lb.xetsvc.com:443"},"filename":"/Users/di/xetdata/xet-core/rust/gitxetcore/src/config/xet.rs","line_number":302,"span":{"command":"cas.probe","name":"gitxet"},"spans":[{"command":"cas.probe","name":"gitxet"}]}
di@di-mbp ~/tt/aa % git xet cas probe d760aaf4beb07581956e24c847c47f1abd2e419166aa68259035bc412232e9da
Probing for hash d760aaf4beb07581956e24c847c47f1abd2e419166aa68259035bc412232e9da ...
Staging:
	◯ Not available

Unexpected error: Other Internal Error: Real call failed: Grpc(status: NotFound, message: "XORB not found", details: [], metadata: MetadataMap { headers: {"server": "awselb/2.0", "date": "Fri, 07 Jun 2024 22:16:17 GMT", "content-type": "application/grpc", "content-length": "0"} }) while accessing remote.
```
 