### PR TITLE
Lower the number of default concurrent upload/download

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -611,6 +611,9 @@ dependencies = [
 [[package]]
 name = "common_constants"
 version = "0.14.2"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "compare"

--- a/rust/common_constants/Cargo.toml
+++ b/rust/common_constants/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.4.0"

--- a/rust/common_constants/src/lib.rs
+++ b/rust/common_constants/src/lib.rs
@@ -1,7 +1,11 @@
-/// The maximum number of simultaneous download streams
-pub const MAX_CONCURRENT_DOWNLOADS: usize = 16;
-/// The maximum number of simultaneous upload streams
-pub const MAX_CONCURRENT_UPLOADS: usize = 16;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// The maximum number of simultaneous download streams
+    pub static ref MAX_CONCURRENT_DOWNLOADS: usize = std::env::var("XET_CONCURRENT_DOWNLOADS").ok().map(|s| s.parse().ok()).flatten().unwrap_or(8);
+    /// The maximum number of simultaneous upload streams
+    pub static ref MAX_CONCURRENT_UPLOADS: usize = std::env::var("XET_CONCURRENT_UPLOADS").ok().map(|s| s.parse().ok()).flatten().unwrap_or(8);
+}
 
 /// The maximum number of simultaneous streams per prefetch call
 pub const MAX_CONCURRENT_PREFETCH_DOWNLOADS: usize = 4;

--- a/rust/common_constants/src/lib.rs
+++ b/rust/common_constants/src/lib.rs
@@ -2,9 +2,9 @@ use lazy_static::lazy_static;
 
 lazy_static! {
     /// The maximum number of simultaneous download streams
-    pub static ref MAX_CONCURRENT_DOWNLOADS: usize = std::env::var("XET_CONCURRENT_DOWNLOADS").ok().map(|s| s.parse().ok()).flatten().unwrap_or(8);
+    pub static ref MAX_CONCURRENT_DOWNLOADS: usize = std::env::var("XET_CONCURRENT_DOWNLOADS").ok().and_then(|s| s.parse().ok()).unwrap_or(8);
     /// The maximum number of simultaneous upload streams
-    pub static ref MAX_CONCURRENT_UPLOADS: usize = std::env::var("XET_CONCURRENT_UPLOADS").ok().map(|s| s.parse().ok()).flatten().unwrap_or(8);
+    pub static ref MAX_CONCURRENT_UPLOADS: usize = std::env::var("XET_CONCURRENT_UPLOADS").ok().and_then(|s| s.parse().ok()).unwrap_or(8);
 }
 
 /// The maximum number of simultaneous streams per prefetch call

--- a/rust/gitxetcore/src/command/dematerialize.rs
+++ b/rust/gitxetcore/src/command/dematerialize.rs
@@ -85,7 +85,7 @@ pub async fn dematerialize_command(cfg: XetConfig, args: &DematerializeArgs) -> 
 
     tokio_par_for_each(
         absolute_path_list,
-        MAX_CONCURRENT_UPLOADS,
+        *MAX_CONCURRENT_UPLOADS,
         |path, _| async move {
             let translator = translator_ref.clone();
             clean_file_to_itself(&translator, &path).await

--- a/rust/gitxetcore/src/command/materialize.rs
+++ b/rust/gitxetcore/src/command/materialize.rs
@@ -85,7 +85,7 @@ pub async fn materialize_command(cfg: XetConfig, args: &MaterializeArgs) -> Resu
 
     tokio_par_for_each(
         absolute_path_list,
-        MAX_CONCURRENT_DOWNLOADS,
+        *MAX_CONCURRENT_DOWNLOADS,
         |path, _| async move {
             let translator = translator_ref.clone();
             smudge_file_to_itself(&translator, &path).await

--- a/rust/gitxetcore/src/data/cas_interface.rs
+++ b/rust/gitxetcore/src/data/cas_interface.rs
@@ -163,7 +163,7 @@ pub async fn data_from_chunks_to_writer(
         let prefix = prefix.clone();
         get_from_cas(cas, prefix, objr.hash, (objr.start as u64, objr.end as u64))
     }))
-    .buffered(MAX_CONCURRENT_DOWNLOADS);
+    .buffered(*MAX_CONCURRENT_DOWNLOADS);
 
     while let Some(buf) = strm.next().await {
         let buf = buf?;

--- a/rust/gitxetcore/src/data/data_processing_v1.rs
+++ b/rust/gitxetcore/src/data/data_processing_v1.rs
@@ -211,7 +211,7 @@ impl PointerFileTranslatorV1 {
 
     pub async fn upload_cas_staged(&self, retain: bool) -> Result<()> {
         self.cas
-            .upload_all_staged(MAX_CONCURRENT_UPLOADS, retain)
+            .upload_all_staged(*MAX_CONCURRENT_UPLOADS, retain)
             .await
             .or_else(convert_cas_error)
     }
@@ -460,7 +460,7 @@ impl PointerFileTranslatorV1 {
                 (objr.start as u64, objr.end as u64),
             )
         }))
-        .buffered(MAX_CONCURRENT_DOWNLOADS);
+        .buffered(*MAX_CONCURRENT_DOWNLOADS);
         let mut is_first = true;
         while let Some(buf) = strm.next().await {
             let buf = buf?;

--- a/rust/gitxetcore/src/data/data_processing_v2.rs
+++ b/rust/gitxetcore/src/data/data_processing_v2.rs
@@ -252,7 +252,7 @@ impl PointerFileTranslatorV2 {
 
     pub async fn upload_cas_staged(&self, retain: bool) -> Result<()> {
         self.cas
-            .upload_all_staged(MAX_CONCURRENT_UPLOADS, retain)
+            .upload_all_staged(*MAX_CONCURRENT_UPLOADS, retain)
             .await
             .or_else(convert_cas_error)
     }
@@ -885,7 +885,7 @@ impl PointerFileTranslatorV2 {
                 (objr.start as u64, objr.end as u64),
             )
         }))
-        .buffered(MAX_CONCURRENT_DOWNLOADS);
+        .buffered(*MAX_CONCURRENT_DOWNLOADS);
 
         while let Some(buf) = strm.next().await {
             let buf = buf?;
@@ -918,7 +918,7 @@ impl PointerFileTranslatorV2 {
                 (objr.start as u64, objr.end as u64),
             )
         }))
-        .buffered(MAX_CONCURRENT_DOWNLOADS);
+        .buffered(*MAX_CONCURRENT_DOWNLOADS);
         let mut is_first = true;
         while let Some(buf) = strm.next().await {
             let buf = buf?;

--- a/rust/gitxetcore/src/data/mdb.rs
+++ b/rust/gitxetcore/src/data/mdb.rs
@@ -345,7 +345,7 @@ pub async fn download_shards_to_cache(
 
     let ret = tokio_par_for_each(
         shards,
-        MAX_CONCURRENT_DOWNLOADS,
+        *MAX_CONCURRENT_DOWNLOADS,
         |shard_hash, _| async move {
             let (path, nbytes) =
                 download_shard(cas_ref, &config.cas.shard_prefix(), &shard_hash, cache_dir).await?;
@@ -642,7 +642,7 @@ pub async fn sync_session_shards_to_remote(
         let shard_prefix = config.cas.shard_prefix();
         let shard_prefix_ref = &shard_prefix;
 
-        tokio_par_for_each(shards, MAX_CONCURRENT_UPLOADS, |si, _| async move {
+        tokio_par_for_each(shards, *MAX_CONCURRENT_UPLOADS, |si, _| async move {
             // For each shard:
             // 1. Upload directly to CAS.
             // 2. Sync to server.

--- a/rust/gitxetcore/src/git_integration/git_xet_repo.rs
+++ b/rust/gitxetcore/src/git_integration/git_xet_repo.rs
@@ -1652,7 +1652,7 @@ impl GitXetRepo {
     pub async fn upload_all_staged(&self) -> Result<()> {
         let cas = self.get_staging_cas().await?;
 
-        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, false)
+        cas.upload_all_staged(*MAX_CONCURRENT_UPLOADS, false)
             .await
             .or_else(convert_cas_error)
     }
@@ -1696,7 +1696,7 @@ impl GitXetRepo {
                     let cas = cas.clone();
 
                     tokio::spawn(async move {
-                        cas.upload_all_staged(MAX_CONCURRENT_UPLOADS, false)
+                        cas.upload_all_staged(*MAX_CONCURRENT_UPLOADS, false)
                             .await
                             .or_else(convert_cas_error)
                     })

--- a/rust/gitxetcore/src/xetblob/xet_repo.rs
+++ b/rust/gitxetcore/src/xetblob/xet_repo.rs
@@ -578,7 +578,7 @@ impl XetRepo {
 
         parutils::tokio_par_for_each(
             Vec::from(reference_files),
-            MAX_CONCURRENT_DOWNLOADS,
+            *MAX_CONCURRENT_DOWNLOADS,
             |(branch, filename), _| async move {
                 let shard_download_info = shard_download_info_ref.clone();
                 if let Ok(body) = self


### PR DESCRIPTION
Fix CLI-221

- lower default concurrent upload/download to 8
- provide env var to reset the default