### PR TITLE
Fix for windows integration test issues.

### DIFF
--- a/gitxet/Cargo.lock
+++ b/gitxet/Cargo.lock
@@ -1409,6 +1409,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "parutils",
+ "path-absolutize",
  "pathdiff",
  "pbr",
  "progress_reporting",
@@ -2703,6 +2704,24 @@ dependencies = [
  "more-asserts",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/libxet/Cargo.lock
+++ b/libxet/Cargo.lock
@@ -1342,6 +1342,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "parutils",
+ "path-absolutize",
  "pathdiff",
  "pbr",
  "progress_reporting",
@@ -2617,6 +2618,24 @@ dependencies = [
  "more-asserts",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -100,7 +100,7 @@ blake3 = "1.5.1"
 uuid = { version = "1.8.0", features = ["std", "rng", "v6"] }
 lz4 = "1.24.0"
 git-url-parse = "0.4.4"
-path_absolutize = "3.1.1" # Can drop after rust 1.79
+path-absolutize = "3.1.1" # Can drop after rust 1.79
 
 # tracing
 tracing-futures = "0.2"

--- a/rust/gitxetcore/Cargo.toml
+++ b/rust/gitxetcore/Cargo.toml
@@ -100,6 +100,7 @@ blake3 = "1.5.1"
 uuid = { version = "1.8.0", features = ["std", "rng", "v6"] }
 lz4 = "1.24.0"
 git-url-parse = "0.4.4"
+path_absolutize = "3.1.1" # Can drop after rust 1.79
 
 # tracing
 tracing-futures = "0.2"

--- a/rust/gitxetcore/src/command/repo.rs
+++ b/rust/gitxetcore/src/command/repo.rs
@@ -76,7 +76,7 @@ async fn migrate_command(config: XetConfig, args: &MigrateArgs) -> Result<()> {
         }
     };
 
-    let working_dir = working_dir.absolutize()?;
+    let working_dir = working_dir.absolutize()?.to_path_buf();
 
     config.permission.create_dir_all(&working_dir)?;
 

--- a/rust/gitxetcore/src/command/repo.rs
+++ b/rust/gitxetcore/src/command/repo.rs
@@ -8,6 +8,7 @@ use crate::config::XetConfig;
 use crate::errors::Result;
 use crate::git_integration::repo_migration::migrate_repo;
 use crate::git_integration::{clone_xet_repo, run_git_captured, run_git_passthrough, GitXetRepo};
+use path_absolutize::*;
 
 #[derive(Args, Debug, Clone)]
 pub struct MigrateArgs {
@@ -75,9 +76,9 @@ async fn migrate_command(config: XetConfig, args: &MigrateArgs) -> Result<()> {
         }
     };
 
-    config.permission.create_dir_all(&working_dir)?;
+    let working_dir = working_dir.absolutize()?;
 
-    let working_dir = working_dir.canonicalize()?;
+    config.permission.create_dir_all(&working_dir)?;
 
     let source_dir = working_dir.join("source");
     let dest_dir = working_dir.join("xet_repo");


### PR DESCRIPTION
So it turns out that canonicalize() is broken on windows in the sense that a canonicalized path can no longer be treated as a linux based path due to //?/ being prepended to it.  This fixes this issue. 