### PR TITLE
Adds download progress reporting for xet. 

### DIFF
--- a/libxet/Cargo.lock
+++ b/libxet/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "cas_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "chunkpipe"
-version = "0.14.1"
+version = "0.14.2"
 
 [[package]]
 name = "clap"
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "common_constants"
-version = "0.14.1"
+version = "0.14.2"
 
 [[package]]
 name = "compare"
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "data_analysis"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "approx",
  "cxx",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "error_printer"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "tracing",
 ]
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "gitxetcore"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "lazy"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "libmagic"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "phf",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "libxet"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "gitxetcore",
  "progress_reporting",
@@ -2059,7 +2059,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mdb_shard"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2089,7 +2089,7 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "merkledb"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "merklehash"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "blake3",
  "generic-array",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "parutils"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "progress_reporting"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "atty",
  "crossterm",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus_dict_encoder"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "memchr",
  "prometheus",
@@ -3162,7 +3162,7 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "retry_strategy"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "tokio-retry",
 ]
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "shard_client"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "tableau_summary"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "error_printer",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "utils"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "xet_config"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "config",
  "dirs 4.0.0",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "xet_error"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "lazy_static",
  "xet-error-impl",

--- a/rust/gitxetcore/src/xetblob/rfile_object.rs
+++ b/rust/gitxetcore/src/xetblob/rfile_object.rs
@@ -1,7 +1,10 @@
 use std::{
     io::{BufWriter, Write},
     path::Path,
+    sync::Arc,
 };
+
+use progress_reporting::{DataProgressReporter, ReportedWriter};
 
 use crate::data::*;
 
@@ -56,14 +59,25 @@ impl XetRFileObject {
 
     /// Downloads the contents of a file and write them to disk
     /// at location specified by path.
-    pub async fn get(&self, path: impl AsRef<Path>) -> anyhow::Result<()> {
-        let mut writer = BufWriter::new(std::fs::File::create(path)?);
+    pub async fn read_to_path(
+        &self,
+        path: impl AsRef<Path>,
+        progress_reporter: Option<Arc<DataProgressReporter>>,
+    ) -> anyhow::Result<()> {
+        let mut writer = ReportedWriter::new(
+            BufWriter::new(std::fs::File::create(path)?),
+            &progress_reporter,
+        );
 
         match &self.content {
             FileContent::Bytes(b) => writer.write_all(b)?,
             FileContent::Pointer((_, translator)) => {
-                translator.smudge_to_writer(&mut writer, None).await?;
+                translator.smudge_to_writer(&mut writer, None).await?
             }
+        }
+
+        if let Some(pr) = progress_reporter.as_ref() {
+            pr.register_progress(Some(1), None);
         }
 
         Ok(())

--- a/rust/progress_reporting/src/lib.rs
+++ b/rust/progress_reporting/src/lib.rs
@@ -1,3 +1,5 @@
 mod data_progress;
+mod writer_with_reporting;
 
 pub use data_progress::DataProgressReporter;
+pub use writer_with_reporting::ReportedWriter;

--- a/rust/progress_reporting/src/writer_with_reporting.rs
+++ b/rust/progress_reporting/src/writer_with_reporting.rs
@@ -11,7 +11,7 @@ impl<W: Write> ReportedWriter<W> {
     pub fn new(writer: W, progress_reporter: &Option<Arc<DataProgressReporter>>) -> Self {
         Self {
             writer,
-            progress_reporter: progress_reporter.as_ref().map(|pr| pr.clone()),
+            progress_reporter: progress_reporter.as_ref().cloned(),
         }
     }
 

--- a/rust/progress_reporting/src/writer_with_reporting.rs
+++ b/rust/progress_reporting/src/writer_with_reporting.rs
@@ -1,0 +1,41 @@
+use crate::DataProgressReporter;
+use std::io::Write;
+use std::sync::Arc;
+
+pub struct ReportedWriter<W: Write> {
+    writer: W,
+    progress_reporter: Option<Arc<DataProgressReporter>>,
+}
+
+impl<W: Write> ReportedWriter<W> {
+    pub fn new(writer: W, progress_reporter: &Option<Arc<DataProgressReporter>>) -> Self {
+        Self {
+            writer,
+            progress_reporter: progress_reporter.as_ref().map(|pr| pr.clone()),
+        }
+    }
+
+    fn report(&self, s: usize) {
+        if let Some(pr) = self.progress_reporter.as_ref() {
+            pr.register_progress(None, Some(s));
+        }
+    }
+}
+
+impl<W: Write> Write for ReportedWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let res = self.writer.write(buf)?;
+        self.report(res);
+        Ok(res)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.writer.write_all(buf)?;
+        self.report(buf.len());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds the xet-core half of the download progress reporting to the direct read-to-file path.  It also renames get(path) to read_to_path(path), which is much less confusing.  

Note: this is tested, but the testing is done with a local version of pyxet, which is up at https://github.com/xetdata/pyxet/pull/140.