### PR TITLE
Return message on query response of forbidden status

### DIFF
--- a/rust/gitxetcore/src/xetblob/bbq_queries.rs
+++ b/rust/gitxetcore/src/xetblob/bbq_queries.rs
@@ -186,6 +186,15 @@ impl BbqClient {
         let response = self
             .perform_bbq_query_internal(remote_base_url, branch, filename, "branch")
             .await?;
+        if matches!(response.status(), reqwest::StatusCode::FORBIDDEN) {
+            return Err(anyhow!(
+                "{}",
+                response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+            ));
+        }
         let response = response.error_for_status()?;
         let body = response.bytes().await?;
         let body = body.to_vec();
@@ -233,6 +242,15 @@ impl BbqClient {
         let response = self
             .perform_bbq_query_internal(remote_base_url, branch, filename, "stat")
             .await?;
+        if matches!(response.status(), reqwest::StatusCode::FORBIDDEN) {
+            return Err(anyhow!(
+                "{}",
+                response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+            ));
+        }
         if matches!(response.status(), reqwest::StatusCode::NOT_FOUND) {
             return Ok(None);
         }
@@ -255,6 +273,15 @@ impl BbqClient {
         let response = self
             .perform_repo_api_query_internal(remote_base_url, op, http_command, body)
             .await?;
+        if matches!(response.status(), reqwest::StatusCode::FORBIDDEN) {
+            return Err(anyhow!(
+                "{}",
+                response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+            ));
+        }
         let response = response.error_for_status()?;
         let body = response.bytes().await?;
         let body = body.to_vec();

--- a/rust/gitxetcore/src/xetblob/bbq_queries.rs
+++ b/rust/gitxetcore/src/xetblob/bbq_queries.rs
@@ -12,6 +12,7 @@ use url::Url;
 const NUM_RETRIES: usize = 5;
 const BASE_RETRY_DELAY_MS: u64 = 500;
 const CACHE_TIME_S: u64 = 30; // 30 seconds
+const DEFAULT_FORBIDDEN_MESSAGE: &str = "Repository access forbidden";
 
 #[derive(Clone)]
 pub struct BbqClient {
@@ -192,7 +193,7 @@ impl BbqClient {
                 response
                     .text()
                     .await
-                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+                    .unwrap_or_else(|_| DEFAULT_FORBIDDEN_MESSAGE.to_owned())
             ));
         }
         let response = response.error_for_status()?;
@@ -248,7 +249,7 @@ impl BbqClient {
                 response
                     .text()
                     .await
-                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+                    .unwrap_or_else(|_| DEFAULT_FORBIDDEN_MESSAGE.to_owned())
             ));
         }
         if matches!(response.status(), reqwest::StatusCode::NOT_FOUND) {
@@ -279,7 +280,7 @@ impl BbqClient {
                 response
                     .text()
                     .await
-                    .unwrap_or_else(|_| "Repository access forbidden".to_owned())
+                    .unwrap_or_else(|_| DEFAULT_FORBIDDEN_MESSAGE.to_owned())
             ));
         }
         let response = response.error_for_status()?;


### PR DESCRIPTION
When the xet api query response statuscode is 403, return the message in the response. Fix FUN-90